### PR TITLE
fix: deploy workflow uses committed site instead of regenerating

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate site
-        run: python3 scripts/site/generate-site.py
+      - name: Run site quality checks
+        run: bash scripts/site/check-site-quality.sh
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- The deploy workflow was regenerating `site/index.html` in CI, wiping community report cards because CI lacks the Reddit post `.md` files
- Replace the `generate site` step with `check-site-quality.sh` (quality validation only)
- The committed `site/index.html` is the source of truth, pre-generated locally by `deploy-site-update.sh`

## Test plan
- [x] Verify `check-site-quality.sh` passes on committed `site/index.html`
- [ ] After merge, verify community report cards appear on https://gemmaclaw.github.io/gemmaclaw/