### PR TITLE
site: refresh Gemma 4 community data and add curated Field Notes

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -203,7 +203,9 @@ def html_escape(text):
 
 def clean_markdown(text):
     """Strip markdown syntax to plain text for display in HTML cards."""
-    # Convert markdown links [text](url) to just text
+    # Remove markdown links where the text is itself a URL: [url](url) -> empty
+    text = re.sub(r'\[https?://[^\]]*\]\([^\)]+\)', '', text)
+    # Convert remaining markdown links [text](url) to just text
     text = re.sub(r'\[([^\]]+)\]\([^\)]+\)', r'\1', text)
     # Remove bare URLs (http/https) that aren't useful as display text
     text = re.sub(r'https?://\S+', '', text)
@@ -218,6 +220,10 @@ def clean_markdown(text):
     text = re.sub(r'^#+\s+', '', text, flags=re.MULTILINE)
     # Remove markdown list markers
     text = re.sub(r'^\s*[-*+]\s+', '', text, flags=re.MULTILINE)
+    # Remove stray brackets from incomplete/truncated markdown links
+    text = re.sub(r'\[\s*\]', '', text)
+    text = re.sub(r'\[\s*$', '', text)  # trailing orphan open bracket
+    text = re.sub(r'^\s*\]', '', text)  # leading orphan close bracket
     # Collapse whitespace
     text = re.sub(r'\s+', ' ', text).strip()
     return text
@@ -469,6 +475,10 @@ def generate_community_cards(posts):
         title = html_escape(post["title"][:120])
         score = post["score"]
         clean_summary = clean_markdown(post["summary"])
+        if not clean_summary:
+            # Fall back to first comment text if summary is just URLs
+            first_text = next((c["text"] for c in post.get("comments", []) if c.get("text")), "")
+            clean_summary = clean_markdown(first_text) if first_text else ""
         summary = html_escape(clean_summary[:250])
         if len(clean_summary) > 250:
             summary += "..."

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -16,6 +16,7 @@ REPO_DIR = Path(__file__).resolve().parent.parent.parent
 RESULTS_DIR = REPO_DIR / "benchmark-results"
 SITE_DIR = REPO_DIR / "site"
 COMMUNITY_CONFIGS_FILE = SITE_DIR / "data" / "gemma4-hardware-configs.json"
+FIELD_NOTES_FILE = SITE_DIR / "data" / "field-notes.md"
 # Workspace knowledge directory for Reddit post files (set via env or default)
 WORKSPACE_DIR = Path(os.environ.get("WORKSPACE", str(REPO_DIR.parent.parent)))
 POSTS_DIR = WORKSPACE_DIR / "knowledge" / "reddit" / "localllama" / "posts"
@@ -548,6 +549,92 @@ def generate_community_cards(posts):
     return filter_bar + '\n<div id="community-cards">' + "\n".join(cards) + '</div>'
 
 
+def render_field_notes_markdown(md_text):
+    """Render the curated field-notes Markdown into an HTML fragment.
+
+    Supports the small Markdown subset used in site/data/field-notes.md:
+    headings (## / ###), paragraphs, italics (*x*), bold (**x**),
+    inline links [text](url), bullet lists, and emphasized last-updated lines.
+    Output is plain HTML wrapped in a <div class="field-notes">.
+    """
+    lines = md_text.splitlines()
+    html_parts = []
+    in_list = False
+    para_buf = []
+
+    def flush_para():
+        if para_buf:
+            text = " ".join(para_buf).strip()
+            if text:
+                html_parts.append(f"<p>{render_inline(text)}</p>")
+            para_buf.clear()
+
+    def close_list():
+        nonlocal in_list
+        if in_list:
+            html_parts.append("</ul>")
+            in_list = False
+
+    def render_inline(text):
+        # Inline links [text](url)
+        def link_sub(m):
+            label, url = m.group(1), m.group(2)
+            return (f'<a href="{html_escape(url)}" target="_blank" '
+                    f'rel="noopener">{html_escape(label)}</a>')
+        # Escape first, then re-apply markdown so links/emphasis work safely.
+        escaped = html_escape(text)
+        # Convert escaped brackets back so the regex matches our markdown links.
+        escaped = escaped.replace("&lt;", "<").replace("&gt;", ">")
+        escaped = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link_sub, escaped)
+        # Bold then italic (order matters so ** wins over *).
+        escaped = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
+        escaped = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", escaped)
+        return escaped
+
+    for raw in lines:
+        line = raw.rstrip()
+        if not line.strip():
+            flush_para()
+            close_list()
+            continue
+        if line.startswith("### "):
+            flush_para()
+            close_list()
+            html_parts.append(f"<h3>{render_inline(line[4:].strip())}</h3>")
+            continue
+        if line.startswith("## "):
+            flush_para()
+            close_list()
+            html_parts.append(f"<h2>{render_inline(line[3:].strip())}</h2>")
+            continue
+        if line.lstrip().startswith("- "):
+            flush_para()
+            if not in_list:
+                html_parts.append('<ul class="setup-list">')
+                in_list = True
+            item = line.lstrip()[2:].strip()
+            html_parts.append(f"<li>{render_inline(item)}</li>")
+            continue
+        para_buf.append(line.strip())
+
+    flush_para()
+    close_list()
+    return '<div class="field-notes">' + "\n".join(html_parts) + "</div>"
+
+
+def load_field_notes():
+    """Return rendered HTML for the curated field-notes section, or empty string."""
+    if not FIELD_NOTES_FILE.exists():
+        return ""
+    try:
+        md_text = FIELD_NOTES_FILE.read_text()
+    except OSError:
+        return ""
+    if not md_text.strip():
+        return ""
+    return render_field_notes_markdown(md_text)
+
+
 def generate_site():
     results = load_benchmark_results()
     best = best_results(results)
