### PR TITLE
ci: add gate jobs for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2163,3 +2163,40 @@ jobs:
               exit 1
               ;;
           esac
+
+  ci-gate:
+    name: CI
+    if: always()
+    needs:
+      - preflight
+      - security-scm-fast
+      - security-dependency-audit
+      - security-fast
+      - build-artifacts
+      - checks-fast-core
+      - checks-fast-channel-contracts
+      - checks-fast-protocol
+      - checks-node-extensions
+      - checks
+      - checks-node-compat
+      - checks-node-core-test
+      - extension-fast
+      - check
+      - check-additional
+      - build-smoke
+      - check-docs
+      - skills-python
+      - checks-windows
+      - macos-node
+      - macos-swift
+      - android
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Evaluate results
+        run: |
+          results='${{ toJSON(needs.*.result) }}'
+          echo "Job results: $results"
+          if echo "$results" | grep -qE '"failure"|"cancelled"'; then
+            echo "One or more CI jobs failed or were cancelled"
+            exit 1
+          fi

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -81,6 +81,21 @@ jobs:
       - name: Disallow tracked merge conflict markers
         run: node scripts/check-no-conflict-markers.mjs
 
+  gate:
+    name: Workflow Sanity
+    if: always() && github.event_name != 'workflow_dispatch'
+    needs: [no-tabs, actionlint]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Evaluate results
+        run: |
+          results='${{ toJSON(needs.*.result) }}'
+          echo "Job results: $results"
+          if echo "$results" | grep -qE '"failure"|"cancelled"'; then
+            echo "One or more sanity checks failed or were cancelled"
+            exit 1
+          fi
+
   generated-doc-baselines:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Branch protection requires checks named "CI" and "Workflow Sanity" but these are workflow names, not job names
- Adds consolidation gate jobs to ci.yml and workflow-sanity.yml that create check runs with the expected names
- Gate jobs depend on all leaf jobs and fail if any fail or are cancelled

## Test plan
- [ ] CI gate job appears as a check run named "CI" on the PR
- [ ] Workflow Sanity gate job appears as a check run named "Workflow Sanity" on the PR
- [ ] Both pass when all dependent jobs pass