### PR TITLE
test: isolate OPENCLAW_GATEWAY_PORT in unit-fast lane

### DIFF
--- a/test/setup.unit-fast.ts
+++ b/test/setup.unit-fast.ts
@@ -1,0 +1,25 @@
+// Minimal env isolation for unit-fast tests.
+//
+// unit-fast intentionally skips installSharedTestSetup() (which calls
+// withIsolatedTestHome) to keep startup fast. But many pure-function unit
+// tests pass `cfg` objects without `gateway.port` and assert default
+// behavior (DEFAULT_GATEWAY_PORT = 18789). When the developer's shell has
+// `OPENCLAW_GATEWAY_PORT` set (e.g. for a locally running gateway on a
+// non-default port), `resolveGatewayPort(cfg)` reads that env var via its
+// default `process.env` argument and returns the leaked value, breaking
+// these unit tests.
+//
+// This file clears the small set of env vars that pure-function unit tests
+// assume are unset. Heavy isolation (temp HOME, profile env loading,
+// channel-specific env scrubbing) stays in installSharedTestSetup for the
+// unit/integration suites that need it.
+const ENV_VARS_TO_CLEAR = [
+  "OPENCLAW_GATEWAY_PORT",
+  "OPENCLAW_BRIDGE_ENABLED",
+  "OPENCLAW_BRIDGE_HOST",
+  "OPENCLAW_BRIDGE_PORT",
+  "OPENCLAW_CANVAS_HOST_PORT",
+];
+for (const key of ENV_VARS_TO_CLEAR) {
+  delete process.env[key];
+}

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -18,7 +18,11 @@ describe("unit-fast vitest lane", () => {
 
     expect(config.test?.isolate).toBe(false);
     expect(config.test?.runner).toBeUndefined();
-    expect(config.test?.setupFiles).toEqual([]);
+    // Only the minimal env-isolation shim should run; the heavy
+    // installSharedTestSetup() must stay out of unit-fast.
+    expect(config.test?.setupFiles).toEqual([
+      expect.stringMatching(/[\\/]test[\\/]setup\.unit-fast\.ts$/),
+    ]);
     expect(config.test?.include).toContain(
       "src/agents/pi-tools.deferred-followup-guidance.test.ts",
     );

--- a/test/vitest/vitest.unit-fast.config.ts
+++ b/test/vitest/vitest.unit-fast.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vitest/config";
 import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
-import { sharedVitestConfig } from "./vitest.shared.config.ts";
+import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { getUnitFastTestFiles } from "./vitest.unit-fast-paths.mjs";
 
 export function createUnitFastVitestConfig(
@@ -19,7 +19,7 @@ export function createUnitFastVitestConfig(
       name: "unit-fast",
       isolate: false,
       runner: undefined,
-      setupFiles: [],
+      setupFiles: [resolveRepoRootPath("test/setup.unit-fast.ts")],
       include: includeFromEnv ?? cliInclude ?? unitFastTestFiles,
       exclude: sharedTest.exclude ?? [],
       passWithNoTests: true,


### PR DESCRIPTION
## Summary

The unit-fast vitest config explicitly skipped `installSharedTestSetup()` to keep startup fast, which left the lane vulnerable to env-var leakage from the developer's shell. Several pure-function unit tests assert default gateway behavior (`DEFAULT_GATEWAY_PORT=18789`) by passing a `cfg` without `gateway.port`, but `resolveGatewayPort()` reads `process.env.OPENCLAW_GATEWAY_PORT` via its default env arg. When a local gateway runs on a non-default port (e.g. `OPENCLAW_GATEWAY_PORT=3001`), the leaked value is returned and these unit-fast tests fail locally even though they pass in CI.

This adds a minimal `test/setup.unit-fast.ts` that clears the small set of port env vars pure-function unit tests assume are unset. Heavy isolation (temp HOME, profile env loading, channel scrubbing) stays in the unit / integration lanes that need it. Setup overhead per worker is in the millisecond range.

## Tests fixed

- `src/commands/status-all/format.test.ts` — 3 cases (dashboard URL, gateway surface values, overview rows)
- `src/commands/gateway-status/helpers.test.ts` — 1 case (wss for local loopback)
- `src/commands/status-overview-surface.test.ts` — 1 case (overview surface bundle)
- `src/hooks/gmail.test.ts` — 1 case (default gmail hook url)

## Test plan
- [x] `OPENCLAW_GATEWAY_PORT=3001 node scripts/test-projects.mjs <failing files>` — all 6 fail before
- [x] After fix, same command — 40 passed
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts` — 6221/6221 passed
- [x] `pnpm check:changed --staged` — green (unit-fast + tooling lanes)
- [x] Updated `test/vitest-unit-fast-config.test.ts` meta-test to assert the new setup file