@@ -567,6 +654,8 @@ def generate_site():
     community_configs = load_community_configs()
     community_cards = generate_community_cards(community_configs)
     community_count = len(community_configs)
+    field_notes_html = load_field_notes()
+    field_notes_nav = '<a href="#field-notes">Field Notes</a>' if field_notes_html else ""
 
     html = f"""<!DOCTYPE html>
 <html lang="en">
@@ -586,6 +675,7 @@ def generate_site():
       <div class="nav-links">
         <a href="#setup">Setup</a>
         <a href="#hosting">Self-Hosting</a>
+        {field_notes_nav}
         <a href="#benchmarks">Benchmarks</a>
         <a href="#goals">Goals</a>
         <a href="https://github.com/gemmaclaw/gemmaclaw">GitHub</a>
@@ -714,6 +804,11 @@ gemmaclaw chat</code></pre>
         {community_cards}
       </div>'''}
     </section>
+
+    {"" if not field_notes_html else f'''<!-- Section 2b: Curated Field Notes -->
+    <section id="field-notes">
+      {field_notes_html}
+    </section>'''}
 
     <!-- Section 3: Benchmark Results -->
     <section id="benchmarks">
@@ -956,6 +1051,50 @@ CSS = """
     p { color: var(--fg-soft); margin-bottom: 1rem; }
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
+
+    /* Field Notes (curated weekly synthesis) */
+    .field-notes {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem 1.75rem;
+      margin: 0;
+    }
+    .field-notes h2 {
+      font-size: 1.5rem; font-weight: 600;
+      margin: 0 0 0.5rem;
+      letter-spacing: -0.01em;
+    }
+    .field-notes h3 {
+      font-size: 1.05rem; font-weight: 600;
+      margin: 1.5rem 0 0.5rem;
+      color: var(--fg);
+    }
+    .field-notes p { color: var(--fg-soft); margin: 0 0 0.75rem; }
+    .field-notes p em { color: var(--muted); }
+    .field-notes ul {
+      list-style: none; margin: 0 0 1rem; padding: 0;
+    }
+    .field-notes li {
+      padding: 0.4rem 0 0.4rem 1.25rem;
+      position: relative;
+      color: var(--fg-soft);
+    }
+    .field-notes li::before {
+      content: '';
+      position: absolute; left: 0; top: 0.75rem;
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--accent);
+    }
+    .field-notes li strong { color: var(--fg); }
+    .field-notes a {
+      color: var(--accent); text-decoration: none;
+    }
+    .field-notes a:hover { text-decoration: underline; }
+    @media (max-width: 640px) {
+      .field-notes { padding: 1rem 1.1rem; }
+      .field-notes h2 { font-size: 1.3rem; }
+    }
 
     /* Lists */
     .setup-list { list-style: none; margin: 0 0 1rem; }

