### PR TITLE
fix: clean stray markdown brackets and empty summaries

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -203,7 +203,9 @@ def html_escape(text):
 
 def clean_markdown(text):
     """Strip markdown syntax to plain text for display in HTML cards."""
-    # Convert markdown links [text](url) to just text
+    # Remove markdown links where the text is itself a URL: [url](url) -> empty
+    text = re.sub(r'\[https?://[^\]]*\]\([^\)]+\)', '', text)
+    # Convert remaining markdown links [text](url) to just text
     text = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)
     # Remove bare URLs (http/https) that aren't useful as display text
     text = re.sub(r'https?://\S+', '', text)
@@ -218,6 +220,10 @@ def clean_markdown(text):
     text = re.sub(r'^#+\s+', '', text, flags=re.MULTILINE)
     # Remove markdown list markers
     text = re.sub(r'^\s*[-*+]\s+', '', text, flags=re.MULTILINE)
+    # Remove stray brackets from incomplete/truncated markdown links
+    text = re.sub(r'\[\s*\]', '', text)
+    text = re.sub(r'\[\s*$', '', text)  # trailing orphan open bracket
+    text = re.sub(r'^\s*\]', '', text)  # leading orphan close bracket
     # Collapse whitespace
     text = re.sub(r'\s+', ' ', text).strip()
     return text
@@ -469,6 +475,10 @@ def generate_community_cards(posts):
         title = html_escape(post["title"][:120])
         score = post["score"]
         clean_summary = clean_markdown(post["summary"])
+        if not clean_summary:
+            # Fall back to first comment text if summary is just URLs
+            first_text = next((c["text"] for c in post.get("comments", []) if c.get("text")), "")
+            clean_summary = clean_markdown(first_text) if first_text else ""
         summary = html_escape(clean_summary[:250])
         if len(clean_summary) > 250:
             summary += "..."

--- a/site/index.html
+++ b/site/index.html
@@ -559,7 +559,7 @@ gemmaclaw chat</code></pre>
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">[</p>
+  <p class="cr-summary">Google is going to show what open weights is about. Happy Easter everyone.</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Both_Opportunity5327 (+529)</span><span class="cr-comment-text">Google is going to show what open weights is about. Happy Easter everyone.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/danielhanchen (+519)</span><span class="cr-comment-text">Gemma-4 has native thinking, tool calling and is multimodal! Use temperature = 1.0, top\p = 0.95, top\k = 64 and the EOS is `&amp;lt;turn|&amp;gt;`. `&amp;lt;|channel&amp;gt;thought\n` is also used for the thinking t...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Altruistic_Heat_9531 (+416)</span><span class="cr-comment-text">And after a week maybe : &quot;Gemma 4 26B Heretic Uncensored Ablated Claude Opus 4.6 Reasoning Distlled Expanded fine tuned quantized&quot; Sorry to tempting lol</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1salgre" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -1103,7 +1103,7 @@ gemmaclaw chat</code></pre>
       <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Going to flag this up front - I know that there are some properly smart people on this sub, please can you correct my noob user errors or misunderstandings and educate my ass. Model: google/gemma-4-26b-a4b Versions: * MLX: [</p>
+  <p class="cr-summary">Going to flag this up front - I know that there are some properly smart people on this sub, please can you correct my noob user errors or misunderstandings and educate my ass. Model: google/gemma-4-26b-a4b Versions: * MLX:</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/EvolvingSoftware (+52)</span><span class="cr-comment-text">GGUF has come a long way recently.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cm8t (+50)</span><span class="cr-comment-text">GGUF/llama.cpp has really caught up to MLX over the past few months by leaning into Metal.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Temporary-Mix8022 (+41)</span><span class="cr-comment-text">That my friend, is the downside of writing my own posts.. yeah, user error over here. Edited it. I was running both on the same model. It was just when googling for those 4-ish bit quants to share the...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1spn7zh" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>


### PR DESCRIPTION
## Summary
- Handle edge case where post summary is entirely URL-text markdown links
- Remove URL-text markdown links `[url](url)` entirely before other cleanup
- Clean up orphaned brackets from truncated/incomplete markdown
- Fall back to first comment text when summary is empty after cleaning

Fixes stray `[` character visible on cards like "Gemma 4 has been released".

## Test plan
- [x] `check-site-quality.sh` passes
- [x] "Gemma 4 has been released" card now shows "Google is going to show what open weights is about" instead of `[`