### PR TITLE
fix: auth test rebrand (openclaw -> gemmaclaw hint)

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -626,7 +626,7 @@ describe("modelsAuthLoginCommand", () => {
     const runtime = createRuntime();
 
     await expect(modelsAuthLoginCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
-      'Unknown provider "anthropic". Loaded providers: openai-codex. Verify plugins via `openclaw plugins list --json`.',
+      'Unknown provider "anthropic". Loaded providers: openai-codex. Verify plugins via `gemmaclaw plugins list --json`.',
     );
   });
 


### PR DESCRIPTION
Fixes a rebrand regression where the auth command test still expected an `openclaw plugins list` hint.

This currently causes `pnpm check:changed` (and CI) to fail on unrelated PRs.