### PR TITLE
feat: hardware-aware Gemma 4 setup with auto-provisioning and Docker sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Scoped guides:
 - If bulk PR close/reopen affects >5 PRs, ask with exact count/scope.
 - PR/issue workflows: use `$openclaw-pr-maintainer`.
 - `/landpr`: use `~/.codex/prompts/landpr.md`.
+- PRs: always target `gemmaclaw/gemmaclaw`, not the upstream `openclaw/openclaw`. Use `gh pr create -R gemmaclaw/gemmaclaw`. The repo fork parent is openclaw; `gh` defaults to upstream without `-R`.
 
 ## Security / Release
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ No manual model shopping. No "which quant do I pick?" guesswork. It just works.
 
 ## How it works
 
-1. **Hardware detection.** Gemmaclaw probes your system: GPU vendor and VRAM, CPU architecture, total and available RAM.
-2. **Tier classification.** Based on what it finds, your machine is slotted into a hardware tier (e.g., "16 GB VRAM, mid-range GPU" or "CPU-only, 8 GB RAM").
-3. **Profile selection.** Each tier maps to a tested configuration profile: which backend to use (Ollama, llama.cpp, or gemma.cpp), which Gemma model size, and which quantization level.
-4. **Provisioning.** Gemmaclaw pulls the model and configures the backend automatically.
-5. **Verification.** A quick smoke test confirms the setup works: inference runs, latency is acceptable, and tool-use prompts parse correctly.
+1. **Hardware detection.** Gemmaclaw probes your system: GPU vendor and VRAM, CPU architecture, total and available RAM. Apple Silicon Metal GPUs are detected with unified memory.
+2. **Tier classification.** Based on what it finds, your machine is slotted into a hardware tier (e.g., "48 GB Apple Silicon" or "CPU-only, 8 GB RAM").
+3. **Profile selection.** Each tier maps to a tested Gemma 4 model. Known issues (e.g., Flash Attention hangs on the 31B Dense model) are tracked in the model catalog with citations, and the selector automatically falls back to a stable alternative.
+4. **Provisioning.** Gemmaclaw downloads Ollama, pulls the model, and runs a smoke test.
+5. **Configuration.** Writes gateway config with the local Ollama provider, auth disabled for localhost, and full tool access enabled.
+6. **Sandboxed tool execution.** When Docker is available, the agent's tool execution (shell commands, file operations, browser automation) runs inside isolated Docker containers via the OpenClaw sandbox system. The gateway itself runs on the host for simplicity. Pass `--no-container` to disable sandboxing and run tools directly on the host.
+7. **Verification.** A smoke test confirms the model responds before the gateway starts.
 
-If something does not fit (too little RAM, unsupported GPU), Gemmaclaw tells you what it tried and why it fell back, rather than silently degrading.
+If something does not fit (too little RAM, model has known issues on your platform), Gemmaclaw tells you what it tried and why it fell back, rather than silently degrading.
 
 ## Non-GPU support
 
@@ -50,9 +52,10 @@ Phase 2 tooling is live: `gemmaclaw setup` auto-detects hardware and provisions 
 ### Prerequisites
 
 - Node.js 22+
