### PR TITLE
feat: add Gemini backend for benchmark runner

### DIFF
--- a/src/cli/program/register.benchmark.ts
+++ b/src/cli/program/register.benchmark.ts
@@ -18,6 +18,8 @@ export function registerBenchmarkCommand(program: Command) {
     .option("--context-length <n>", "Context window size (num_ctx)", parseInt)
     .option("--gpu-layers <n>", "Number of GPU layers (num_gpu)", parseInt)
     .option("--batch-size <n>", "Batch size (num_batch)", parseInt)
+    .option("--gemini-api-key <key>", "Gemini API key for cloud-based evaluation")
+    .option("--gemini-model <model>", "Gemini model name (default: gemini-2.5-pro)")
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { benchmarkGemmaCommand } = await import("../../commands/benchmark-gemma.js");
@@ -31,6 +33,8 @@ export function registerBenchmarkCommand(program: Command) {
           contextLength: opts.contextLength as number | undefined,
           gpuLayers: opts.gpuLayers as number | undefined,
           batchSize: opts.batchSize as number | undefined,
+          geminiApiKey: opts.geminiApiKey as string | undefined,
+          geminiModel: opts.geminiModel as string | undefined,
         });
       });
     });

--- a/src/commands/benchmark-gemma.ts
+++ b/src/commands/benchmark-gemma.ts
@@ -23,6 +23,10 @@ export type BenchmarkGemmaCommandOpts = {
   validatePack?: boolean;
   /** Skip Docker and run the benchmark directly on the host. */
   local?: boolean;
+  /** Gemini API key for cloud-based evaluation (uses Gemini instead of local Ollama). */
+  geminiApiKey?: string;
+  /** Gemini model to use (e.g. gemini-2.5-flash). Only applies when geminiApiKey is set. */
+  geminiModel?: string;
 };
 
 export type BenchmarkSandboxOpts = {
@@ -154,9 +158,12 @@ async function runLocally(opts: BenchmarkGemmaCommandOpts, runtime: RuntimeEnv):
     await import("../gemmaclaw/benchmark/index.js");
   const { findPreset } = await import("../gemmaclaw/provision/model-registry.js");
 
-  const backend: BackendType = (
-    opts.backend === "llama-cpp" ? "llama-cpp" : "ollama"
-  ) as BackendType;
+  const geminiApiKey = opts.geminiApiKey ?? process.env.GEMINI_API_KEY;
+  const geminiModel = opts.geminiModel ?? process.env.GEMINI_MODEL;
+
+  const backend: BackendType = geminiApiKey
+    ? "gemini"
+    : ((opts.backend === "llama-cpp" ? "llama-cpp" : "ollama") as BackendType);
 
   const model = opts.model ?? resolveConfiguredModel() ?? "gemma3:4b";
   const ollamaUrl = opts.ollamaUrl ?? "http://127.0.0.1:11434";
@@ -198,6 +205,9 @@ async function runLocally(opts: BenchmarkGemmaCommandOpts, runtime: RuntimeEnv):
   }
 
   runtime.log(`Backend: ${backend}`);
+  if (backend === "gemini") {
+    runtime.log(`Gemini model: ${geminiModel ?? "gemini-2.5-pro"}`);
+  }
   runtime.log(`Model: ${model}`);
   if (preset) {
     runtime.log(`Preset: ${preset.displayName} (${preset.architecture}, ${preset.parameterCount})`);
@@ -223,7 +233,7 @@ async function runLocally(opts: BenchmarkGemmaCommandOpts, runtime: RuntimeEnv):
   }
   runtime.log("");
 