--- a/site/data/field-notes.md
+++ b/site/data/field-notes.md
@@ -1,0 +1,55 @@
+## Field Notes — 2026-04-29
+
+A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.
+Curated from the latest 14 Gemma-mentioning posts and their top comment threads.
+This is community signal, not a benchmark, and confidence is **medium** unless noted.
+
+### Best current setup (today)
+
+- **Mid-to-high GPU (24+ GB VRAM):** Gemma 4 31B Dense at Q6_K or higher remains the strongest single-GPU pick for general tasks and visual understanding. Drop to Q4 only if you must, and expect noticeably more glitches in agentic workflows.
+- **Constrained GPU (8-16 GB VRAM):** Gemma 4 26B MoE at a good quant (Q5/Q6) holds up for local coding and chat. Q3 should be treated as gambling, not a working setup, when precision matters.
+- **CPU-only / Pi / Apple Silicon at the low end:** Gemma 4 E4B (9.6 GB on disk, effectively 9B-A4B) is the practical workhorse. It runs at 140+ tok/s on a Ryzen 9 5900X and is the default we recommend for non-GPU rigs.
+- **Apple Silicon (32-64 GB unified):** Gemma 4 26B MoE via Ollama Metal continues to perform; 48+ GB can move up to 31B Dense.
+
+### What works
+
+- **Visual understanding:** Gemma 4 is consistently called out as still the strongest open model for image+text, even by users who otherwise prefer Qwen 3.6 for coding. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
+- **Quality on real coding tasks:** Gemma 4 31B is reported to still match or beat Qwen 3.6 on some applications when the harness, quant, and context are tuned. The headline story is Qwen 3.6 27B catching up, not Gemma 4 falling off. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
+- **Speculative decoding pairing:** Gemma 4 31B paired with Gemma 4 E2B as a draft model continues to deliver 120-200 tok/s on specific tasks for users with the headroom. ([source](https://reddit.com/r/LocalLLaMA/comments/1sw782p))
+- **Pi / coding agent walkthrough:** Patrick Loeber's tutorial on running a Gemma 4 coding agent on a Pi is now circulating; commenters note the same workflow generalizes to llama.cpp, not just LM Studio. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
+
+### Known limits
+
+- **Local coding is not yet a Claude Code substitute.** A widely-upvoted writeup (806+ score) argues that even Gemma 4 31B and Qwen 3.6 27B lose enough productivity vs Claude Code that the trade-off is hard to justify for serious work. Calibrate expectations accordingly. ([source](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c))
+- **Quant floor matters for agents.** With agentic workflows that issue hundreds of tool calls, low quants (Q3, sometimes Q4) introduce small structural glitches (stray characters, malformed JSON) that break the run. Default to Q5_K_M or higher when you can. ([source](https://reddit.com/r/LocalLLaMA/comments/1ssdim1))
+- **Safety filters on E2B.** Gemma-4-E2B's safety filters have been flagged as overly aggressive for emergency/medical-style prompts. Plan for an unfiltered or alternate model if that is your use case. ([source](https://reddit.com/r/LocalLLaMA/comments/1sr35pk))
+- **E4B size confusion.** Gemma 4 E4B is a 9B-A4B MoE on disk, not a 4B dense model. Comparisons against true 4B competitors are not apples to apples. ([source](https://reddit.com/r/LocalLLaMA/comments/1sxch39))
+
+### Open questions
+
+- **Qwen 3.6 27B vs Gemma 4 31B for coding:** The community is mid-split on which is better, but tooling, quant, and context length keep changing the answer. We will keep an eye on harness-controlled comparisons.
+- **Gemma 4 26B MoE quant sweet spot:** GGUF benchmarks are still landing. Q4_K_M vs Q5_K_M vs Q6_K trade-offs on consumer GPUs deserve their own controlled run on our benchmark harness.
+- **Strix Halo and other unified-memory APUs:** Early reports on AMD Strix Halo 128GB suggest viable 27-31B dense inference, but day-2 numbers are sparse. Worth tracking for the late-2026 hardware cycle.
+
+### Sources
+
+The 14 newly updated Gemma-mentioning posts driving this update:
+
+- [How to run a local coding agent with Gemma 4 and Pi (Patrick Loeber)](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t)
+- [The 4B class of 2026 (benchmark)](https://reddit.com/r/LocalLLaMA/comments/1sxch39)
+- [Tested how OpenCode works with self-hosted LLMs (Qwen 3.5/3.6, Gemma 4, Nemotron 3, GLM-4.7)](https://reddit.com/r/LocalLLaMA/comments/1ssdim1)
+- [Youtuber tries Qwen 3.5 35B, Qwen 3.6 35B, and Gemma 4 27B on large JS reverse engineering](https://reddit.com/r/LocalLLaMA/comments/1ssadey)
+- [I'm done with using local LLMs for coding](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c)
+- [Qwen 3.6 27B BF16 vs Q4_K_M vs Q8_0 GGUF evaluation](https://reddit.com/r/LocalLLaMA/comments/1sxzqry)
+- [Local model on coding has reached a certain threshold to be feasible for real work](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2)
+- [Built myself a bit of a local LLM workhorse (56 GB VRAM)](https://reddit.com/r/LocalLLaMA/comments/1sxd2sc)
+- [Qwen 3.6 27B on Strix Halo 128GB: any experiences?](https://reddit.com/r/LocalLLaMA/comments/1sxbvux)
+- [Qwen 3.6 is actually useful for vibe-coding, and way cheaper than Claude](https://reddit.com/r/LocalLLaMA/comments/1st3m8y)
+- [Switched from Qwen 3.6 35B-A3B to Qwen 3.6 27B mid-coding](https://reddit.com/r/LocalLLaMA/comments/1swifke)
+- [Is a high-end private local LLM setup worth it?](https://reddit.com/r/LocalLLaMA/comments/1ss7bcs)
+- [Guys this is so fun!](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4)
+- [Something from Mistral (Vibe) tomorrow](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo)
+
+The full set of 61 community reports lives in the Community Reports section above, filterable by hardware category.
+
+_Last updated: 2026-04-29. Confidence: medium. Next update fires when the daily Gemma4 research cron flags notable new findings._

--- a/site/index.html
+++ b/site/index.html
@@ -80,6 +80,50 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Field Notes (curated weekly synthesis) */
+    .field-notes {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.5rem 1.75rem;
+      margin: 0;
+    }
+    .field-notes h2 {
+      font-size: 1.5rem; font-weight: 600;
+      margin: 0 0 0.5rem;
+      letter-spacing: -0.01em;
+    }
+    .field-notes h3 {
+      font-size: 1.05rem; font-weight: 600;
+      margin: 1.5rem 0 0.5rem;
+      color: var(--fg);
+    }
+    .field-notes p { color: var(--fg-soft); margin: 0 0 0.75rem; }
+    .field-notes p em { color: var(--muted); }
+    .field-notes ul {
+      list-style: none; margin: 0 0 1rem; padding: 0;
+    }
+    .field-notes li {
+      padding: 0.4rem 0 0.4rem 1.25rem;
+      position: relative;
+      color: var(--fg-soft);
+    }
+    .field-notes li::before {
+      content: '';
+      position: absolute; left: 0; top: 0.75rem;
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--accent);
+    }
+    .field-notes li strong { color: var(--fg); }
+    .field-notes a {
+      color: var(--accent); text-decoration: none;
+    }
+    .field-notes a:hover { text-decoration: underline; }
+    @media (max-width: 640px) {
+      .field-notes { padding: 1rem 1.1rem; }
+      .field-notes h2 { font-size: 1.3rem; }
+    }
+
     /* Lists */
     .setup-list { list-style: none; margin: 0 0 1rem; }
     .setup-list li {
@@ -351,6 +395,7 @@
       <div class="nav-links">
         <a href="#setup">Setup</a>
         <a href="#hosting">Self-Hosting</a>
+        <a href="#field-notes">Field Notes</a>
         <a href="#benchmarks">Benchmarks</a>
         <a href="#goals">Goals</a>
         <a href="https://github.com/gemmaclaw/gemmaclaw">GitHub</a>
@@ -1584,6 +1629,59 @@ gemmaclaw chat</code></pre>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1staxnq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div></div>
       </div>
+    </section>
+
+    <!-- Section 2b: Curated Field Notes -->
+    <section id="field-notes">
+      <div class="field-notes"><h2>Field Notes — 2026-04-29</h2>
+<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest 14 Gemma-mentioning posts and their top comment threads. This is community signal, not a benchmark, and confidence is <strong>medium</strong> unless noted.</p>
+<h3>Best current setup (today)</h3>
+<ul class="setup-list">
+<li><strong>Mid-to-high GPU (24+ GB VRAM):</strong> Gemma 4 31B Dense at Q6_K or higher remains the strongest single-GPU pick for general tasks and visual understanding. Drop to Q4 only if you must, and expect noticeably more glitches in agentic workflows.</li>
+<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Gemma 4 26B MoE at a good quant (Q5/Q6) holds up for local coding and chat. Q3 should be treated as gambling, not a working setup, when precision matters.</li>
+<li><strong>CPU-only / Pi / Apple Silicon at the low end:</strong> Gemma 4 E4B (9.6 GB on disk, effectively 9B-A4B) is the practical workhorse. It runs at 140+ tok/s on a Ryzen 9 5900X and is the default we recommend for non-GPU rigs.</li>
+<li><strong>Apple Silicon (32-64 GB unified):</strong> Gemma 4 26B MoE via Ollama Metal continues to perform; 48+ GB can move up to 31B Dense.</li>
+</ul>
+<h3>What works</h3>
+<ul class="setup-list">
+<li><strong>Visual understanding:</strong> Gemma 4 is consistently called out as still the strongest open model for image+text, even by users who otherwise prefer Qwen 3.6 for coding. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Quality on real coding tasks:</strong> Gemma 4 31B is reported to still match or beat Qwen 3.6 on some applications when the harness, quant, and context are tuned. The headline story is Qwen 3.6 27B catching up, not Gemma 4 falling off. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Speculative decoding pairing:</strong> Gemma 4 31B paired with Gemma 4 E2B as a draft model continues to deliver 120-200 tok/s on specific tasks for users with the headroom. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sw782p" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Pi / coding agent walkthrough:</strong> Patrick Loeber's tutorial on running a Gemma 4 coding agent on a Pi is now circulating; commenters note the same workflow generalizes to llama.cpp, not just LM Studio. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
+</ul>
+<h3>Known limits</h3>
+<ul class="setup-list">
+<li><strong>Local coding is not yet a Claude Code substitute.</strong> A widely-upvoted writeup (806+ score) argues that even Gemma 4 31B and Qwen 3.6 27B lose enough productivity vs Claude Code that the trade-off is hard to justify for serious work. Calibrate expectations accordingly. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Quant floor matters for agents.</strong> With agentic workflows that issue hundreds of tool calls, low quants (Q3, sometimes Q4) introduce small structural glitches (stray characters, malformed JSON) that break the run. Default to Q5_K_M or higher when you can. (<a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Safety filters on E2B.</strong> Gemma-4-E2B's safety filters have been flagged as overly aggressive for emergency/medical-style prompts. Plan for an unfiltered or alternate model if that is your use case. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sr35pk" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>E4B size confusion.</strong> Gemma 4 E4B is a 9B-A4B MoE on disk, not a 4B dense model. Comparisons against true 4B competitors are not apples to apples. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" target="_blank" rel="noopener">source</a>)</li>
+</ul>
+<h3>Open questions</h3>
+<ul class="setup-list">
+<li><strong>Qwen 3.6 27B vs Gemma 4 31B for coding:</strong> The community is mid-split on which is better, but tooling, quant, and context length keep changing the answer. We will keep an eye on harness-controlled comparisons.</li>
+<li><strong>Gemma 4 26B MoE quant sweet spot:</strong> GGUF benchmarks are still landing. Q4_K_M vs Q5_K_M vs Q6_K trade-offs on consumer GPUs deserve their own controlled run on our benchmark harness.</li>
+<li><strong>Strix Halo and other unified-memory APUs:</strong> Early reports on AMD Strix Halo 128GB suggest viable 27-31B dense inference, but day-2 numbers are sparse. Worth tracking for the late-2026 hardware cycle.</li>
+</ul>
+<h3>Sources</h3>
+<p>The 14 newly updated Gemma-mentioning posts driving this update:</p>
+<ul class="setup-list">
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">How to run a local coding agent with Gemma 4 and Pi (Patrick Loeber)</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" target="_blank" rel="noopener">The 4B class of 2026 (benchmark)</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" target="_blank" rel="noopener">Tested how OpenCode works with self-hosted LLMs (Qwen 3.5/3.6, Gemma 4, Nemotron 3, GLM-4.7)</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ssadey" target="_blank" rel="noopener">Youtuber tries Qwen 3.5 35B, Qwen 3.6 35B, and Gemma 4 27B on large JS reverse engineering</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" target="_blank" rel="noopener">I'm done with using local LLMs for coding</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxzqry" target="_blank" rel="noopener">Qwen 3.6 27B BF16 vs Q4_K_M vs Q8_0 GGUF evaluation</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxn7x2" target="_blank" rel="noopener">Local model on coding has reached a certain threshold to be feasible for real work</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxd2sc" target="_blank" rel="noopener">Built myself a bit of a local LLM workhorse (56 GB VRAM)</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxbvux" target="_blank" rel="noopener">Qwen 3.6 27B on Strix Halo 128GB: any experiences?</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1st3m8y" target="_blank" rel="noopener">Qwen 3.6 is actually useful for vibe-coding, and way cheaper than Claude</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1swifke" target="_blank" rel="noopener">Switched from Qwen 3.6 35B-A3B to Qwen 3.6 27B mid-coding</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ss7bcs" target="_blank" rel="noopener">Is a high-end private local LLM setup worth it?</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxjnv4" target="_blank" rel="noopener">Guys this is so fun!</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sy6xoo" target="_blank" rel="noopener">Something from Mistral (Vibe) tomorrow</a></li>
+</ul>
+<p>The full set of 61 community reports lives in the Community Reports section above, filterable by hardware category.</p>
+<p>_Last updated: 2026-04-29. Confidence: medium. Next update fires when the daily Gemma4 research cron flags notable new findings._</p></div>
     </section>
 
     <!-- Section 3: Benchmark Results -->

--- a/site/index.html
+++ b/site/index.html
@@ -559,7 +559,7 @@ gemmaclaw chat</code></pre>
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">[</p>
+  <p class="cr-summary">Google is going to show what open weights is about. Happy Easter everyone.</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Both_Opportunity5327 (+529)</span><span class="cr-comment-text">Google is going to show what open weights is about. Happy Easter everyone.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/danielhanchen (+519)</span><span class="cr-comment-text">Gemma-4 has native thinking, tool calling and is multimodal! Use temperature = 1.0, top\p = 0.95, top\k = 64 and the EOS is `&amp;lt;turn|&amp;gt;`. `&amp;lt;|channel&amp;gt;thought\n` is also used for the thinking t...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Altruistic_Heat_9531 (+416)</span><span class="cr-comment-text">And after a week maybe : &quot;Gemma 4 26B Heretic Uncensored Ablated Claude Opus 4.6 Reasoning Distlled Expanded fine tuned quantized&quot; Sorry to tempting lol</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1salgre" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -1103,7 +1103,7 @@ gemmaclaw chat</code></pre>
       <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Going to flag this up front - I know that there are some properly smart people on this sub, please can you correct my noob user errors or misunderstandings and educate my ass. Model: google/gemma-4-26b-a4b Versions: * MLX: [</p>
+  <p class="cr-summary">Going to flag this up front - I know that there are some properly smart people on this sub, please can you correct my noob user errors or misunderstandings and educate my ass. Model: google/gemma-4-26b-a4b Versions: * MLX:</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/EvolvingSoftware (+52)</span><span class="cr-comment-text">GGUF has come a long way recently.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cm8t (+50)</span><span class="cr-comment-text">GGUF/llama.cpp has really caught up to MLX over the past few months by leaning into Metal.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Temporary-Mix8022 (+41)</span><span class="cr-comment-text">That my friend, is the downside of writing my own posts.. yeah, user error over here. Edited it. I was running both on the same model. It was just when googling for those 4-ish bit quants to share the...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1spn7zh" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>


### PR DESCRIPTION
## Summary

- Adds a weekly synthesis section ("Field Notes") to the self-hosting guide that summarizes the latest Gemma 4 findings from r/LocalLLaMA in polished prose, structured per the editorial bar (Best current setup / What works / Known limits / Open questions / Sources).
- Drives the section from a hand-curated Markdown source at `site/data/field-notes.md`, rendered into HTML by `generate-site.py` so future cron-led updates can replace prose without touching `site/index.html`. Adds a conditional `#field-notes` nav link and dark-theme styling that's mobile responsive.
- Tightens `clean_markdown()` to drop self-referential `[url](url)` links and stray empty brackets so future community report cards stay clean (carrying forward the local fix that was already on the working tree).

## Test plan

- [x] python3 scripts/site/generate-site.py runs cleanly (61 community reports, 7 unique model/backend combos)
- [x] bash scripts/site/check-site-quality.sh all checks PASS
- [x] OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test:changed exits 0
- [x] Local file:// Chrome render confirms Field Notes section displays cleanly with correct nav link, prose flow, source links, and styling
- [ ] CI green
- [ ] Post-merge: https://gemmaclaw.github.io/gemmaclaw/#field-notes renders correctly on desktop and mobile viewports

## Notes

- 14 newly-updated Gemma-mentioning Reddit posts feed the prose synthesis (full source list rendered in the Sources subsection).
- site/data/gemma4-hardware-configs.json content is semantically unchanged after the daily research extractor (61 entries, same post IDs, oxfmt formatting matches the committed version), so the JSON refresh was a no-op for git but the synthesis it triggered is real.