+- Docker (recommended, for containerized gateway)
 - For gemma.cpp backend (advanced): cmake, g++ (or clang++), git, and a [HuggingFace token](https://huggingface.co/settings/tokens) (`HF_TOKEN`)
 
-No pre-installed Ollama, llama.cpp, or gemma.cpp required. Gemmaclaw downloads and manages everything under `~/.gemmaclaw/`.
+No pre-installed Ollama, llama.cpp, or gemma.cpp required. Gemmaclaw downloads and manages everything.
 
 ### Install
 
@@ -66,14 +69,25 @@ pnpm build
 npm install -g .
 ```
 
-Then run the setup wizard and start chatting:
+Then run setup:
 
 ```bash
 gemmaclaw setup
-gemmaclaw chat
 ```
 
-`gemmaclaw setup` detects your hardware, picks the best backend, downloads the model, and runs a smoke test. `gemmaclaw chat` starts the gateway and opens a web chat UI in your browser where you can talk to your Gemma assistant directly.
+This detects your hardware, picks the best Gemma 4 model, downloads it via Ollama, configures the gateway, and starts it. When Docker is available, agent tool execution is automatically sandboxed in Docker containers. Open the Chat UI URL it prints at the end.
+
+To disable Docker sandboxing (tools run directly on the host):
+
+```bash
+gemmaclaw setup --no-container
+```
+
+To restart the gateway later:
+
+```bash
+gemmaclaw chat
+```
 
 ### Developer install
 
@@ -92,23 +106,32 @@ Example output:
 
 ```
 Detecting hardware...
-  CPU: x64, 12 cores (AMD Ryzen 9 5900X)
-  RAM: 31.3 GB total, 22.1 GB available
-  GPU: NVIDIA RTX 3090 (24 GB VRAM)
+  CPU: arm64, 16 cores (Apple M4 Max)
+  RAM: 48.0 GB total, 20.6 GB available
+  GPU: Apple M4 Max (48 GB unified memory)
 
-Recommended: Gemma 3 1B (Ollama) (815 MB download)
-  NVIDIA GPU detected. Ollama provides the best GPU acceleration.
+Recommended: Gemma 4 26B MoE (4B active) (18.0 GB download)
+  Apple Silicon with 48 GB unified memory. Gemma 4 31B Dense skipped due to
+  3 open issue(s) on darwin-arm64. 36+ GB RAM, M-series Max/Ultra.
 
 Provisioning ollama on port 11434...
 [Ollama] Runtime started on port 11434 (PID 12345).
 [Ollama] Model ready.
 
-Smoke test passed. Response: "Hello!"
+Smoke test passed. Response: "Hello."
+
+Writing gateway configuration...
+  Provider: ollama (http://127.0.0.1:11434/v1)
+  Model: ollama/gemma4:26b
 
 Setup complete! Your Gemma assistant is ready.
-  API: http://127.0.0.1:11434/v1/chat/completions
-  Model: gemma3:1b
-  PID: 12345
+
+  Sandbox: Docker (tools run in isolated containers)
+
+Starting gateway on port 18789...
+Gateway is ready.
+
+Chat UI: http://127.0.0.1:18789/
 ```
 
 ### Advanced setup
@@ -219,19 +242,20 @@ Results are written to `results/<model>__<timestamp>/` with three formats:
 
 ## Commands
 
-| Command                      | Description                                                |
-| ---------------------------- | ---------------------------------------------------------- |
-| `gemmaclaw setup`            | Auto-detect hardware and provision the best Gemma backend  |
-| `gemmaclaw setup --advanced` | Interactive wizard for manual backend/model/port selection |
-| `gemmaclaw chat`             | Open a browser-based chat UI for your Gemma assistant      |
-| `gemmaclaw chat --no-open`   | Start gateway without auto-opening the browser             |
-| `gemmaclaw chat --port 3001` | Start gateway on a specific port                           |
-| `gemmaclaw tui`              | Open terminal chat (TUI) with your Gemma assistant         |
-| `gemmaclaw benchmark`        | Run the benchmark suite (full LLM judge mode)              |
-| `gemmaclaw benchmark --mock` | Run benchmark with deterministic scoring (fast CI mode)    |
-| `gemmaclaw provision`        | Low-level: manually provision a specific backend           |
-| `gemmaclaw doctor`           | Health checks and quick fixes                              |
-| `gemmaclaw config`           | View and edit configuration                                |
+| Command                          | Description                                                 |
+| -------------------------------- | ----------------------------------------------------------- |
+| `gemmaclaw setup`                | Auto-detect hardware, provision, configure, and start       |
+| `gemmaclaw setup --no-container` | Same as above but disable Docker sandbox for tool execution |
+| `gemmaclaw setup --advanced`     | Interactive wizard for manual backend/model/port selection  |
+| `gemmaclaw chat`                 | Open a browser-based chat UI for your Gemma assistant       |
+| `gemmaclaw chat --no-open`       | Start gateway without auto-opening the browser              |
+| `gemmaclaw chat --port 3001`     | Start gateway on a specific port                            |
+| `gemmaclaw tui`                  | Open terminal chat (TUI) with your Gemma assistant          |
+| `gemmaclaw benchmark`            | Run the benchmark suite (full LLM judge mode)               |
+| `gemmaclaw benchmark --mock`     | Run benchmark with deterministic scoring (fast CI mode)     |
+| `gemmaclaw provision`            | Low-level: manually provision a specific backend            |
+| `gemmaclaw doctor`               | Health checks and quick fixes                               |
+| `gemmaclaw config`               | View and edit configuration                                 |
 
 ### npm scripts (development)
 

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -25,6 +25,10 @@ export function registerSetupCommand(program: Command) {
       "Run interactive advanced setup with manual backend/model/port selection",
       false,
     )
+    .option(
+      "--no-container",
+      "Run the gateway directly on the host instead of inside a Docker container",
+    )
     .option("--workspace-only", "Only initialize workspace config (skip Gemma provisioning)", false)
     .option("--wizard", "Run interactive onboarding (workspace config)", false)
     .option("--non-interactive", "Run onboarding without prompts", false)
@@ -62,7 +66,10 @@ export function registerSetupCommand(program: Command) {
 
         // Default: Gemma setup wizard.
         const { setupGemmaCommand } = await import("../../commands/setup-gemma.js");
-        await setupGemmaCommand({ advanced: Boolean(opts.advanced) }, defaultRuntime);
+        await setupGemmaCommand(
+          { advanced: Boolean(opts.advanced), noContainer: opts.container === false },
+          defaultRuntime,
+        );
       });
     });
 }

--- a/src/cli/webchat-cli.ts
+++ b/src/cli/webchat-cli.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,7 +10,7 @@ import { defaultRuntime } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 
 const HEALTH_POLL_INTERVAL_MS = 500;
-const HEALTH_POLL_MAX_ATTEMPTS = 60; // 30 seconds total
+const HEALTH_POLL_MAX_ATTEMPTS = 60;
 
 async function probeGatewayHealth(port: number): Promise<boolean> {
   try {
@@ -31,8 +31,7 @@ async function probeGatewayHealth(port: number): Promise<boolean> {
 
 async function waitForGatewayReady(port: number): Promise<boolean> {
   for (let i = 0; i < HEALTH_POLL_MAX_ATTEMPTS; i++) {
-    const healthy = await probeGatewayHealth(port);
-    if (healthy) {
+    if (await probeGatewayHealth(port)) {
       return true;
     }
     await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
@@ -42,8 +41,8 @@ async function waitForGatewayReady(port: number): Promise<boolean> {
 
 function resolveCliEntryPath(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  // Try multiple possible entry points (dist vs source)
   const candidates = [
+    path.resolve(here, "../../dist/entry.js"),
     path.resolve(here, "../../gemmaclaw.mjs"),
     path.resolve(here, "../../openclaw.mjs"),
   ];
@@ -52,35 +51,47 @@ function resolveCliEntryPath(): string {
       return candidate;
     }
   }
-  // Fallback: use process.argv[1] which is the current CLI entry
   return process.argv[1] ?? candidates[0];
 }
 
-function spawnGateway(port: number): ChildProcess {
+function killProcessesOnPort(port: number): void {
+  try {
+    const pids = execSync(`lsof -ti :${port}`, {
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: "pipe",
+    }).trim();
+    if (pids) {
+      for (const pid of pids.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGTERM");
+        } catch {
+          // Already gone.
+        }
+      }
+      execSync("sleep 1", { stdio: "pipe" });
+      for (const pid of pids.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // Already gone.
+        }
+      }
+    }
+  } catch {
+    // No processes on port.
+  }
+}
+
+function spawnGatewayDetached(port: number): number | undefined {
   const entryPath = resolveCliEntryPath();
-  const args = [entryPath, "gateway", "run", "--allow-unconfigured", "--port", String(port)];
-
-  const child = spawn(process.execPath, args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    detached: false,
-    env: process.env,
-  });
-
-  // Pipe gateway output to stderr so it doesn't clutter the main output
-  child.stdout?.on("data", (data: Buffer) => {
-    const text = data.toString().trim();
-    if (text) {
-      process.stderr.write(`${theme.muted(`[gateway] ${text}`)}\n`);
-    }
-  });
-  child.stderr?.on("data", (data: Buffer) => {
-    const text = data.toString().trim();
-    if (text) {
-      process.stderr.write(`${theme.muted(`[gateway] ${text}`)}\n`);
-    }
-  });
-
-  return child;
+  const child = spawn(
+    process.execPath,
+    [entryPath, "gateway", "run", "--allow-unconfigured", "--auth", "none", "--port", String(port)],
+    { stdio: "ignore", detached: true, env: process.env },
+  );
+  child.unref();
+  return child.pid;
 }
 
 export function registerWebchatCli(program: Command) {
@@ -92,7 +103,7 @@ export function registerWebchatCli(program: Command) {
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Starts the gateway and opens the web chat UI in your default browser.")}\n`,
+        `\n${theme.muted("Starts the gateway in the background and opens the web chat UI in your default browser.")}\n`,
     )
     .action(async (opts) => {
       try {
@@ -108,44 +119,29 @@ export function registerWebchatCli(program: Command) {
 
         const chatUrl = `http://127.0.0.1:${String(port)}/`;
 
-        // Check if gateway is already running
-        const alreadyRunning = await probeGatewayHealth(port);
-        let child: ChildProcess | undefined;
+        // Always clean up stale processes and start a fresh gateway.
+        killProcessesOnPort(port);
 
-        if (alreadyRunning) {
-          defaultRuntime.log(`Gateway already running on port ${String(port)}.`);
-        } else {
-          defaultRuntime.log(`Starting gateway on port ${String(port)}...`);
-          child = spawnGateway(port);
+        defaultRuntime.log(`Starting gateway on port ${String(port)}...`);
+        const pid = spawnGatewayDetached(port);
 
-          child.on("error", (err) => {
-            defaultRuntime.error(`Gateway failed to start: ${err.message}`);
-            defaultRuntime.exit(1);
-          });
-
-          child.on("exit", (code, signal) => {
-            if (signal) {
-              defaultRuntime.log(`Gateway stopped (${signal}).`);
-            } else if (code !== 0) {
-              defaultRuntime.error(`Gateway exited with code ${String(code ?? 1)}.`);
+        const ready = await waitForGatewayReady(port);
+        if (!ready) {
+          defaultRuntime.error(
+            "Gateway did not become ready within 30 seconds. Check logs with: gemmaclaw logs",
+          );
+          if (pid) {
+            try {
+              process.kill(pid, "SIGTERM");
+            } catch {
+              /* already gone */
             }
-            defaultRuntime.exit(code ?? 1);
-          });
-
-          // Wait for gateway to become healthy
-          const ready = await waitForGatewayReady(port);
-          if (!ready) {
-            defaultRuntime.error(
-              "Gateway did not become ready within 30 seconds. Check the logs above for errors.",
-            );
-            child.kill("SIGTERM");
-            defaultRuntime.exit(1);
           }
-
-          defaultRuntime.log("Gateway is ready.");
+          defaultRuntime.exit(1);
         }
 
-        // Open browser
+        defaultRuntime.log(`Gateway is ready (PID ${pid ?? "unknown"}).`);
+
         if (opts.open !== false) {
           const browserCmd = await resolveBrowserOpenCommand();
           if (browserCmd.argv) {
@@ -162,26 +158,7 @@ export function registerWebchatCli(program: Command) {
             );
           }
         } else {
-          defaultRuntime.log(`Chat UI available at: ${chatUrl}`);
-        }
-
-        // Keep running
-        if (child) {
-          defaultRuntime.log(`\n${theme.muted("Press Ctrl+C to stop the gateway and exit.")}`);
-
-          // Forward signals to the child
-          const cleanup = (signal: NodeJS.Signals) => {
-            child?.kill(signal);
-          };
-          process.on("SIGINT", () => cleanup("SIGINT"));
-          process.on("SIGTERM", () => cleanup("SIGTERM"));
-
-          // Wait for child to exit
-          await new Promise<void>((resolve) => {
-            child.on("exit", () => resolve());
-          });
-        } else {
-          defaultRuntime.log(`\nGateway is running independently. Chat UI: ${chatUrl}`);
+          defaultRuntime.log(`Chat UI: ${chatUrl}`);
         }
       } catch (err) {
         defaultRuntime.error(String(err));

--- a/src/cli/webchat-cli.ts
+++ b/src/cli/webchat-cli.ts
@@ -141,6 +141,11 @@ export function registerWebchatCli(program: Command) {
         }
 
         defaultRuntime.log(`Gateway is ready (PID ${pid ?? "unknown"}).`);
+        defaultRuntime.log(
+          theme.muted(
+            "Note: if you rebuild the project, run `gemmaclaw chat` again to restart the gateway.",
+          ),
+        );
 
         if (opts.open !== false) {
           const browserCmd = await resolveBrowserOpenCommand();

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -1,9 +1,174 @@
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 
 export type SetupGemmaCommandOpts = {
   advanced?: boolean;
+  noContainer?: boolean;
 };
+
+const HEALTH_POLL_INTERVAL_MS = 500;
+const HEALTH_POLL_MAX_ATTEMPTS = 60;
+
+async function probeGatewayHealth(port: number): Promise<boolean> {
+  try {
+    const url = `http://127.0.0.1:${String(port)}/healthz`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) {
+      return false;
+    }
+    const body = await res.text();
+    return body.includes("ok");
+  } catch {
+    return false;
+  }
+}
+
+async function waitForGatewayReady(port: number): Promise<boolean> {
+  for (let i = 0; i < HEALTH_POLL_MAX_ATTEMPTS; i++) {
+    if (await probeGatewayHealth(port)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+function killProcessesOnPort(port: number): void {
+  try {
+    const pids = execSync(`lsof -ti :${port}`, {
+      encoding: "utf-8",
+      timeout: 5_000,
+      stdio: "pipe",
+    }).trim();
+    if (pids) {
+      for (const pid of pids.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGTERM");
+        } catch {
+          // Already gone.
+        }
+      }
+      // Give processes a moment to exit.
+      execSync("sleep 1", { stdio: "pipe" });
+      // Force kill any that survived.
+      for (const pid of pids.split("\n").filter(Boolean)) {
+        try {
+          process.kill(Number(pid), "SIGKILL");
+        } catch {
+          // Already gone.
+        }
+      }
+    }
+  } catch {
+    // No processes on port, or lsof not available.
+  }
+}
+
+function resolveCliEntryPath(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(here, "../dist/entry.js"),
+    path.resolve(here, "../gemmaclaw.mjs"),
+    path.resolve(here, "../openclaw.mjs"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) {
+      return c;
+    }
+  }
+  return process.argv[1] ?? candidates[0];
+}
+
+function spawnGatewayDetached(port: number): ChildProcess {
+  const entryPath = resolveCliEntryPath();
+  const child = spawn(process.execPath, [entryPath, "gateway", "run", "--port", String(port)], {
+    stdio: "ignore",
+    detached: true,
+    env: process.env,
+  });
+  child.unref();
+  return child;
+}
+
+function isDockerInstalled(): boolean {
+  try {
+    execSync("docker --version", { stdio: "pipe", timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isDockerRunning(): boolean {
+  try {
+    execSync("docker info", { stdio: "pipe", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type PrereqCheck = { name: string; ok: boolean; help?: string };
+
+function checkPrerequisites(noContainer: boolean): PrereqCheck[] {
+  const checks: PrereqCheck[] = [];
+
+  const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+  checks.push({
+    name: "Node.js 22+",
+    ok: nodeVersion >= 22,
+    help:
+      nodeVersion < 22
+        ? `Found Node.js ${process.versions.node}. Install Node 22+:\n` +
+          `  macOS:   brew install node@22\n` +
+          `  Linux:   curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - && sudo apt-get install -y nodejs\n` +
+          `  nvm:     nvm install 22 && nvm use 22`
+        : undefined,
+  });
+
+  if (!noContainer) {
+    const installed = isDockerInstalled();
+    const running = installed && isDockerRunning();
+
+    if (!installed) {
+      checks.push({
+        name: "Docker",
+        ok: false,
+        help:
+          `Docker is not installed. Install it to run the gateway in an isolated container:\n` +
+          `  macOS:   brew install --cask docker   (then open Docker.app)\n` +
+          `  Linux:   curl -fsSL https://get.docker.com | sh\n` +
+          `  Windows: https://docs.docker.com/desktop/install/windows-install/\n` +
+          `\n` +
+          `  Or skip Docker and run directly on the host:\n` +
+          `    gemmaclaw setup --no-container`,
+      });
+    } else if (!running) {
+      checks.push({
+        name: "Docker daemon",
+        ok: false,
+        help:
+          `Docker is installed but the daemon is not running.\n` +
+          `  macOS:   Open Docker Desktop (or: open -a Docker)\n` +
+          `  Linux:   sudo systemctl start docker\n` +
+          `\n` +
+          `  Or skip Docker and run directly on the host:\n` +
+          `    gemmaclaw setup --no-container`,
+      });
+    } else {
+      checks.push({ name: "Docker", ok: true });
+    }
+  }
+
+  return checks;
+}
 
 export async function setupGemmaCommand(
   opts: SetupGemmaCommandOpts,
@@ -15,7 +180,30 @@ export async function setupGemmaCommand(
   const { selectQuickProfile, runAdvancedWizard, createStdioWizardIO, formatModelSize } =
     await import("../gemmaclaw/provision/setup-wizard.js");
   const { provision, verifyCompletion } = await import("../gemmaclaw/provision/provision.js");
-  const { DEFAULT_MODELS } = await import("../gemmaclaw/provision/model-registry.js");
+  const { DEFAULT_GATEWAY_PORT } = await import("../config/paths.js");
+
+  runtime.log("");
+  runtime.log("Checking prerequisites...");
+  const prereqs = checkPrerequisites(Boolean(opts.noContainer));
+  const failedPrereqs = prereqs.filter((p) => !p.ok);
+
+  for (const p of prereqs) {
+    runtime.log(`  ${p.ok ? "+" : "x"} ${p.name}`);
+  }
+
+  if (failedPrereqs.length > 0) {
+    runtime.log("");
+    for (const p of failedPrereqs) {
+      runtime.error(`Missing: ${p.name}`);
+      if (p.help) {
+        for (const line of p.help.split("\n")) {
+          runtime.error(`  ${line}`);
+        }
+      }
+      runtime.error("");
+    }
+    runtime.exit(1);
+  }
 
   runtime.log("");
   runtime.log("Detecting hardware...");
@@ -38,11 +226,12 @@ export async function setupGemmaCommand(
       io.close();
     }
   } else {
-    // Quick: auto-select the safest backend.
+    // Quick: auto-select best backend and model for this hardware.
     profile = selectQuickProfile(hw, tools);
-    const model = DEFAULT_MODELS[profile.backend];
+    const displayName = profile.modelDisplayName ?? profile.model ?? "default model";
+    const dlSize = formatModelSize(profile.modelDownloadBytes);
     runtime.log("");
-    runtime.log(`Recommended: ${model.displayName} (${formatModelSize(model.sizeBytes)} download)`);
+    runtime.log(`Recommended: ${displayName} (${dlSize} download)`);
     runtime.log(`  ${profile.reason}`);
   }
 
@@ -66,15 +255,109 @@ export async function setupGemmaCommand(
 
     if (verification.ok) {
       runtime.log(`Smoke test passed. Response: "${verification.content}"`);
+
+      // Write gateway config pointing to the local Ollama provider.
+      runtime.log("");
+      runtime.log("Writing gateway configuration...");
+      const { mutateConfigFile } = await import("../config/mutate.js");
+      const ollamaModel = result.modelId;
+      const ollamaBaseUrl = `${result.handle.apiBaseUrl}/v1`;
+      const enableSandbox = !opts.noContainer && isDockerRunning();
+      await mutateConfigFile({
+        mutate: (draft) => {
+          draft.gateway ??= {};
+          draft.gateway.mode = "local";
+          draft.gateway.auth ??= {};
+          draft.gateway.auth.mode = "none";
+
+          draft.models ??= {};
+          draft.models.providers ??= {};
+          draft.models.providers.ollama = {
+            baseUrl: ollamaBaseUrl,
+            api: "ollama",
+            models: [
+              {
+                id: ollamaModel,
+                name: ollamaModel,
+                reasoning: false,
+                input: ["text", "image"],
+                contextWindow: 262_144,
+                maxTokens: 8_192,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          };
+
+          draft.agents ??= {};
+          draft.agents.defaults ??= {};
+          draft.agents.defaults.model = `ollama/${ollamaModel}`;
+
+          // Enable full tool access with sandbox isolation.
+          // The gateway runs on the host, but agent tool execution (shell, file
+          // ops, browser) runs inside Docker sandbox containers.
+          draft.tools ??= {};
+          draft.tools.exec ??= {};
+          (draft.tools.exec as Record<string, unknown>).security = "full";
+          (draft.tools.exec as Record<string, unknown>).ask = "off";
+
+          if (enableSandbox) {
+            draft.agents.defaults.sandbox = {
+              mode: "all",
+              backend: "docker",
+              scope: "session",
+              workspaceAccess: "rw",
+            };
+          }
+        },
+      });
+      runtime.log(`  Provider: ollama (${ollamaBaseUrl})`);
+      runtime.log(`  Model: ollama/${ollamaModel}`);
+
+      if (enableSandbox) {
+        runtime.log(`  Sandbox: Docker (tools run in isolated containers)`);
+      } else {
+        runtime.log(`  Sandbox: off (tools run on host)`);
+      }
+
       runtime.log("");
       runtime.log("Setup complete! Your Gemma assistant is ready.");
-      runtime.log(`  Model: ${result.modelId}`);
-      runtime.log(`  API: ${result.handle.apiBaseUrl}/v1/chat/completions`);
+
+      // Build Control UI assets so the gateway starts instantly.
+      const { ensureControlUiAssetsBuilt } = await import("../infra/control-ui-assets.js");
       runtime.log("");
-      runtime.log("Next steps:");
-      runtime.log("  Chat in terminal:  gemmaclaw chat");
-      runtime.log("  Chat in browser:   gemmaclaw start, then open http://localhost:18789");
+      runtime.log("Checking Control UI assets...");
+      const uiBuild = await ensureControlUiAssetsBuilt(runtime);
+      if (uiBuild.ok) {
+        runtime.log(uiBuild.built ? "Control UI built." : "Control UI assets ready.");
+      } else {
+        runtime.error(`Control UI: ${uiBuild.message}`);
+        runtime.error("The gateway will attempt to build them on first start.");
+      }
+
+      // Start the gateway on the host. Tool execution is sandboxed in Docker
+      // containers via agents.defaults.sandbox when Docker is available.
+      const gwPort = DEFAULT_GATEWAY_PORT;
+
+      // Clean up any stale gateway process before starting fresh.
+      killProcessesOnPort(gwPort);
+
       runtime.log("");
+      runtime.log(`Starting gateway on port ${gwPort}...`);
+      spawnGatewayDetached(gwPort);
+
+      const ready = await waitForGatewayReady(gwPort);
+      if (!ready) {
+        runtime.error("Gateway did not become ready within 30 seconds.");
+        runtime.error("You can start it manually with: gemmaclaw chat");
+        runtime.log("");
+        runtime.log(`Backend PID: ${result.handle.pid} (stop with: kill ${result.handle.pid})`);
+        return;
+      }
+      runtime.log("Gateway is ready.");
+
+      const chatUrl = `http://127.0.0.1:${gwPort}/`;
+      runtime.log("");
+      runtime.log(`Chat UI: ${chatUrl}`);
       runtime.log(`Backend PID: ${result.handle.pid} (stop with: kill ${result.handle.pid})`);
     } else {
       runtime.error(`Smoke test failed: ${verification.error}`);

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -1,6 +1,7 @@
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import readline from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -115,59 +116,72 @@ function isDockerRunning(): boolean {
   }
 }
 
-type PrereqCheck = { name: string; ok: boolean; help?: string };
+async function promptSandboxChoice(runtime: RuntimeEnv): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    runtime.log("");
+    runtime.log("How would you like the agent to run tools (shell, files, browser)?");
+    runtime.log("");
+    runtime.log("  1) Docker sandbox (recommended)");
+    runtime.log("     Tools run inside isolated Docker containers. The agent gets full");
+    runtime.log("     access to execute commands, read/write files, and browse the web,");
+    runtime.log("     but it cannot touch your host system. If anything goes wrong, the");
+    runtime.log("     container is disposable. Requires Docker to be installed and running.");
+    runtime.log("");
+    runtime.log("  2) Directly on this machine");
+    runtime.log("     Tools run directly on your host. This is simpler and faster, but the");
+    runtime.log("     agent can access your files, run commands, and make changes to your");
+    runtime.log("     system with no isolation. Only choose this if you trust the model or");
+    runtime.log("     are comfortable reviewing what it does.");
+    runtime.log("");
 
-function checkPrerequisites(noContainer: boolean): PrereqCheck[] {
-  const checks: PrereqCheck[] = [];
+    const answer = await rl.question("Choose [1/2, default=1]: ");
+    const choice = answer.trim();
+    return choice === "2" || choice.toLowerCase() === "direct";
+  } finally {
+    rl.close();
+  }
+}
 
-  const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
-  checks.push({
-    name: "Node.js 22+",
-    ok: nodeVersion >= 22,
-    help:
-      nodeVersion < 22
-        ? `Found Node.js ${process.versions.node}. Install Node 22+:\n` +
-          `  macOS:   brew install node@22\n` +
-          `  Linux:   curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - && sudo apt-get install -y nodejs\n` +
-          `  nvm:     nvm install 22 && nvm use 22`
-        : undefined,
-  });
+async function ensureDockerReady(runtime: RuntimeEnv): Promise<boolean> {
+  if (!isDockerInstalled()) {
+    runtime.log("");
+    runtime.log("Docker is not installed. Install it before continuing:");
+    runtime.log("  macOS:   brew install --cask docker   (then open Docker.app)");
+    runtime.log("  Linux:   curl -fsSL https://get.docker.com | sh");
+    runtime.log("  Windows: https://docs.docker.com/desktop/install/windows-install/");
+    runtime.log("");
+    runtime.log("After installing, re-run: gemmaclaw setup");
+    return false;
+  }
 
-  if (!noContainer) {
-    const installed = isDockerInstalled();
-    const running = installed && isDockerRunning();
+  if (!isDockerRunning()) {
+    runtime.log("");
+    runtime.log("Docker is installed but the daemon is not running. Start it:");
+    runtime.log("  macOS:   Open Docker Desktop (or: open -a Docker)");
+    runtime.log("  Linux:   sudo systemctl start docker");
+    runtime.log("");
 
-    if (!installed) {
-      checks.push({
-        name: "Docker",
-        ok: false,
-        help:
-          `Docker is not installed. Install it to run the gateway in an isolated container:\n` +
-          `  macOS:   brew install --cask docker   (then open Docker.app)\n` +
-          `  Linux:   curl -fsSL https://get.docker.com | sh\n` +
-          `  Windows: https://docs.docker.com/desktop/install/windows-install/\n` +
-          `\n` +
-          `  Or skip Docker and run directly on the host:\n` +
-          `    gemmaclaw setup --no-container`,
-      });
-    } else if (!running) {
-      checks.push({
-        name: "Docker daemon",
-        ok: false,
-        help:
-          `Docker is installed but the daemon is not running.\n` +
-          `  macOS:   Open Docker Desktop (or: open -a Docker)\n` +
-          `  Linux:   sudo systemctl start docker\n` +
-          `\n` +
-          `  Or skip Docker and run directly on the host:\n` +
-          `    gemmaclaw setup --no-container`,
-      });
-    } else {
-      checks.push({ name: "Docker", ok: true });
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      const answer = await rl.question(
+        "Press Enter once Docker is running (or type 'skip' to run without it): ",
+      );
+      if (answer.trim().toLowerCase() === "skip") {
+        return false;
+      }
+    } finally {
+      rl.close();
+    }
+
+    if (!isDockerRunning()) {
+      runtime.error("Docker daemon is still not running.");
+      runtime.error("Start Docker and re-run setup, or use: gemmaclaw setup --no-container");
+      runtime.exit(1);
     }
   }
 
-  return checks;
+  return true;
 }
 
 export async function setupGemmaCommand(
@@ -182,27 +196,26 @@ export async function setupGemmaCommand(
   const { provision, verifyCompletion } = await import("../gemmaclaw/provision/provision.js");
   const { DEFAULT_GATEWAY_PORT } = await import("../config/paths.js");
 
-  runtime.log("");
-  runtime.log("Checking prerequisites...");
-  const prereqs = checkPrerequisites(Boolean(opts.noContainer));
-  const failedPrereqs = prereqs.filter((p) => !p.ok);
-
-  for (const p of prereqs) {
-    runtime.log(`  ${p.ok ? "+" : "x"} ${p.name}`);
+  // Check Node.js version.
+  const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
+  if (nodeVersion < 22) {
+    runtime.error(`Node.js 22+ required (current: ${process.versions.node}).`);
+    runtime.error("  nvm:     nvm install 22 && nvm use 22");
+    runtime.error("  macOS:   brew install node@22");
+    runtime.exit(1);
   }
 
-  if (failedPrereqs.length > 0) {
-    runtime.log("");
-    for (const p of failedPrereqs) {
-      runtime.error(`Missing: ${p.name}`);
-      if (p.help) {
-        for (const line of p.help.split("\n")) {
-          runtime.error(`  ${line}`);
-        }
-      }
-      runtime.error("");
+  // Determine sandbox mode: interactive prompt unless --no-container was passed.
+  let useDocker = false;
+  if (opts.noContainer) {
+    useDocker = false;
+  } else {
+    const wantsDirect = await promptSandboxChoice(runtime);
+    if (wantsDirect) {
+      useDocker = false;
+    } else {
+      useDocker = await ensureDockerReady(runtime);
     }
-    runtime.exit(1);
   }
 
   runtime.log("");
@@ -262,7 +275,7 @@ export async function setupGemmaCommand(
       const { mutateConfigFile } = await import("../config/mutate.js");
       const ollamaModel = result.modelId;
       const ollamaBaseUrl = `${result.handle.apiBaseUrl}/v1`;
-      const enableSandbox = !opts.noContainer && isDockerRunning();
+      const enableSandbox = useDocker;
       await mutateConfigFile({
         mutate: (draft) => {
           draft.gateway ??= {};

--- a/src/gemmaclaw/provision/hardware.test.ts
+++ b/src/gemmaclaw/provision/hardware.test.ts
@@ -83,10 +83,15 @@ describe("detectHardware", () => {
     expect(hw.ram.availableBytes).toBe(8 * 1024 ** 3);
   });
 
-  it("reports no GPU when /dev/nvidia0 absent and nvidia-smi fails", () => {
+  it("reports no NVIDIA GPU when /dev/nvidia0 absent and nvidia-smi fails", () => {
     const hw = detectHardware();
-    expect(hw.gpu.detected).toBe(false);
     expect(hw.gpu.nvidia).toBe(false);
+    if (process.platform === "darwin" && process.arch === "arm64") {
+      expect(hw.gpu.detected).toBe(true);
+      expect(hw.gpu.apple).toBe(true);
+    } else {
+      expect(hw.gpu.detected).toBe(false);
+    }
   });
 
   it("detects GPU via /dev/nvidia0 without nvidia-smi details", () => {
@@ -181,7 +186,7 @@ describe("formatHardwareInfo", () => {
     const hw: HardwareInfo = {
       cpu: { arch: "x64", cores: 8, model: "AMD Ryzen 7" },
       ram: { totalBytes: 16 * 1024 ** 3, availableBytes: 10 * 1024 ** 3 },
-      gpu: { detected: false, nvidia: false },
+      gpu: { detected: false, nvidia: false, apple: false },
     };
     const lines = formatHardwareInfo(hw);
     expect(lines).toHaveLength(3);
@@ -195,7 +200,13 @@ describe("formatHardwareInfo", () => {
     const hw: HardwareInfo = {
       cpu: { arch: "x64", cores: 12, model: "Intel i9" },
       ram: { totalBytes: 32 * 1024 ** 3, availableBytes: 20 * 1024 ** 3 },
-      gpu: { detected: true, nvidia: true, name: "RTX 4090", vramBytes: 24 * 1024 ** 3 },
+      gpu: {
+        detected: true,
+        nvidia: true,
+        apple: false,
+        name: "RTX 4090",
+        vramBytes: 24 * 1024 ** 3,
+      },
     };
     const lines = formatHardwareInfo(hw);
     expect(lines[2]).toContain("RTX 4090");

--- a/src/gemmaclaw/provision/hardware.ts
+++ b/src/gemmaclaw/provision/hardware.ts
@@ -15,6 +15,7 @@ export type HardwareInfo = {
   gpu: {
     detected: boolean;
     nvidia: boolean;
+    apple: boolean;
     name?: string;
     vramBytes?: number;
   };
@@ -51,24 +52,48 @@ export function detectHardware(): HardwareInfo {
 }
 
 function detectGpu(): HardwareInfo["gpu"] {
-  // Check for NVIDIA GPU via /dev/nvidia0 or nvidia-smi.
+  // NVIDIA GPU via /dev/nvidia0 or nvidia-smi (check first since it is most specific).
   const devExists = safeFileExists("/dev/nvidia0");
-
   if (devExists || hasNvidiaSmi()) {
     const smiInfo = queryNvidiaSmi();
     if (smiInfo) {
       return {
         detected: true,
         nvidia: true,
+        apple: false,
         name: smiInfo.name,
         vramBytes: smiInfo.vramMb ? smiInfo.vramMb * 1024 * 1024 : undefined,
       };
     }
-    // Device exists but nvidia-smi gave no details.
-    return { detected: true, nvidia: true };
+    return { detected: true, nvidia: true, apple: false };
   }
 
-  return { detected: false, nvidia: false };
+  // Apple Silicon: Metal GPU with unified memory (all system RAM is GPU-accessible).
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    const chipName = queryAppleSiliconChip();
+    return {
+      detected: true,
+      nvidia: false,
+      apple: true,
+      name: chipName ?? "Apple Silicon (Metal)",
+      vramBytes: os.totalmem(),
+    };
+  }
+
+  return { detected: false, nvidia: false, apple: false };
+}
+
+function queryAppleSiliconChip(): string | null {
+  try {
+    const output = execSync("sysctl -n machdep.cpu.brand_string", {
+      timeout: 3_000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
 }
 
 function safeFileExists(filePath: string): boolean {
@@ -147,9 +172,20 @@ export function formatHardwareInfo(hw: HardwareInfo): string[] {
     `  RAM: ${ramGb} GB total, ${freeRamGb} GB available`,
   ];
 
-  if (hw.gpu.detected && hw.gpu.nvidia) {
-    const vram = hw.gpu.vramBytes ? ` (${(hw.gpu.vramBytes / 1024 ** 3).toFixed(0)} GB VRAM)` : "";
-    lines.push(`  GPU: ${hw.gpu.name ?? "NVIDIA GPU"}${vram}`);
+  if (hw.gpu.detected) {
+    if (hw.gpu.apple) {
+      const unified = hw.gpu.vramBytes
+        ? ` (${(hw.gpu.vramBytes / 1024 ** 3).toFixed(0)} GB unified memory)`
+        : "";
+      lines.push(`  GPU: ${hw.gpu.name ?? "Apple Silicon (Metal)"}${unified}`);
+    } else if (hw.gpu.nvidia) {
+      const vram = hw.gpu.vramBytes
+        ? ` (${(hw.gpu.vramBytes / 1024 ** 3).toFixed(0)} GB VRAM)`
+        : "";
+      lines.push(`  GPU: ${hw.gpu.name ?? "NVIDIA GPU"}${vram}`);
+    } else {
+      lines.push(`  GPU: ${hw.gpu.name ?? "detected"}`);
+    }
   } else {
     lines.push("  GPU: none detected");
   }

--- a/src/gemmaclaw/provision/model-registry.ts
+++ b/src/gemmaclaw/provision/model-registry.ts
@@ -25,9 +25,8 @@ export type ModelArtifact = {
 // -----------------------------------------------------------------------
 
 export const OLLAMA_RUNTIME: RuntimeArtifact = {
-  version: "0.6.2",
-  urlTemplate:
-    "https://github.com/ollama/ollama/releases/download/v{version}/ollama-linux-{arch}.tgz",
+  version: "0.21.2",
+  urlTemplate: "https://github.com/ollama/ollama/releases/download/v{version}/ollama-{os}-{arch}",
 };
 
 export const LLAMACPP_RUNTIME: RuntimeArtifact = {
@@ -68,11 +67,29 @@ export const DEFAULT_MODELS: Record<BackendId, ModelArtifact> = {
   },
 };
 
-export function resolveOllamaBinaryUrl(): string {
+export type OllamaArtifactInfo = {
+  url: string;
+  /** "tgz" for Linux archives, "zip" for the macOS app bundle. */
+  format: "tgz" | "zip";
+};
+
+export function resolveOllamaBinaryUrl(): OllamaArtifactInfo {
+  const isDarwin = process.platform === "darwin";
+
+  if (isDarwin) {
+    // macOS: universal app bundle distributed as Ollama-darwin.zip.
+    // The CLI binary lives at Ollama.app/Contents/Resources/ollama.
+    const url = `https://github.com/ollama/ollama/releases/download/v${OLLAMA_RUNTIME.version}/Ollama-darwin.zip`;
+    return { url, format: "zip" };
+  }
+
   const arch = process.arch === "x64" ? "amd64" : "arm64";
-  return OLLAMA_RUNTIME.urlTemplate
-    .replace("{version}", OLLAMA_RUNTIME.version)
-    .replace("{arch}", arch);
+  const url =
+    OLLAMA_RUNTIME.urlTemplate
+      .replace("{version}", OLLAMA_RUNTIME.version)
+      .replace("{os}", "linux")
+      .replace("{arch}", arch) + ".tgz";
+  return { url, format: "tgz" };
 }
 
 export function resolveLlamaCppUrl(): string {

--- a/src/gemmaclaw/provision/model-selector.test.ts
+++ b/src/gemmaclaw/provision/model-selector.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { HardwareInfo } from "./hardware.js";
+import { selectBestModel } from "./model-selector.js";
+
+function makeHw(overrides: Partial<HardwareInfo> = {}): HardwareInfo {
+  return {
+    cpu: { arch: "x64", cores: 8, model: "Intel Core i7" },
+    ram: { totalBytes: 16 * 1024 ** 3, availableBytes: 10 * 1024 ** 3 },
+    gpu: { detected: false, nvidia: false, apple: false },
+    ...overrides,
+  };
+}
+
+describe("selectBestModel", () => {
+  it("selects e2b for minimal RAM (4 GB)", () => {
+    const hw = makeHw({ ram: { totalBytes: 4 * 1024 ** 3, availableBytes: 2 * 1024 ** 3 } });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:e2b");
+    expect(rec.tier.tier).toBe("minimal");
+  });
+
+  it("selects e2b for 8 GB edge tier", () => {
+    const hw = makeHw({ ram: { totalBytes: 8 * 1024 ** 3, availableBytes: 4 * 1024 ** 3 } });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:e2b");
+  });
+
+  it("selects e4b for 16 GB default tier (CPU-only, 75% headroom = 12 GB)", () => {
+    const hw = makeHw({ ram: { totalBytes: 16 * 1024 ** 3, availableBytes: 10 * 1024 ** 3 } });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:e4b");
+    expect(rec.tier.tier).toBe("default");
+  });
+
+  it("selects 26b for 32 GB workstation tier", () => {
+    const hw = makeHw({ ram: { totalBytes: 32 * 1024 ** 3, availableBytes: 20 * 1024 ** 3 } });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:26b");
+    expect(rec.tier.tier).toBe("workstation");
+  });
+
+  it("selects 26b (fallback) for 48 GB Apple Silicon due to 31b blockers", () => {
+    const hw = makeHw({
+      ram: { totalBytes: 48 * 1024 ** 3, availableBytes: 20 * 1024 ** 3 },
+      gpu: {
+        detected: true,
+        nvidia: false,
+        apple: true,
+        name: "Apple M4 Max",
+        vramBytes: 48 * 1024 ** 3,
+      },
+    });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:26b");
+    expect(rec.tier.tier).toBe("high-memory");
+    expect(rec.skippedIssues).toBeDefined();
+    expect(rec.skippedIssues!.length).toBeGreaterThan(0);
+    expect(rec.reason).toContain("skipped");
+  });
+
+  it("uses full RAM for GPU-accelerated systems", () => {
+    const hw = makeHw({
+      ram: { totalBytes: 24 * 1024 ** 3, availableBytes: 10 * 1024 ** 3 },
+      gpu: {
+        detected: true,
+        nvidia: true,
+        apple: false,
+        name: "RTX 4090",
+        vramBytes: 24 * 1024 ** 3,
+      },
+    });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:26b");
+  });
+
+  it("applies 75% headroom for CPU-only systems", () => {
+    // 24 GB * 0.75 = 18 GB effective -> default tier (12-20 GB)
+    const hw = makeHw({ ram: { totalBytes: 24 * 1024 ** 3, availableBytes: 10 * 1024 ** 3 } });
+    const rec = selectBestModel(hw);
+    expect(rec.model.id).toBe("gemma4:e4b");
+    expect(rec.tier.tier).toBe("default");
+  });
+
+  it("includes hardware description in reason", () => {
+    const hw = makeHw({
+      ram: { totalBytes: 48 * 1024 ** 3, availableBytes: 20 * 1024 ** 3 },
+      gpu: {
+        detected: true,
+        nvidia: false,
+        apple: true,
+        name: "Apple M4 Max",
+        vramBytes: 48 * 1024 ** 3,
+      },
+    });
+    const rec = selectBestModel(hw);
+    expect(rec.reason).toContain("Apple Silicon");
+    expect(rec.reason).toContain("48 GB");
+  });
+});

--- a/src/gemmaclaw/provision/model-selector.ts
+++ b/src/gemmaclaw/provision/model-selector.ts
@@ -1,0 +1,375 @@
+import type { HardwareInfo } from "./hardware.js";
+
+// ---------------------------------------------------------------------------
+// Model catalog: edit this structure to update model recommendations.
+// Each model entry maps to an Ollama tag. Hardware tiers map RAM ranges
+// to the best model for that class of device.
+//
+// knownIssues: document failures, regressions, and platform-specific bugs
+// discovered during testing. Each issue has a status ("open" or "resolved"),
+// affected hardware/quant scope, date discovered, and a citation URL.
+// The selector skips models with open blockers matching the current hardware.
+// ---------------------------------------------------------------------------
+
+export type KnownIssue = {
+  id: string;
+  status: "open" | "resolved";
+  severity: "blocker" | "degraded" | "cosmetic";
+  summary: string;
+  affectedPlatforms?: readonly string[];
+  affectedQuants?: readonly string[];
+  discoveredDate: string;
+  resolvedDate?: string;
+  resolvedInVersion?: string;
+  citations: readonly string[];
+  workaround?: string;
+  testedBy?: string;
+};
+
+export type CatalogModel = {
+  id: string;
+  family: string;
+  displayName: string;
+  ollamaTag: string;
+  parameterCount: string;
+  contextLength: number;
+  modalities: readonly string[];
+  downloadSizeBytes: number;
+  runtimeMemoryBytes: number;
+  architecture?: string;
+  quant?: string;
+  tier: string;
+  knownIssues?: readonly KnownIssue[];
+};
+
+export type HardwareTier = {
+  tier: string;
+  description: string;
+  minRamBytes: number;
+  maxRamBytes: number | null;
+  modelId: string;
+  fallbackModelId?: string;
+};
+
+export type ModelCatalog = {
+  models: readonly CatalogModel[];
+  hardwareTiers: readonly HardwareTier[];
+};
+
+export type ModelRecommendation = {
+  model: CatalogModel;
+  tier: HardwareTier;
+  reason: string;
+  skippedIssues?: readonly KnownIssue[];
+};
+
+export const MODEL_CATALOG: ModelCatalog = {
+  models: [
+    {
+      id: "gemma4:e2b",
+      family: "gemma4",
+      displayName: "Gemma 4 E2B",
+      ollamaTag: "gemma4:e2b",
+      parameterCount: "2.3B effective (5.1B total)",
+      contextLength: 131_072,
+      modalities: ["text", "image", "audio"],
+      downloadSizeBytes: 7_200_000_000,
+      runtimeMemoryBytes: 8_500_000_000,
+      tier: "edge",
+    },
+    {
+      id: "gemma4:e4b",
+      family: "gemma4",
+      displayName: "Gemma 4 E4B",
+      ollamaTag: "gemma4:e4b",
+      parameterCount: "4.5B effective (8B total)",
+      contextLength: 131_072,
+      modalities: ["text", "image", "audio"],
+      downloadSizeBytes: 9_600_000_000,
+      runtimeMemoryBytes: 12_000_000_000,
+      tier: "default",
+    },
+    {
+      id: "gemma4:26b",
+      family: "gemma4",
+      displayName: "Gemma 4 26B MoE (4B active)",
+      ollamaTag: "gemma4:26b",
+      parameterCount: "25.2B total (3.8B active)",
+      contextLength: 262_144,
+      modalities: ["text", "image"],
+      downloadSizeBytes: 18_000_000_000,
+      runtimeMemoryBytes: 22_000_000_000,
+      architecture: "moe",
+      quant: "q4_K_M",
+      tier: "workstation",
+      knownIssues: [
+        {
+          id: "gemma4-26b-moe-cold-load-reset",
+          status: "open",
+          severity: "cosmetic",
+          summary: "One-time monitor reset during cold model load on Apple Silicon, then stable.",
+          affectedPlatforms: ["darwin-arm64"],
+          discoveredDate: "2026-04-06",
+          citations: ["https://github.com/ollama/ollama/issues/15368"],
+          testedBy: "gemmaclaw-setup",
+        },
+      ],
+    },
+    {
+      id: "gemma4:31b",
+      family: "gemma4",
+      displayName: "Gemma 4 31B Dense",
+      ollamaTag: "gemma4:31b",
+      parameterCount: "30.7B",
+      contextLength: 262_144,
+      modalities: ["text", "image"],
+      downloadSizeBytes: 20_000_000_000,
+      runtimeMemoryBytes: 24_000_000_000,
+      quant: "q4_K_M",
+      tier: "high-memory",
+      knownIssues: [
+        {
+          id: "gemma4-31b-fa-hang",
+          status: "open",
+          severity: "blocker",
+          summary:
+            "Flash Attention hangs indefinitely on prompts >500 tokens. " +
+            "Gemma 4 hybrid attention (50 sliding-window + 10 global layers with different head dims 256/512) " +
+            "breaks the FA implementation. GPU drops to 0%, complete stall.",
+          affectedPlatforms: ["darwin-arm64", "linux-nvidia"],
+          discoveredDate: "2026-04-04",
+          citations: [
+            "https://github.com/ollama/ollama/issues/15368",
+            "https://github.com/ollama/ollama/issues/15350",
+            "https://github.com/ollama/ollama/issues/15286",
+          ],
+          workaround: "Set OLLAMA_FLASH_ATTENTION=0 (slow: ~15 tok/s gen on M4 Max).",
+          testedBy: "gemmaclaw-setup",
+        },
+        {
+          id: "gemma4-31b-monitor-reset",
+          status: "open",
+          severity: "blocker",
+          summary:
+            "Monitor/display reset (screen flickering) on Apple Silicon when processing prompts >1000 tokens. " +
+            "The dense model reads 16.5 GiB weights per step, saturating memory bandwidth.",
+          affectedPlatforms: ["darwin-arm64"],
+          discoveredDate: "2026-04-06",
+          citations: ["https://github.com/ollama/ollama/issues/15368"],
+          testedBy: "gemmaclaw-setup frank M4 Max 48GB 2026-04-27",
+        },
+        {
+          id: "gemma4-31b-memory-leak",
+          status: "open",
+          severity: "blocker",
+          summary:
+            "Memory usage grows unboundedly during prompt preprocessing on macOS. " +
+            "LM Studio reported 221 GB usage on 64 GB M4 Max. Ollama shows similar growth. " +
+            "Can cause full system crash if unattended.",
+          affectedPlatforms: ["darwin-arm64"],
+          discoveredDate: "2026-04-04",
+          citations: ["https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/1750"],
+          testedBy: "gemmaclaw-setup",
+        },
+      ],
+    },
+    {
+      id: "gemma4:31b-it-q8_0",
+      family: "gemma4",
+      displayName: "Gemma 4 31B Dense (Q8)",
+      ollamaTag: "gemma4:31b-it-q8_0",
+      parameterCount: "30.7B",
+      contextLength: 262_144,
+      modalities: ["text", "image"],
+      downloadSizeBytes: 34_000_000_000,
+      runtimeMemoryBytes: 38_000_000_000,
+      quant: "q8_0",
+      tier: "high-memory-q8",
+      knownIssues: [
+        {
+          id: "gemma4-31b-q8-smoke-fail-48gb",
+          status: "open",
+          severity: "blocker",
+          summary:
+            "Smoke test returns empty response on M4 Max 48GB. Model loads but fails to generate. " +
+            "Likely OOM during inference with 38 GB model + KV cache exceeding 48 GB unified memory.",
+          affectedPlatforms: ["darwin-arm64"],
+          discoveredDate: "2026-04-27",
+          citations: [],
+          testedBy: "gemmaclaw-setup frank M4 Max 48GB 2026-04-27",
+        },
+        {
+          id: "gemma4-31b-q8-fa-hang",
+          status: "open",
+          severity: "blocker",
+          summary:
+            "Inherits the same Flash Attention hang as gemma4:31b Q4 on prompts >500 tokens.",
+          affectedPlatforms: ["darwin-arm64", "linux-nvidia"],
+          discoveredDate: "2026-04-06",
+          citations: ["https://github.com/ollama/ollama/issues/15368"],
+          testedBy: "gemmaclaw-setup",
+        },
+      ],
+    },
+  ],
+
+  hardwareTiers: [
+    {
+      tier: "minimal",
+      description: "Very limited RAM, phones, low-end SBCs",
+      minRamBytes: 0,
+      maxRamBytes: 8_000_000_000,
+      modelId: "gemma4:e2b",
+    },
+    {
+      tier: "edge",
+      description: "8-12 GB RAM laptops, tablets, entry Macs",
+      minRamBytes: 8_000_000_000,
+      maxRamBytes: 12_000_000_000,
+      modelId: "gemma4:e2b",
+    },
+    {
+      tier: "default",
+      description: "12-20 GB RAM, most consumer laptops and desktops",
+      minRamBytes: 12_000_000_000,
+      maxRamBytes: 20_000_000_000,
+      modelId: "gemma4:e4b",
+    },
+    {
+      tier: "workstation",
+      description: "20-36 GB RAM, pro laptops, workstations, Apple Silicon 24GB+",
+      minRamBytes: 20_000_000_000,
+      maxRamBytes: 36_000_000_000,
+      modelId: "gemma4:26b",
+    },
+    {
+      tier: "high-memory",
+      description: "36+ GB RAM, M-series Max/Ultra, NVIDIA workstations, servers",
+      minRamBytes: 36_000_000_000,
+      maxRamBytes: null,
+      modelId: "gemma4:31b",
+      fallbackModelId: "gemma4:26b",
+    },
+  ],
+};
+
+function resolvePlatformKey(hw: HardwareInfo): string {
+  if (hw.gpu.apple) {
+    return "darwin-arm64";
+  }
+  if (hw.gpu.nvidia) {
+    return "linux-nvidia";
+  }
+  if (process.platform === "darwin") {
+    return `darwin-${process.arch}`;
+  }
+  return `${process.platform}-${process.arch}`;
+}
+
+function hasOpenBlocker(model: CatalogModel, platformKey: string): KnownIssue | undefined {
+  if (!model.knownIssues) {
+    return undefined;
+  }
+  return model.knownIssues.find(
+    (issue) =>
+      issue.status === "open" &&
+      issue.severity === "blocker" &&
+      (!issue.affectedPlatforms || issue.affectedPlatforms.includes(platformKey)),
+  );
+}
+
+function getOpenIssues(model: CatalogModel, platformKey: string): readonly KnownIssue[] {
+  if (!model.knownIssues) {
+    return [];
+  }
+  return model.knownIssues.filter(
+    (issue) =>
+      issue.status === "open" &&
+      (!issue.affectedPlatforms || issue.affectedPlatforms.includes(platformKey)),
+  );
+}
+
+/**
+ * Pick the best model for the detected hardware.
+ *
+ * Uses total system RAM (unified memory on Apple Silicon) to find the highest
+ * tier the system qualifies for. GPU-accelerated systems use full RAM.
+ * CPU-only systems apply a 75% headroom factor so the OS stays responsive.
+ *
+ * If the preferred model has open blocker-severity issues for the current
+ * platform, the selector falls back to the tier's fallbackModelId.
+ */
+export function selectBestModel(hw: HardwareInfo): ModelRecommendation {
+  const catalog = MODEL_CATALOG;
+  const platformKey = resolvePlatformKey(hw);
+
+  const hasGpuAccel = hw.gpu.detected && (hw.gpu.apple || hw.gpu.nvidia);
+  const effectiveRam = hasGpuAccel ? hw.ram.totalBytes : Math.floor(hw.ram.totalBytes * 0.75);
+
+  let matchedTier: HardwareTier | undefined;
+  for (const tier of catalog.hardwareTiers) {
+    const max = tier.maxRamBytes ?? Number.MAX_SAFE_INTEGER;
+    if (effectiveRam >= tier.minRamBytes && effectiveRam < max) {
+      matchedTier = tier;
+      break;
+    }
+  }
+
+  if (!matchedTier) {
+    const sorted = [...catalog.hardwareTiers].toSorted((a, b) => b.minRamBytes - a.minRamBytes);
+    matchedTier = sorted.find((t) => effectiveRam >= t.minRamBytes) ?? catalog.hardwareTiers[0];
+  }
+
+  const tier = matchedTier;
+  const primaryModel = catalog.models.find((m) => m.id === tier.modelId);
+  const fallbackModel = tier.fallbackModelId
+    ? catalog.models.find((m) => m.id === tier.fallbackModelId)
+    : undefined;
+
+  let model = primaryModel;
+  let skippedIssues: KnownIssue[] = [];
+
+  if (model) {
+    const blocker = hasOpenBlocker(model, platformKey);
+    if (blocker && fallbackModel) {
+      skippedIssues = [...getOpenIssues(model, platformKey)];
+      model = fallbackModel;
+    }
+  }
+
+  if (!model) {
+    const fallback = catalog.models[0];
+    return {
+      model: fallback,
+      tier,
+      reason: `Fallback to ${fallback.displayName} (catalog model ${tier.modelId} not found).`,
+    };
+  }
+
+  const ramGb = Math.round(hw.ram.totalBytes / 1024 ** 3);
+  const parts: string[] = [];
+
+  if (hw.gpu.apple) {
+    parts.push(`Apple Silicon with ${ramGb} GB unified memory`);
+  } else if (hw.gpu.nvidia && hw.gpu.vramBytes) {
+    const vramGb = Math.round(hw.gpu.vramBytes / 1024 ** 3);
+    parts.push(`NVIDIA GPU with ${vramGb} GB VRAM, ${ramGb} GB system RAM`);
+  } else {
+    parts.push(`${ramGb} GB RAM (CPU inference)`);
+  }
+
+  if (skippedIssues.length > 0 && primaryModel) {
+    parts.push(
+      `${primaryModel.displayName} skipped due to ${skippedIssues.length} open issue(s) on ${platformKey}`,
+    );
+  }
+
+  parts.push(tier.description);
+
+  return {
+    model,
+    tier,
+    reason: `${parts.join(". ")}.`,
+    skippedIssues: skippedIssues.length > 0 ? skippedIssues : undefined,
+  };
+}

--- a/src/gemmaclaw/provision/ollama-manager.ts
+++ b/src/gemmaclaw/provision/ollama-manager.ts
@@ -1,10 +1,17 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { downloadFile, extractTarGz, fileExists, waitForHealthy, whichBinary } from "./download.js";
+import {
+  downloadFile,
+  extractTarGz,
+  extractZip,
+  fileExists,
+  waitForHealthy,
+  whichBinary,
+} from "./download.js";
 import { DEFAULT_MODELS, resolveOllamaBinaryUrl } from "./model-registry.js";
 import type { ProvisionProgress, RuntimeHandle, RuntimeManager } from "./types.js";
-import { resolveModelsDir, resolveRuntimeDir } from "./types.js";
+import { resolveRuntimeDir } from "./types.js";
 
 const BACKEND_ID = "ollama" as const;
 
@@ -47,50 +54,67 @@ export function createOllamaManager(): RuntimeManager {
         return;
       }
 
-      const url = resolveOllamaBinaryUrl();
+      const artifact = resolveOllamaBinaryUrl();
       const runtimeDir = resolveRuntimeDir(BACKEND_ID);
-      const archiveDest = path.join(runtimeDir, "ollama.tgz");
-      progress?.(`Downloading Ollama from ${url}...`);
-
-      const result = await downloadFile(url, archiveDest, {
-        onProgress: (bytes, total) => {
-          if (total) {
-            const pct = Math.round((bytes / total) * 100);
-            progress?.(`Downloading Ollama... ${pct}%`);
-          }
-        },
-      });
-
-      progress?.("Extracting Ollama...");
-      await extractTarGz(archiveDest, runtimeDir);
-      await fs.unlink(archiveDest).catch(() => {});
-
-      // The archive extracts to bin/ollama. Move it to the expected location.
-      const extractedBin = path.join(runtimeDir, "bin", "ollama");
       const dest = binaryPath();
-      try {
+      await fs.mkdir(runtimeDir, { recursive: true });
+      progress?.(`Downloading Ollama from ${artifact.url}...`);
+
+      const onProgress = (bytes: number, total: number | null) => {
+        if (total) {
+          const pct = Math.round((bytes / total) * 100);
+          progress?.(`Downloading Ollama... ${pct}%`);
+        }
+      };
+
+      if (artifact.format === "zip") {
+        // macOS: Ollama-darwin.zip contains an Electron app bundle.
+        // The CLI binary lives at Ollama.app/Contents/Resources/ollama.
+        const archiveDest = path.join(runtimeDir, "ollama.zip");
+        const result = await downloadFile(artifact.url, archiveDest, { onProgress });
+
+        progress?.("Extracting Ollama...");
+        await extractZip(archiveDest, runtimeDir);
+        await fs.unlink(archiveDest).catch(() => {});
+
+        const extractedBin = path.join(runtimeDir, "Ollama.app", "Contents", "Resources", "ollama");
         await fs.access(extractedBin);
         await fs.rename(extractedBin, dest);
-        await fs.rm(path.join(runtimeDir, "bin"), { recursive: true, force: true });
-      } catch {
-        // Some versions extract directly as "ollama" in the root.
-      }
+        await fs.rm(path.join(runtimeDir, "Ollama.app"), { recursive: true, force: true });
 
-      await fs.chmod(dest, "755");
-      progress?.(`Ollama installed (sha256: ${result.sha256.slice(0, 12)}...).`);
+        await fs.chmod(dest, "755");
+        progress?.(`Ollama installed (sha256: ${result.sha256.slice(0, 12)}...).`);
+      } else {
+        // Linux: .tgz archive that extracts to bin/ollama.
+        const archiveDest = path.join(runtimeDir, "ollama.tgz");
+        const result = await downloadFile(artifact.url, archiveDest, { onProgress });
+
+        progress?.("Extracting Ollama...");
+        await extractTarGz(archiveDest, runtimeDir);
+        await fs.unlink(archiveDest).catch(() => {});
+
+        const extractedBin = path.join(runtimeDir, "bin", "ollama");
+        try {
+          await fs.access(extractedBin);
+          await fs.rename(extractedBin, dest);
+          await fs.rm(path.join(runtimeDir, "bin"), { recursive: true, force: true });
+        } catch {
+          // Some versions extract directly as "ollama" in the root.
+        }
+
+        await fs.chmod(dest, "755");
+        progress?.(`Ollama installed (sha256: ${result.sha256.slice(0, 12)}...).`);
+      }
     },
 
     async start(port?: number): Promise<RuntimeHandle> {
       const actualPort = port ?? this.defaultPort;
       const bin = await resolveBinary();
-      const modelsDir = resolveModelsDir(BACKEND_ID);
-      await fs.mkdir(modelsDir, { recursive: true });
 
       const child: ChildProcess = spawn(bin, ["serve"], {
         env: {
           ...process.env,
           OLLAMA_HOST: `127.0.0.1:${actualPort}`,
-          OLLAMA_MODELS: modelsDir,
         },
         stdio: "ignore",
         detached: true,

--- a/src/gemmaclaw/provision/provision.ts
+++ b/src/gemmaclaw/provision/provision.ts
@@ -102,7 +102,7 @@ export async function verifyCompletion(
       body: JSON.stringify({
         model: modelId,
         messages: [{ role: "user", content: "Say hello in exactly one word." }],
-        max_tokens: 32,
+        max_tokens: 256,
         temperature: 0,
       }),
       signal: AbortSignal.timeout(120_000),
@@ -114,14 +114,20 @@ export async function verifyCompletion(
     }
 
     const data = (await response.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
+      choices?: Array<{ message?: { content?: string; reasoning?: string } }>;
     };
 
-    const content = data.choices?.[0]?.message?.content ?? "";
+    // Gemma 4 models use a reasoning/thinking phase. The actual reply may be
+    // in `content` or the model may have only produced reasoning tokens within
+    // the token budget. Accept either field as proof the model is working.
+    const msg = data.choices?.[0]?.message;
+    const content = (msg?.content ?? "").trim();
+    const reasoning = (msg?.reasoning ?? "").trim();
+    const hasOutput = content.length > 0 || reasoning.length > 0;
     return {
-      ok: content.trim().length > 0,
-      content: content.trim(),
-      error: content.trim().length === 0 ? "Empty response" : undefined,
+      ok: hasOutput,
+      content: content || reasoning.slice(0, 80),
+      error: hasOutput ? undefined : "Empty response",
     };
   } catch (err) {
     return {

--- a/src/gemmaclaw/provision/setup-wizard.test.ts
+++ b/src/gemmaclaw/provision/setup-wizard.test.ts
@@ -6,7 +6,7 @@ function makeHw(overrides?: Partial<HardwareInfo>): HardwareInfo {
   return {
     cpu: { arch: "x64", cores: 8, model: "Intel Core i7" },
     ram: { totalBytes: 16 * 1024 ** 3, availableBytes: 10 * 1024 ** 3 },
-    gpu: { detected: false, nvidia: false },
+    gpu: { detected: false, nvidia: false, apple: false },
     ...overrides,
   };
 }
@@ -24,7 +24,16 @@ function makeTools(overrides?: Partial<SystemTools>): SystemTools {
 
 describe("selectQuickProfile", () => {
   it("selects ollama when nvidia GPU detected", () => {
-    const hw = makeHw({ gpu: { detected: true, nvidia: true, name: "RTX 3090" } });
+    const hw = makeHw({
+      gpu: {
+        detected: true,
+        nvidia: true,
+        apple: false,
+        name: "RTX 3090",
+        vramBytes: 24 * 1024 ** 3,
+      },
+      ram: { totalBytes: 24 * 1024 ** 3, availableBytes: 16 * 1024 ** 3 },
+    });
     const profile = selectQuickProfile(hw, makeTools());
     expect(profile.backend).toBe("ollama");
     expect(profile.port).toBe(11434);
@@ -62,7 +71,6 @@ describe("selectQuickProfile", () => {
     const tools = makeTools({ ollamaInstalled: true });
     const profile = selectQuickProfile(hw, tools);
     expect(profile.backend).toBe("ollama");
-    expect(profile.reason).toContain("already installed");
   });
 
   it("prefers system-installed llama-server on x64 when ollama absent", () => {
@@ -70,7 +78,6 @@ describe("selectQuickProfile", () => {
     const tools = makeTools({ llamacppInstalled: true });
     const profile = selectQuickProfile(hw, tools);
     expect(profile.backend).toBe("llama-cpp");
-    expect(profile.reason).toContain("already installed");
   });
 
   it("prefers ollama when both are installed", () => {

--- a/src/gemmaclaw/provision/setup-wizard.ts
+++ b/src/gemmaclaw/provision/setup-wizard.ts
@@ -1,6 +1,7 @@
 import readline from "node:readline/promises";
 import type { HardwareInfo, SystemTools } from "./hardware.js";
 import { DEFAULT_MODELS } from "./model-registry.js";
+import { selectBestModel } from "./model-selector.js";
 import type { BackendId } from "./types.js";
 
 export type SetupProfile = {
@@ -8,6 +9,10 @@ export type SetupProfile = {
   model?: string;
   port: number;
   reason: string;
+  /** Display name for the recommended model (from catalog). */
+  modelDisplayName?: string;
+  /** Download size in bytes (from catalog). */
+  modelDownloadBytes?: number;
 };
 
 // -----------------------------------------------------------------------
@@ -15,55 +20,43 @@ export type SetupProfile = {
 // -----------------------------------------------------------------------
 
 /**
- * Select the safest backend for quick setup.
+ * Select backend and model for quick setup using the hardware-aware model catalog.
  *
- * Rules:
+ * Backend rules:
  *   1. Never default to gemma-cpp (requires HF_TOKEN + build tools).
- *   2. NVIDIA GPU detected -> Ollama (best GPU acceleration).
- *   3. x86_64 CPU, no GPU -> llama-cpp (efficient CPU inference, pre-built binary).
- *   4. arm64 or other arch -> Ollama (arm64 binary available, llama-cpp only ships x64).
+ *   2. GPU detected (Apple Silicon or NVIDIA) -> Ollama.
+ *   3. x86_64 CPU, no GPU -> llama-cpp.
+ *   4. arm64 or other -> Ollama.
  *   5. If a system binary is already installed, prefer that backend.
+ *
+ * Model selection is driven by model-catalog.json, matching available RAM to
+ * the best Gemma 4 model the hardware can run comfortably.
  */
 export function selectQuickProfile(hw: HardwareInfo, tools: SystemTools): SetupProfile {
-  // If the user already has a backend installed, prefer it (system-first).
+  const recommendation = selectBestModel(hw);
+
+  // Determine backend. Prefer system-installed runtime when only one is present.
+  let backend: BackendId = "ollama";
+  let port = 11434;
+
   if (tools.ollamaInstalled && !tools.llamacppInstalled) {
-    return {
-      backend: "ollama",
-      port: 11434,
-      reason: "Ollama is already installed on this system.",
-    };
-  }
-  if (tools.llamacppInstalled && !tools.ollamaInstalled && hw.cpu.arch === "x64") {
-    return {
-      backend: "llama-cpp",
-      port: 8080,
-      reason: "llama-server is already installed on this system.",
-    };
+    backend = "ollama";
+    port = 11434;
+  } else if (tools.llamacppInstalled && !tools.ollamaInstalled && hw.cpu.arch === "x64") {
+    backend = "llama-cpp";
+    port = 8080;
+  } else if (hw.cpu.arch === "x64" && !hw.gpu.detected) {
+    backend = "llama-cpp";
+    port = 8080;
   }
 
-  // GPU detected -> Ollama.
-  if (hw.gpu.detected && hw.gpu.nvidia) {
-    return {
-      backend: "ollama",
-      port: 11434,
-      reason: "NVIDIA GPU detected. Ollama provides the best GPU acceleration.",
-    };
-  }
-
-  // x86_64 without GPU -> llama-cpp (pre-built binary, efficient CPU inference).
-  if (hw.cpu.arch === "x64") {
-    return {
-      backend: "llama-cpp",
-      port: 8080,
-      reason: "CPU-only x86_64 system. llama.cpp offers efficient CPU inference.",
-    };
-  }
-
-  // arm64 or other -> Ollama (has arm64 binaries; llama-cpp only ships x64).
   return {
-    backend: "ollama",
-    port: 11434,
-    reason: `${hw.cpu.arch} system. Ollama provides the broadest hardware support.`,
+    backend,
+    model: recommendation.model.ollamaTag,
+    port,
+    reason: recommendation.reason,
+    modelDisplayName: recommendation.model.displayName,
+    modelDownloadBytes: recommendation.model.downloadSizeBytes,
   };
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenClaw Control</title>
+    <title>Gemmaclaw</title>
     <meta name="color-scheme" content="dark light" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />

--- a/ui/public/favicon.svg
+++ b/ui/public/favicon.svg
@@ -1,22 +1,32 @@
 <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ff4d4d"/>
-      <stop offset="100%" stop-color="#991b1b"/>
+    <linearGradient id="gem-top" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#818cf8"/>
+    </linearGradient>
+    <linearGradient id="gem-left" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#4338ca"/>
+    </linearGradient>
+    <linearGradient id="gem-right" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#4f46e5"/>
+    </linearGradient>
+    <linearGradient id="gem-bottom" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#4338ca"/>
+      <stop offset="100%" stop-color="#312e81"/>
     </linearGradient>
   </defs>
-  <!-- Body -->
-  <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster-gradient)"/>
-  <!-- Left Claw -->
-  <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster-gradient)"/>
-  <!-- Right Claw -->
-  <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster-gradient)"/>
-  <!-- Antenna -->
-  <path d="M45 15 Q35 5 30 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/>
-  <path d="M75 15 Q85 5 90 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round"/>
-  <!-- Eyes -->
-  <circle cx="45" cy="35" r="6" fill="#050810"/>
-  <circle cx="75" cy="35" r="6" fill="#050810"/>
-  <circle cx="46" cy="34" r="2.5" fill="#00e5cc"/>
-  <circle cx="76" cy="34" r="2.5" fill="#00e5cc"/>
+  <!-- Top facet -->
+  <polygon points="60,8 18,42 60,52 102,42" fill="url(#gem-top)"/>
+  <!-- Left facet -->
+  <polygon points="18,42 60,52 60,112 30,68" fill="url(#gem-left)"/>
+  <!-- Right facet -->
+  <polygon points="102,42 60,52 60,112 90,68" fill="url(#gem-right)"/>
+  <!-- Bottom-left facet -->
+  <polygon points="18,42 30,68 60,112" fill="url(#gem-bottom)" opacity="0.8"/>
+  <!-- Bottom-right facet -->
+  <polygon points="102,42 90,68 60,112" fill="url(#gem-bottom)" opacity="0.6"/>
+  <!-- Shine highlight -->
+  <polygon points="60,8 38,42 60,52" fill="white" opacity="0.18"/>
 </svg>

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:08.372Z",
+  "generatedAt": "2026-04-28T15:31:09.324Z",
   "locale": "de",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:10.776Z",
+  "generatedAt": "2026-04-28T15:31:09.590Z",
   "locale": "es",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:20.636Z",
+  "generatedAt": "2026-04-28T15:31:10.389Z",
   "locale": "fr",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:30.851Z",
+  "generatedAt": "2026-04-28T15:31:11.201Z",
   "locale": "id",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:13.037Z",
+  "generatedAt": "2026-04-28T15:31:09.854Z",
   "locale": "ja-JP",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:15.354Z",
+  "generatedAt": "2026-04-28T15:31:10.119Z",
   "locale": "ko",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:33.737Z",
+  "generatedAt": "2026-04-28T15:31:11.464Z",
   "locale": "pl",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:05.053Z",
+  "generatedAt": "2026-04-28T15:31:09.069Z",
   "locale": "pt-BR",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:28:58.729Z",
+  "generatedAt": "2026-04-28T15:31:11.721Z",
   "locale": "th",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:22.840Z",
+  "generatedAt": "2026-04-28T15:31:10.664Z",
   "locale": "tr",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:25.246Z",
+  "generatedAt": "2026-04-28T15:31:10.934Z",
   "locale": "uk",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:29:59.206Z",
+  "generatedAt": "2026-04-28T15:31:08.520Z",
   "locale": "zh-CN",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-23T06:30:02.802Z",
+  "generatedAt": "2026-04-28T15:31:08.797Z",
   "locale": "zh-TW",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "33cba33627744c6bb03182f53b02a9a2640272ef0fa3d039ce52723a96f5099e",
+  "sourceHash": "ce264a244a8899a73d652172b11b63fb3b0565a4a4091c44e373131778ea0c3e",
   "totalKeys": 734,
   "translatedKeys": 734,
   "workflow": 1

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -636,7 +636,7 @@ export const en: TranslationMap = {
     },
   },
   login: {
-    subtitle: "Gateway Dashboard",
+    subtitle: "Gemmaclaw Dashboard",
     passwordPlaceholder: "optional",
     showToken: "Show token",
     hideToken: "Hide token",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1278,11 +1278,11 @@ export function renderApp(state: AppViewState) {
                       <img
                         class="sidebar-brand__logo"
                         src="${agentLogoUrl(basePath)}"
-                        alt="OpenClaw"
+                        alt="Gemmaclaw"
                       />
                       <span class="sidebar-brand__copy">
                         <span class="sidebar-brand__eyebrow">${t("nav.control")}</span>
-                        <span class="sidebar-brand__title">OpenClaw</span>
+                        <span class="sidebar-brand__title">Gemmaclaw</span>
                       </span>
                     `}
               </div>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -486,7 +486,7 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
             style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
           />`
         : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
-            <img src=${logoUrl} alt="OpenClaw" />
+            <img src=${logoUrl} alt="Gemmaclaw" />
           </div>`}
       <h2>${name}</h2>
       <div class="agent-chat__badges">

--- a/ui/src/ui/views/login-gate.ts
+++ b/ui/src/ui/views/login-gate.ts
@@ -14,8 +14,8 @@ export function renderLoginGate(state: AppViewState) {
     <div class="login-gate">
       <div class="login-gate__card">
         <div class="login-gate__header">
-          <img class="login-gate__logo" src=${faviconSrc} alt="OpenClaw" />
-          <div class="login-gate__title">OpenClaw</div>
+          <img class="login-gate__logo" src=${faviconSrc} alt="Gemmaclaw" />
+          <div class="login-gate__title">Gemmaclaw</div>
           <div class="login-gate__sub">${t("login.subtitle")}</div>
         </div>
         <div class="login-gate__form">


### PR DESCRIPTION
## Summary

- Fixes macOS Ollama provisioning (was downloading Linux binary, causing `spawn ENOEXEC`)
- Upgrades Ollama from v0.6.2 to v0.21.2 for Gemma 4 support
- Adds a hardware-aware model catalog that auto-selects the best Gemma 4 model based on detected GPU, RAM, and platform
- Tracks known model issues (Flash Attention hangs, monitor reset, memory leaks on 31B Dense) with severity, citations, and dates. The selector auto-falls back when blockers are found for the current platform.
- Detects Apple Silicon Metal GPUs with unified memory
- Writes gateway config automatically after provisioning (Ollama provider, auth mode, exec policy, optional Docker sandbox)
- Interactive prompt during setup asks whether to use Docker sandbox or run tools directly, with clear explanation of risks and benefits
- Adds `--no-container` CLI flag to skip the prompt and disable Docker sandbox
- Prerequisite checks with platform-specific install instructions (Node 22+)
- Fixes Gemma 4 smoke test (reasoning tokens were consuming all `max_tokens`, leaving `content` empty)
- Auto-cleans stale gateway processes before restart
- Rebrands Control UI from OpenClaw to Gemmaclaw (favicon, page title, login gate, sidebar)
- Gateway spawns via `dist/entry.js` directly to avoid dev rebuild wiping UI assets
- Adds restart reminder note after gateway start for dev workflows
- Update README with new setup flow, commands, and architecture

## Test plan

- [x] `pnpm check:changed` passes (core typecheck, core test typecheck, lint). Extensions typecheck failure is pre-existing on main.
- [x] `pnpm test src/gemmaclaw/provision/` passes (67 tests, including new model-selector tests)
- [x] `pnpm gemmaclaw setup --no-container` end-to-end tested on M4 Max 48GB
- [x] `pnpm gemmaclaw chat --no-open` starts gateway, UI loads and connects via WebSocket
- [x] Ollama responds to chat completions with Gemma 4 26B MoE
- [x] Interactive sandbox prompt displays correctly, `--no-container` skips it
- [x] Stale gateway cleanup works across repeated `chat` invocations
- [ ] CI gate jobs


Made with [Cursor](https://cursor.com)