-  if (!isMock) {
+  if (!isMock && backend !== "gemini") {
     if (backend === "ollama") {
       try {
         await ollamaPing(ollamaUrl, model);
@@ -265,6 +275,8 @@ async function runLocally(opts: BenchmarkGemmaCommandOpts, runtime: RuntimeEnv):
       contextLength,
       gpuLayers: opts.gpuLayers,
       batchSize: opts.batchSize,
+      geminiApiKey,
+      geminiModel,
     },
     hw,
     (msg) => runtime.log(msg),

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -120,6 +120,8 @@ if (opts.sandbox) {
         : undefined,
       gpuLayers: opts.gpuLayers ? Number.parseInt(String(opts.gpuLayers), 10) : undefined,
       batchSize: opts.batchSize ? Number.parseInt(String(opts.batchSize), 10) : undefined,
+      geminiApiKey: opts.geminiApiKey as string | undefined,
+      geminiModel: opts.geminiModel as string | undefined,
     },
     defaultRuntime,
   ).catch((err) => {

--- a/src/gemmaclaw/benchmark/runner.ts
+++ b/src/gemmaclaw/benchmark/runner.ts
@@ -20,7 +20,7 @@ import {
 } from "./scorer.js";
 import type { BenchmarkTask } from "./tasks.js";
 
-export type BackendType = "ollama" | "llama-cpp";
+export type BackendType = "ollama" | "llama-cpp" | "gemini";
 
 export type BenchmarkConfig = {
   backend: BackendType;
@@ -33,6 +33,8 @@ export type BenchmarkConfig = {
   contextLength?: number;
   gpuLayers?: number;
   batchSize?: number;
+  geminiApiKey?: string;
+  geminiModel?: string;
 };
 
 export type FailureMode =
@@ -196,6 +198,74 @@ function llamaCppChat(
   });
 }
 
+async function geminiChat(
+  apiKey: string,
+  model: string,
+  prompt: string,
+  system?: string,
+): Promise<ChatResponse> {
+  const contents: Array<{ role: string; parts: Array<{ text: string }> }> = [];
+  if (system) {
+    contents.push({ role: "user", parts: [{ text: system }] });
+    contents.push({ role: "model", parts: [{ text: "Understood." }] });
+  }
+  contents.push({ role: "user", parts: [{ text: prompt }] });
+
+  const body = JSON.stringify({ contents });
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+  const https = await import("node:https");
+  const parsed = new URL(url);
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        hostname: parsed.hostname,
+        path: `${parsed.pathname}${parsed.search}`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+        timeout: 300_000,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const status = res.statusCode ?? 0;
+          const text = Buffer.concat(chunks).toString();
+          if (status >= 400) {
+            reject(new Error(`Gemini HTTP ${status}: ${text.slice(0, 300)}`));
+            return;
+          }
+          try {
+            const data = JSON.parse(text);
+            const candidate = data.candidates?.[0];
+            const content =
+              candidate?.content?.parts?.map((p: { text?: string }) => p.text ?? "").join("") ?? "";
+            const usage = data.usageMetadata;
+            resolve({
+              content,
+              promptTokens: usage?.promptTokenCount,
+              completionTokens: usage?.candidatesTokenCount,
+            });
+          } catch (e) {
+            reject(new Error(`Invalid Gemini response: ${String(e)}`));
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Gemini request timed out"));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
 function classifyFailure(error: string): FailureMode {
   const lower = error.toLowerCase();
   if (lower.includes("timed out") || lower.includes("timeout")) {
@@ -242,6 +312,7 @@ export async function runBenchmark(
     num_ctx: config.contextLength,
   };
 
+  const isGemini = config.backend === "gemini";
   const isLlamaCpp = config.backend === "llama-cpp";
   const chatUrl = isLlamaCpp ? config.llamaCppUrl : config.ollamaUrl;
 
@@ -262,7 +333,14 @@ export async function runBenchmark(
 
     try {
       let response: ChatResponse;
-      if (isLlamaCpp) {
+      if (isGemini) {
+        response = await geminiChat(
+          config.geminiApiKey!,
+          config.geminiModel ?? config.model,
+          prompt,
+          task.system,
+        );
+      } else if (isLlamaCpp) {
         response = await llamaCppChat(chatUrl, prompt, task.system, llamaCppOptions);
       } else {
         response = await ollamaChat(chatUrl, config.model, prompt, task.system, ollamaOptions);
@@ -310,12 +388,21 @@ export async function runBenchmark(
       // LLM judge mode: ask the same model to grade the output.
       try {
         const judgePrompt = buildJudgePrompt(task, output);
+        const judgeSystem = "You are a strict but fair evaluator. Score the response accurately.";
         let judgeContent: string;
-        if (isLlamaCpp) {
+        if (isGemini) {
+          const judgeResponse = await geminiChat(
+            config.geminiApiKey!,
+            config.geminiModel ?? config.model,
+            judgePrompt,
+            judgeSystem,
+          );
+          judgeContent = judgeResponse.content;
+        } else if (isLlamaCpp) {
           const judgeResponse = await llamaCppChat(
             chatUrl,
             judgePrompt,
-            "You are a strict but fair evaluator. Score the response accurately.",
+            judgeSystem,
             llamaCppOptions,
           );
           judgeContent = judgeResponse.content;
@@ -324,7 +411,7 @@ export async function runBenchmark(
             config.ollamaUrl,
             config.model,
             judgePrompt,
-            "You are a strict but fair evaluator. Score the response accurately.",
+            judgeSystem,
             ollamaOptions,
           );
           judgeContent = judgeResponse.content;


### PR DESCRIPTION
## Summary
- Add Gemini as a third backend for the benchmark runner alongside Ollama and llama-cpp
- Fix the `--gemini-api-key` / `--gemini-model` flags that were only defined on the `benchmark sandbox` subcommand but forwarded as CLI args to the main `benchmark` command inside Docker (causing "unknown option" errors)
- Auto-select the `gemini` backend when a Gemini API key is provided via CLI flag or `GEMINI_API_KEY` env var

## Test plan
- [x] Verified `pnpm tsgo` typecheck passes with no errors
- [x] Verified `pnpm lint:core` passes with no errors
- [x] End-to-end tested: `pnpm gemmaclaw benchmark sandbox --file /tmp/benchmark-test-input.json --gemini-api-key $KEY --gemini-model gemini-2.5-flash` — container ran with `Backend: gemini`, received Gemini API responses, no "unknown option" error
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)