### PR TITLE
site: refresh Gemma 4 field notes for 2026-04-30 (NVFP4 + chat-template fix)

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -589,6 +589,12 @@ def render_field_notes_markdown(md_text):
         # Bold then italic (order matters so ** wins over *).
         escaped = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", escaped)
         escaped = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", escaped)
+        # Underscore italic, but not inside identifiers like Q5_K_M.
+        escaped = re.sub(
+            r"(?<![A-Za-z0-9_])_([^_\n]+)_(?![A-Za-z0-9_])",
+            r"<em>\1</em>",
+            escaped,
+        )
         return escaped
 
     for raw in lines:
@@ -964,6 +970,21 @@ gemmaclaw chat</code></pre>
 
     // Initially hide all model details
     document.querySelectorAll('.model-detail').forEach(d => d.style.display = 'none');
+
+    // Active nav highlight on scroll
+    const sections = document.querySelectorAll('section[id]');
+    const navLinks = document.querySelectorAll('.nav-links a[href^="#"]');
+    function updateActiveNav() {{
+      let current = '';
+      sections.forEach(s => {{
+        if (window.scrollY >= s.offsetTop - 80) current = s.id;
+      }});
+      navLinks.forEach(a => {{
+        a.classList.toggle('active', a.getAttribute('href') === '#' + current);
+      }});
+    }}
+    window.addEventListener('scroll', updateActiveNav, {{ passive: true }});
+    updateActiveNav();
   </script>
 </body>
 </html>"""
@@ -980,18 +1001,18 @@ gemmaclaw chat</code></pre>
 
 CSS = """
     :root {
-      --bg: #0d1117;
-      --bg-elev: #161b22;
-      --bg-elev-2: #1c2129;
-      --border: #30363d;
-      --fg: #e6edf3;
-      --fg-soft: #c9d1d9;
-      --muted: #8b949e;
+      --bg: #ffffff;
+      --bg-elev: #f6f8fa;
+      --bg-elev-2: #eef1f5;
+      --border: #d0d7de;
+      --fg: #1f2328;
+      --fg-soft: #424a53;
+      --muted: #656d76;
       --accent: #4285f4;
-      --accent-soft: #1f3a5f;
-      --good: #3fb950;
-      --warn: #d29922;
-      --bad: #f85149;
+      --accent-soft: #dbe8fc;
+      --good: #1a7f37;
+      --warn: #9a6700;
+      --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { scroll-behavior: smooth; }
@@ -1006,7 +1027,7 @@ CSS = """
     /* Nav */
     .topnav {
       position: sticky; top: 0; z-index: 100;
-      background: rgba(13, 17, 23, 0.95);
+      background: rgba(255, 255, 255, 0.95);
       backdrop-filter: blur(12px);
       border-bottom: 1px solid var(--border);
     }
@@ -1019,12 +1040,19 @@ CSS = """
       font-size: 1.1rem; font-weight: 700; color: var(--accent);
       text-decoration: none;
     }
-    .nav-links { display: flex; gap: 1.5rem; }
+    .nav-links {
+      display: flex; gap: 1.5rem;
+      overflow-x: auto; -webkit-overflow-scrolling: touch;
+      scrollbar-width: none; -ms-overflow-style: none;
+    }
+    .nav-links::-webkit-scrollbar { display: none; }
     .nav-links a {
       color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 500;
-      transition: color 0.15s;
+      transition: color 0.15s; white-space: nowrap; flex-shrink: 0;
+      padding: 0.25rem 0; border-bottom: 2px solid transparent;
     }
     .nav-links a:hover { color: var(--fg); }
+    .nav-links a.active { color: var(--accent); border-bottom-color: var(--accent); }
 
     .wrap { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
 
@@ -1347,8 +1375,10 @@ CSS = """
     @media (max-width: 640px) {
       h1 { font-size: 2rem; }
       .tagline { font-size: 1rem; }
-      .nav-links { gap: 1rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-inner { padding: 0.5rem 1rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
+      .wrap { padding: 1.5rem 1rem 3rem; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { flex-wrap: wrap; gap: 0.5rem; }
       .cat-filter-bar { gap: 0.35rem; }

--- a/site/data/field-notes.md
+++ b/site/data/field-notes.md
@@ -1,55 +1,63 @@
-## Field Notes — 2026-04-29
+## Field Notes — 2026-04-30
 
 A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.
-Curated from the latest 14 Gemma-mentioning posts and their top comment threads.
-This is community signal, not a benchmark, and confidence is **medium** unless noted.
+Curated from the latest 14 Gemma-mentioning posts (5 net-new since 2026-04-29) and their top comment threads.
+Confidence is **medium** unless noted, since this is community signal rather than a controlled benchmark.
+
+### Headline this week
+
+Two findings reshape how you should run Gemma 4 today. First, llama.cpp's preliminary SM120 native NVFP4 MMQ landed, and three Gemma 4 31B-it NVFP4 GGUFs are already live on Hugging Face. On consumer Blackwell (RTX 5xxx) that means prefill is a lot faster because weights speak the GPU's native FP4 language with no translation step. Second, a contributor traced the long-running "Gemma 4 is bad at tools" complaint to a real chat-template bug rather than a model deficiency, with a candidate fix already on the Hugging Face discussion. If your agent stack has been flaky, the runtime, not Gemma, was likely the bottleneck.
 
 ### Best current setup (today)
 
-- **Mid-to-high GPU (24+ GB VRAM):** Gemma 4 31B Dense at Q6_K or higher remains the strongest single-GPU pick for general tasks and visual understanding. Drop to Q4 only if you must, and expect noticeably more glitches in agentic workflows.
-- **Constrained GPU (8-16 GB VRAM):** Gemma 4 26B MoE at a good quant (Q5/Q6) holds up for local coding and chat. Q3 should be treated as gambling, not a working setup, when precision matters.
-- **CPU-only / Pi / Apple Silicon at the low end:** Gemma 4 E4B (9.6 GB on disk, effectively 9B-A4B) is the practical workhorse. It runs at 140+ tok/s on a Ryzen 9 5900X and is the default we recommend for non-GPU rigs.
-- **Apple Silicon (32-64 GB unified):** Gemma 4 26B MoE via Ollama Metal continues to perform; 48+ GB can move up to 31B Dense.
+- **RTX 5xxx (Blackwell consumer):** if you have an SM120-class card, switch to a Gemma 4 31B-it NVFP4 GGUF and an llama.cpp build that includes [PR #22196](https://github.com/ggml-org/llama.cpp/pull/22196). Q4_K_M still falls back to the regular MMQ/MMA path, so you only see the speedup with NVFP4 weights. Early reports describe a meaningful prefill jump versus 35B-UD_Q4_XL on dual 5060 Ti 16GB rigs. ([source](https://reddit.com/r/LocalLLaMA/comments/1syjflw))
+- **Mid-to-high single GPU (24+ GB VRAM, non-Blackwell):** Gemma 4 31B Dense at Q5_K_M or Q6_K is still the strongest single-card choice for general work and visual understanding. Drop to Q4 only if you have to, and expect more agentic-loop failures once you do.
+- **Constrained GPU (8-16 GB VRAM):** Gemma 4 26B MoE at Q5_K_M holds up for local coding and chat. Treat Q3 as gambling for any workflow that depends on consistent JSON output.
+- **CPU-only / Pi / Apple Silicon at the low end:** Gemma 4 E4B (effectively 9B-A4B on disk, ~9.6 GB) is still the practical workhorse. It runs at 140+ tok/s on a Ryzen 9 5900X and is the sane default for non-GPU rigs.
+- **Apple Silicon (32-64 GB unified):** Gemma 4 26B MoE via Ollama Metal continues to perform; 48+ GB headroom can move up to 31B Dense, with the caveat from Apr 29 that MLX has not pulled ahead of GGUF for Gemma 4 yet.
 
 ### What works
 
-- **Visual understanding:** Gemma 4 is consistently called out as still the strongest open model for image+text, even by users who otherwise prefer Qwen 3.6 for coding. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
-- **Quality on real coding tasks:** Gemma 4 31B is reported to still match or beat Qwen 3.6 on some applications when the harness, quant, and context are tuned. The headline story is Qwen 3.6 27B catching up, not Gemma 4 falling off. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
-- **Speculative decoding pairing:** Gemma 4 31B paired with Gemma 4 E2B as a draft model continues to deliver 120-200 tok/s on specific tasks for users with the headroom. ([source](https://reddit.com/r/LocalLLaMA/comments/1sw782p))
-- **Pi / coding agent walkthrough:** Patrick Loeber's tutorial on running a Gemma 4 coding agent on a Pi is now circulating; commenters note the same workflow generalizes to llama.cpp, not just LM Studio. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
+- **Translation and creative writing.** This week's most upvoted thread (606 score) pulls together what people use Gemma 4 _for_: the model is consistently called the open-weights pick for translation and long-form creative output, while Qwen 3.6 leads on coding and game generation. ([source](https://reddit.com/r/LocalLLaMA/comments/1syt38w))
+- **Visual understanding.** Gemma 4 remains the strongest open multimodal answer for image plus text, even from users who otherwise prefer Qwen 3.6 for code-heavy work. ([source](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t))
+- **Speculative decoding pairing.** Gemma 4 31B with Gemma 4 E2B as a draft model still delivers 120-200 tok/s on suitable tasks for users with the headroom. ([source](https://reddit.com/r/LocalLLaMA/comments/1sw782p))
+- **Native FP4 on Blackwell.** The new NVFP4 path lets RTX 50-series cards skip the dequantize-then-multiply step entirely, since the tensor cores have FP4 math in silicon. The PR is preliminary, so expect rough edges, but this is the first time a full open-weights stack runs end-to-end at SM120 native FP4. ([source](https://reddit.com/r/LocalLLaMA/comments/1syjflw))
 
 ### Known limits
 
-- **Local coding is not yet a Claude Code substitute.** A widely-upvoted writeup (806+ score) argues that even Gemma 4 31B and Qwen 3.6 27B lose enough productivity vs Claude Code that the trade-off is hard to justify for serious work. Calibrate expectations accordingly. ([source](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c))
-- **Quant floor matters for agents.** With agentic workflows that issue hundreds of tool calls, low quants (Q3, sometimes Q4) introduce small structural glitches (stray characters, malformed JSON) that break the run. Default to Q5_K_M or higher when you can. ([source](https://reddit.com/r/LocalLLaMA/comments/1ssdim1))
-- **Safety filters on E2B.** Gemma-4-E2B's safety filters have been flagged as overly aggressive for emergency/medical-style prompts. Plan for an unfiltered or alternate model if that is your use case. ([source](https://reddit.com/r/LocalLLaMA/comments/1sr35pk))
-- **E4B size confusion.** Gemma 4 E4B is a 9B-A4B MoE on disk, not a 4B dense model. Comparisons against true 4B competitors are not apples to apples. ([source](https://reddit.com/r/LocalLLaMA/comments/1sxch39))
+- **Tool calling has had a real bug, not just bad vibes.** A contributor traced Gemma 4's intermittent MCP/OpenAI tool failures to its Jinja chat template not being a faithful JSON Schema renderer. JSON shapes like `anyOf: [$ref, null]` (the standard "nullable reference" pattern) collapse to empty `type` fields before the model ever sees them. A patched template lives at [HF discussion 91](https://huggingface.co/google/gemma-4-31B-it/discussions/91); until it lands officially, prefer flat tool schemas and avoid `$ref`/`anyOf` compositions. This finally explains why Qwen 3.6 has felt more reliable as an agent than Gemma 4. ([source](https://reddit.com/r/LocalLLaMA/comments/1syps6i))
+- **Translation quality drops fast on smaller languages.** A native Latvian speaker reports Gemma 4 31B understands the input fine but produces 2010-Google-Translate-grade output, with multiple spelling errors per word and brutal idiom transfer. Treat the "great at translation" reputation as English/Mandarin/Spanish-class, not universal. ([source](https://reddit.com/r/LocalLLaMA/comments/1syt38w))
+- **Local coding still trails Claude Code on long horizons.** The widely-shared "I'm done with using local LLMs for coding" essay (806 score) argues that even Gemma 4 31B and Qwen 3.6 27B lose enough productivity vs Claude Code that the trade-off is hard to justify for serious deadline work. Calibrate expectations. ([source](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c))
+- **Quant floor matters more for agents than for chat.** With workflows that fire hundreds of tool calls, Q3 (and sometimes Q4) introduces small structural glitches (stray characters, malformed JSON) that break a run. Default to Q5_K_M or higher when budget allows. ([source](https://reddit.com/r/LocalLLaMA/comments/1ssdim1))
+- **Safety filters on E2B.** Gemma-4-E2B's safety filters remain too aggressive for emergency or medical-shape prompts. Plan an unfiltered or alternate model for those use cases. ([source](https://reddit.com/r/LocalLLaMA/comments/1sr35pk))
 
 ### Open questions
 
-- **Qwen 3.6 27B vs Gemma 4 31B for coding:** The community is mid-split on which is better, but tooling, quant, and context length keep changing the answer. We will keep an eye on harness-controlled comparisons.
-- **Gemma 4 26B MoE quant sweet spot:** GGUF benchmarks are still landing. Q4_K_M vs Q5_K_M vs Q6_K trade-offs on consumer GPUs deserve their own controlled run on our benchmark harness.
-- **Strix Halo and other unified-memory APUs:** Early reports on AMD Strix Halo 128GB suggest viable 27-31B dense inference, but day-2 numbers are sparse. Worth tracking for the late-2026 hardware cycle.
+- **Will the NVFP4 path beat regular Q4 on inference, or only prefill?** Early commentary is that the speedup is concentrated in prefill on consumer Blackwell. We need controlled before/after numbers on tokens-per-second for both prefill and decode at typical chat and agent context lengths.
+- **How much of Gemma 4's "weak agent" reputation evaporates with the chat-template fix?** Side-by-side reruns of the recent OpenCode comparisons with the patched template will tell us whether Qwen 3.6's lead on tool calling was model quality or template plumbing.
+- **Gemma 4 26B MoE quant sweet spot.** GGUF benchmarks for the MoE keep landing piecemeal. Q4_K_M vs Q5_K_M vs Q6_K trade-offs on consumer GPUs deserve a controlled run on our benchmark harness.
+- **Strix Halo and unified-memory APUs.** Reports on AMD Strix Halo 128GB suggest viable 27-31B dense inference, but day-2 numbers are still sparse. Worth tracking through the late-2026 hardware cycle.
+- **Granite 4.1 and Laguna XS.2/M.1 vs Gemma 4 at the same parameter count.** Two new model families dropped this week; neither has community-validated numbers yet, and the question is whether either lands on the Gemma 4 frontier or stays niche. ([Granite 4.1](https://reddit.com/r/LocalLLaMA/comments/1sz23wn), [Laguna](https://reddit.com/r/LocalLLaMA/comments/1sy6oxr))
 
 ### Sources
 
-The 14 newly updated Gemma-mentioning posts driving this update:
+The 14 most relevant Gemma-mentioning posts driving this update, with the 5 newest first:
 
+- [I stumbled on a Gemma 4 chat template bug for tools and fixed it](https://reddit.com/r/LocalLLaMA/comments/1syps6i) (Apr 29, 2026)
+- [llama.cpp's Preliminary SM120 Native NVFP4 MMQ Is Merged](https://reddit.com/r/LocalLLaMA/comments/1syjflw) (Apr 29, 2026)
+- [What it feels like to have to have Qwen 3.6 or Gemma 4 running locally](https://reddit.com/r/LocalLLaMA/comments/1syt38w) (Apr 29, 2026)
+- [Introducing the IBM Granite 4.1 family of models (3B/8B/30B)](https://reddit.com/r/LocalLLaMA/comments/1sz23wn) (Apr 29, 2026)
+- [Introducing Laguna XS.2 and Laguna M.1](https://reddit.com/r/LocalLLaMA/comments/1sy6oxr) (Apr 28, 2026)
 - [How to run a local coding agent with Gemma 4 and Pi (Patrick Loeber)](https://reddit.com/r/LocalLLaMA/comments/1sx5h1t)
-- [The 4B class of 2026 (benchmark)](https://reddit.com/r/LocalLLaMA/comments/1sxch39)
+- [The 4B class of 2026](https://reddit.com/r/LocalLLaMA/comments/1sxch39)
 - [Tested how OpenCode works with self-hosted LLMs (Qwen 3.5/3.6, Gemma 4, Nemotron 3, GLM-4.7)](https://reddit.com/r/LocalLLaMA/comments/1ssdim1)
-- [Youtuber tries Qwen 3.5 35B, Qwen 3.6 35B, and Gemma 4 27B on large JS reverse engineering](https://reddit.com/r/LocalLLaMA/comments/1ssadey)
 - [I'm done with using local LLMs for coding](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c)
+- [Speculative decoding with Gemma-4-31B + Gemma-4-E2B](https://reddit.com/r/LocalLLaMA/comments/1sw782p)
 - [Qwen 3.6 27B BF16 vs Q4_K_M vs Q8_0 GGUF evaluation](https://reddit.com/r/LocalLLaMA/comments/1sxzqry)
 - [Local model on coding has reached a certain threshold to be feasible for real work](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2)
-- [Built myself a bit of a local LLM workhorse (56 GB VRAM)](https://reddit.com/r/LocalLLaMA/comments/1sxd2sc)
-- [Qwen 3.6 27B on Strix Halo 128GB: any experiences?](https://reddit.com/r/LocalLLaMA/comments/1sxbvux)
-- [Qwen 3.6 is actually useful for vibe-coding, and way cheaper than Claude](https://reddit.com/r/LocalLLaMA/comments/1st3m8y)
-- [Switched from Qwen 3.6 35B-A3B to Qwen 3.6 27B mid-coding](https://reddit.com/r/LocalLLaMA/comments/1swifke)
-- [Is a high-end private local LLM setup worth it?](https://reddit.com/r/LocalLLaMA/comments/1ss7bcs)
-- [Guys this is so fun!](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4)
-- [Something from Mistral (Vibe) tomorrow](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo)
+- [Gemma 4 - MLX doesn't seem better than GGUF](https://reddit.com/r/LocalLLaMA/comments/1spn7zh)
+- [Gemma-4-E2B's safety filters make it unusable for emergencies](https://reddit.com/r/LocalLLaMA/comments/1sr35pk)
 
-The full set of 61 community reports lives in the Community Reports section above, filterable by hardware category.
+The full set of 65 community reports lives in the Community Reports section above, filterable by hardware category and search.
 
-_Last updated: 2026-04-29. Confidence: medium. Next update fires when the daily Gemma4 research cron flags notable new findings._
+_Last updated: 2026-04-30. Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings._

--- a/site/data/gemma4-hardware-configs.json
+++ b/site/data/gemma4-hardware-configs.json
@@ -3,11 +3,11 @@
     "post": "1sxbvux",
     "file": "1sxbvux.md",
     "hardware_mentions": [
-      "- Score: 39",
-      "1. [u/Willing-Toe1942 (score 35)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oilqea8/)",
-      "2. [u/tecneeq (score 17)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oilsfa9/)",
-      "3. [u/Sixstringsickness (score 15)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oilr6dn/)",
-      "4. [u/Pretend_Engineer5951 (score 9)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oiltndz/)"
+      "- Score: 40",
+      "1. [u/Willing-Toe1942 (score 38)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oilqea8/)",
+      "2. [u/tecneeq (score 18)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oilsfa9/)",
+      "3. [u/Sixstringsickness (score 13)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oilr6dn/)",
+      "4. [u/Pretend_Engineer5951 (score 11)](https://reddit.com/r/LocalLLaMA/comments/1sxbvux/qwen_36_27b_on_strix_halo_128gb_any_experiences/oiltndz/)"
     ]
   },
   {
@@ -58,11 +58,11 @@
     "post": "1sxjnv4",
     "file": "1sxjnv4.md",
     "hardware_mentions": [
-      "- Score: 55",
+      "- Score: 57",
       "Running my own models. I was having some trouble getting vLLM going so dropped down to LM Studio which I've used on my 24GB MacBook Air. I now have LM Link across both laptops into the AI Workstation RTX Pro 6000 Blackwell. And my phone on LM Mini. It's so cool and I'm just getting started. Currently have Qwen3.5 9B going with Qwen3.6 27B and 35B A3B downloading. Going to play with some Llamas to\u2026",
-      "1. [u/jacek2023 (score 24)](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4/guys_this_is_so_fun/oincljb/)",
-      "2. [u/rm-rf-rm (score 14)](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4/guys_this_is_so_fun/oinf1aw/)",
-      "Please see the Best LLMs megathread linked in the sidebar (and stickied currently)"
+      "1. [u/jacek2023 (score 25)](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4/guys_this_is_so_fun/oincljb/)",
+      "2. [u/Guilty_Rooster_6708 (score 13)](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4/guys_this_is_so_fun/oinpccv/)",
+      "3. [u/rm-rf-rm (score 12)](https://reddit.com/r/LocalLLaMA/comments/1sxjnv4/guys_this_is_so_fun/oinf1aw/)"
     ]
   },
   {
@@ -80,11 +80,11 @@
     "post": "1sxzqry",
     "file": "1sxzqry.md",
     "hardware_mentions": [
-      "- Score: 577",
-      "1. [u/PassengerPigeon343 (score 306)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqg770/)",
-      "2. [u/audioen (score 66)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqhtcn/)",
-      "3. [u/doc-acula (score 61)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqh20m/)",
-      "4. [u/spaceman_ (score 52)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqg25y/)"
+      "- Score: 690",
+      "1. [u/PassengerPigeon343 (score 346)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqg770/)",
+      "2. [u/audioen (score 73)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqhtcn/)",
+      "3. [u/doc-acula (score 71)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqh20m/)",
+      "4. [u/spaceman_ (score 53)](https://reddit.com/r/LocalLLaMA/comments/1sxzqry/qwen_36_27b_bf16_vs_q4_k_m_vs_q8_0_gguf_evaluation/oiqg25y/)"
     ]
   },
   {
@@ -93,7 +93,7 @@
     "hardware_mentions": [
       "# Nvidia RTX 3090 vs Intel Arc Pro B70 llama.cpp Benchmarks",
       "- Permalink: https://reddit.com/r/LocalLLaMA/comments/1st6lp6/nvidia_rtx_3090_vs_intel_arc_pro_b70_llamacpp/",
-      "- Score: 69",
+      "- Score: 67",
       "- URL: https://www.reddit.com/r/LocalLLaMA/comments/1st6lp6/nvidia_rtx_3090_vs_intel_arc_pro_b70_llamacpp/",
       "***Just sharing the results from experimenting with the B70 on my setup....*** These results compare three `llama.cpp` execution paths on the same machine: * **RTX 3090 (Vulkan)** on NixOS host, using main llama.cpp repo (compiled on 4/21/2026) * **Arc Pro B70 (Vulkan)** on NixOS host, using main llama.cpp repo (compiled on 4/21/2026) * **Arc Pro B70 (SYCL)** inside an Ubuntu 24.04 Docker contain\u2026"
     ]
@@ -102,11 +102,11 @@
     "post": "1sxn7x2",
     "file": "1sxn7x2.md",
     "hardware_mentions": [
-      "- Score: 99",
+      "- Score: 107",
       "edits to call out some information: \\- All local model uses \\`Q4\\_K\\_M\\` quantization with \\`llama.cpp\\` engine \\- Main factor contribute to difference with Qwen's official post (59% vs 38%) is probably benchmark task timeout used, then quantization, harness, inference engine etc. \\- We expect this can be improved a lot with some prompt/harness/llama.cpp tuning \\- updated the diagram https://prev\u2026",
-      "1. [u/false79 (score 23)](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2/local_model_on_coding_has_reached_a_certain/oioftp2/)",
-      "2. [u/alrojo (score 16)](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2/local_model_on_coding_has_reached_a_certain/oiodo8k/)",
-      "3. [u/cygn (score 14)](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2/local_model_on_coding_has_reached_a_certain/oio923m/)"
+      "1. [u/false79 (score 29)](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2/local_model_on_coding_has_reached_a_certain/oioftp2/)",
+      "2. [u/alrojo (score 17)](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2/local_model_on_coding_has_reached_a_certain/oiodo8k/)",
+      "3. [u/cygn (score 13)](https://reddit.com/r/LocalLLaMA/comments/1sxn7x2/local_model_on_coding_has_reached_a_certain/oio923m/)"
     ]
   },
   {
@@ -187,6 +187,17 @@
     ]
   },
   {
+    "post": "1syt38w",
+    "file": "1syt38w.md",
+    "hardware_mentions": [
+      "- Score: 606",
+      "1. [u/RetroPeel2025 (score 101)](https://reddit.com/r/LocalLLaMA/comments/1syt38w/what_it_feels_like_to_have_to_have_qwen_36_or/oiwr3a7/)",
+      "2. [u/slvrsmth (score 38)](https://reddit.com/r/LocalLLaMA/comments/1syt38w/what_it_feels_like_to_have_to_have_qwen_36_or/oiwxv3p/)",
+      "3. [u/phenotype001 (score 28)](https://reddit.com/r/LocalLLaMA/comments/1syt38w/what_it_feels_like_to_have_to_have_qwen_36_or/oiwv299/)",
+      "4. [u/VEHICOULE (score 18)](https://reddit.com/r/LocalLLaMA/comments/1syt38w/what_it_feels_like_to_have_to_have_qwen_36_or/oiwly48/)"
+    ]
+  },
+  {
     "post": "1staxnq",
     "file": "1staxnq.md",
     "hardware_mentions": [
@@ -195,17 +206,6 @@
       "2. [u/mp3m4k3r (score 13)](https://reddit.com/r/LocalLLaMA/comments/1staxnq/gemma_4_beats_qwen_35_update_and_qwen_36_27b/ohtkfkc/)",
       "3. [u/Truth-Does-Not-Exist (score 10)](https://reddit.com/r/LocalLLaMA/comments/1staxnq/gemma_4_beats_qwen_35_update_and_qwen_36_27b/ohsgtpd/)",
       "4. [u/jacek2023 (score 9)](https://reddit.com/r/LocalLLaMA/comments/1staxnq/gemma_4_beats_qwen_35_update_and_qwen_36_27b/ohs5yun/)"
-    ]
-  },
-  {
-    "post": "1sxd2sc",
-    "file": "1sxd2sc.md",
-    "hardware_mentions": [
-      "# Built myself a bit of a local llm workhorse. What's a good model to try out with llamacpp that will put my 56G of VRAM to good use? Any other fun suggestions?",
-      "- Score: 41",
-      "1. [u/Long_comment_san (score 63)](https://reddit.com/r/LocalLLaMA/comments/1sxd2sc/built_myself_a_bit_of_a_local_llm_workhorse_whats/oilyq5v/)",
-      "2. [u/oxygen_addiction (score 23)](https://reddit.com/r/LocalLLaMA/comments/1sxd2sc/built_myself_a_bit_of_a_local_llm_workhorse_whats/oim3gsi/)",
-      "3. [u/specify_ (score 5)](https://reddit.com/r/LocalLLaMA/comments/1sxd2sc/built_myself_a_bit_of_a_local_llm_workhorse_whats/oim02xj/)"
     ]
   },
   {
@@ -228,6 +228,28 @@
       "2. [u/DelKarasique (score 89)](https://reddit.com/r/LocalLLaMA/comments/1srgqk4/which_gemma_model_do_you_want_next/ohelvr2/)",
       "3. [u/DeepOrangeSky (score 88)](https://reddit.com/r/LocalLLaMA/comments/1srgqk4/which_gemma_model_do_you_want_next/ohep84l/)",
       "4. [u/BigYoSpeck (score 65)](https://reddit.com/r/LocalLLaMA/comments/1srgqk4/which_gemma_model_do_you_want_next/oheyxd8/)"
+    ]
+  },
+  {
+    "post": "1syjflw",
+    "file": "1syjflw.md",
+    "hardware_mentions": [
+      "- Score: 58",
+      "1. [u/Bulky-Priority6824 (score 13)](https://reddit.com/r/LocalLLaMA/comments/1syjflw/llamacpps_preliminary_sm120_native_nvfp4_mmq_is/oiuzs2r/)",
+      "nvfp4 speaks the gpus native language. The blackwell tensor cores have FP4 math built directly into the silicon so the model weights go in as is and the multiplication happens without any translation step. Less overhead, faster math, same bit width. that being said, benched vs 35B-UD\\_Q4\\_XL using dual 5060ti16's in l\u2026",
+      "2. [u/ggonavyy (score 13)](https://reddit.com/r/LocalLLaMA/comments/1syjflw/llamacpps_preliminary_sm120_native_nvfp4_mmq_is/oiv156y/)",
+      "3. [u/ggonavyy (score 9)](https://reddit.com/r/LocalLLaMA/comments/1syjflw/llamacpps_preliminary_sm120_native_nvfp4_mmq_is/oiusipn/)"
+    ]
+  },
+  {
+    "post": "1syps6i",
+    "file": "1syps6i.md",
+    "hardware_mentions": [
+      "- Score: 56",
+      "TLDR: tool parameters using the common JSON Schema pattern \\`anyOf: \\[$ref, null\\]\\` are rendered into the prompt as empty \\`type\\` fields. This strips the useful schema information before the model sees it. \\-- Long, rambling version: Gemma 4 was having issues with calling my custom MCP tool on &gt;3 inference engines, while Qwen3.5 and gpt-oss-20b were doing fine. I guessed it was either a chat\u2026",
+      "1. [u/onil_gova (score 8)](https://reddit.com/r/LocalLLaMA/comments/1syps6i/i_stumbled_on_a_gemma_4_chat_template_bug_for/oiw5dxl/)",
+      "2. [u/EntertainmentBroad43 (score 6)](https://reddit.com/r/LocalLLaMA/comments/1syps6i/i_stumbled_on_a_gemma_4_chat_template_bug_for/oiw6hy3/)",
+      "3. [u/EntertainmentBroad43 (score 5)](https://reddit.com/r/LocalLLaMA/comments/1syps6i/i_stumbled_on_a_gemma_4_chat_template_bug_for/oiwrkv7/)"
     ]
   },
   {
@@ -418,14 +440,25 @@
     ]
   },
   {
+    "post": "1sy6oxr",
+    "file": "1sy6oxr.md",
+    "hardware_mentions": [
+      "- Score: 61",
+      "1. [u/pmttyji (score 17)](https://reddit.com/r/LocalLLaMA/comments/1sy6oxr/introducing_laguna_xs2_and_laguna_m1/oirylfn/)",
+      "2. [u/abkibaarnsit (score 13)](https://reddit.com/r/LocalLLaMA/comments/1sy6oxr/introducing_laguna_xs2_and_laguna_m1/oirxtfg/)",
+      "3. [u/coder543 (score 11)](https://reddit.com/r/LocalLLaMA/comments/1sy6oxr/introducing_laguna_xs2_and_laguna_m1/ois260b/)",
+      "4. [u/rm-rf-rm (score 3)](https://reddit.com/r/LocalLLaMA/comments/1sy6oxr/introducing_laguna_xs2_and_laguna_m1/oivy5xz/)"
+    ]
+  },
+  {
     "post": "1sxqa2c",
     "file": "1sxqa2c.md",
     "hardware_mentions": [
-      "- Score: 806",
-      "1. [u/PeerlessYeeter (score 504)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oiopwx1/)",
-      "2. [u/onethousandmonkey (score 278)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oioy00h/)",
-      "3. [u/Hans-Wermhatt (score 179)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oip36d6/)",
-      "4. [u/falconandeagle (score 117)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oioyzek/)"
+      "- Score: 917",
+      "1. [u/PeerlessYeeter (score 525)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oiopwx1/)",
+      "2. [u/onethousandmonkey (score 313)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oioy00h/)",
+      "3. [u/Hans-Wermhatt (score 185)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oip36d6/)",
+      "4. [u/patricious (score 133)](https://reddit.com/r/LocalLLaMA/comments/1sxqa2c/im_done_with_using_local_llms_for_coding/oiptqtm/)"
     ]
   },
   {
@@ -542,11 +575,11 @@
     "post": "1suyu7a",
     "file": "1suyu7a.md",
     "hardware_mentions": [
-      "- Score: 545",
-      "1. [u/Daemontatox (score 255)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi4n1eq/)",
-      "2. [u/KeikakuAccelerator (score 134)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi52xrd/)",
+      "- Score: 552",
+      "1. [u/Daemontatox (score 259)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi4n1eq/)",
+      "2. [u/KeikakuAccelerator (score 138)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi52xrd/)",
       "3. [u/ttkciar (score 85)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi4ovor/)",
-      "4. [u/a9udn9u (score 78)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi4qu2q/)"
+      "4. [u/a9udn9u (score 80)](https://reddit.com/r/LocalLLaMA/comments/1suyu7a/im_glad_we_have_deepseek/oi4qu2q/)"
     ]
   },
   {
@@ -597,11 +630,11 @@
     "post": "1sy6xoo",
     "file": "1sy6xoo.md",
     "hardware_mentions": [
-      "- Score: 374",
-      "1. [u/RepulsiveRaisin7 (score 102)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois0cr6/)",
-      "2. [u/szansky (score 70)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois1o9w/)",
-      "3. [u/CYTR_ (score 34)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois473r/)",
-      "4. [u/LegacyRemaster (score 26)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois0s94/)"
+      "- Score: 459",
+      "1. [u/RepulsiveRaisin7 (score 125)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois0cr6/)",
+      "2. [u/szansky (score 72)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois1o9w/)",
+      "3. [u/CYTR_ (score 37)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois473r/)",
+      "4. [u/BumblebeeParty6389 (score 33)](https://reddit.com/r/LocalLLaMA/comments/1sy6xoo/something_from_mistral_vibe_tomorrow/ois25b8/)"
     ]
   },
   {
@@ -627,14 +660,25 @@
     ]
   },
   {
+    "post": "1sz23wn",
+    "file": "1sz23wn.md",
+    "hardware_mentions": [
+      "- Score: 205",
+      "1. [u/sine120 (score 55)](https://reddit.com/r/LocalLLaMA/comments/1sz23wn/introducing_the_ibm_granite_41_family_of_models/oiyh0oc/)",
+      "2. [u/abkibaarnsit (score 32)](https://reddit.com/r/LocalLLaMA/comments/1sz23wn/introducing_the_ibm_granite_41_family_of_models/oiygj40/)",
+      "3. [u/Middle_Bullfrog_6173 (score 26)](https://reddit.com/r/LocalLLaMA/comments/1sz23wn/introducing_the_ibm_granite_41_family_of_models/oiyn2dv/)",
+      "Very weak on benchmarks FWIW. 30B scored 15 on AA index. Equal to the non-reasoning scores of Gemma 4 E4B and Qwen 3.5 2B."
+    ]
+  },
+  {
     "post": "1sxch39",
     "file": "1sxch39.md",
     "hardware_mentions": [
-      "- Score: 200",
+      "- Score: 208",
       "Bench 2 from my 18GB M3 Pro. Last week was specialists vs generalists at 7-8B (which I hosed by giving thinking models a 128-token budget, so half the post was an apology). This week: the 4B class of 2026, every model released or actively-current at the 3-4B size, head-to-head on the same task suite. Lineup (sizes on disk): gemma4:e4b 9.6 GB Google, Apr 2 2026 qwen3.5:4b 3.4 GB Alibaba, Mar 1 202\u2026",
-      "1. [u/Pristine-Woodpecker (score 102)](https://reddit.com/r/LocalLLaMA/comments/1sxch39/the_4b_class_of_2026_benchmark/oilyckt/)",
+      "1. [u/Pristine-Woodpecker (score 98)](https://reddit.com/r/LocalLLaMA/comments/1sxch39/the_4b_class_of_2026_benchmark/oilyckt/)",
       "2. [u/Dabber43 (score 57)](https://reddit.com/r/LocalLLaMA/comments/1sxch39/the_4b_class_of_2026_benchmark/oilxlnx/)",
-      "3. [u/Sufficient-Bid3874 (score 44)](https://reddit.com/r/LocalLLaMA/comments/1sxch39/the_4b_class_of_2026_benchmark/oilxye3/)"
+      "3. [u/Sufficient-Bid3874 (score 46)](https://reddit.com/r/LocalLLaMA/comments/1sxch39/the_4b_class_of_2026_benchmark/oilxye3/)"
     ]
   },
   {

--- a/site/index.html
+++ b/site/index.html
@@ -8,18 +8,18 @@
   <style>
 
     :root {
-      --bg: #0d1117;
-      --bg-elev: #161b22;
-      --bg-elev-2: #1c2129;
-      --border: #30363d;
-      --fg: #e6edf3;
-      --fg-soft: #c9d1d9;
-      --muted: #8b949e;
+      --bg: #ffffff;
+      --bg-elev: #f6f8fa;
+      --bg-elev-2: #eef1f5;
+      --border: #d0d7de;
+      --fg: #1f2328;
+      --fg-soft: #424a53;
+      --muted: #656d76;
       --accent: #4285f4;
-      --accent-soft: #1f3a5f;
-      --good: #3fb950;
-      --warn: #d29922;
-      --bad: #f85149;
+      --accent-soft: #dbe8fc;
+      --good: #1a7f37;
+      --warn: #9a6700;
+      --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { scroll-behavior: smooth; }
@@ -34,7 +34,7 @@
     /* Nav */
     .topnav {
       position: sticky; top: 0; z-index: 100;
-      background: rgba(13, 17, 23, 0.95);
+      background: rgba(255, 255, 255, 0.95);
       backdrop-filter: blur(12px);
       border-bottom: 1px solid var(--border);
     }
@@ -47,12 +47,19 @@
       font-size: 1.1rem; font-weight: 700; color: var(--accent);
       text-decoration: none;
     }
-    .nav-links { display: flex; gap: 1.5rem; }
+    .nav-links {
+      display: flex; gap: 1.5rem;
+      overflow-x: auto; -webkit-overflow-scrolling: touch;
+      scrollbar-width: none; -ms-overflow-style: none;
+    }
+    .nav-links::-webkit-scrollbar { display: none; }
     .nav-links a {
       color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 500;
-      transition: color 0.15s;
+      transition: color 0.15s; white-space: nowrap; flex-shrink: 0;
+      padding: 0.25rem 0; border-bottom: 2px solid transparent;
     }
     .nav-links a:hover { color: var(--fg); }
+    .nav-links a.active { color: var(--accent); border-bottom-color: var(--accent); }
 
     .wrap { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
 
@@ -375,8 +382,10 @@
     @media (max-width: 640px) {
       h1 { font-size: 2rem; }
       .tagline { font-size: 1rem; }
-      .nav-links { gap: 1rem; }
-      .nav-links a { font-size: 0.82rem; }
+      .nav-inner { padding: 0.5rem 1rem; }
+      .nav-links { gap: 0.75rem; }
+      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
+      .wrap { padding: 1.5rem 1rem 3rem; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { flex-wrap: wrap; gap: 0.5rem; }
       .cat-filter-bar { gap: 0.35rem; }
@@ -588,9 +597,9 @@ gemmaclaw chat</code></pre>
       </div>
 
       <div class="community-section" id="community">
-        <h3>Community Reports (61 from r/LocalLLaMA)</h3>
+        <h3>Community Reports (65 from r/LocalLLaMA)</h3>
         <p>Real-world hardware experiences from the community. Filter by hardware category or search above. These are user reports, not official benchmarks.</p>
-        <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (10)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (7)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (3)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (2)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (5)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (47)</button><button class="cat-filter-btn" data-cat="general">Other (11)</button></div>
+        <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (12)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (7)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (4)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (2)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (5)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (50)</button><button class="cat-filter-btn" data-cat="general">Other (12)</button></div>
 <div id="community-cards"><div class="cr-card" data-search="gemma 4 has been released [ quantization agents anthropic google gemma google is going to show what open weights is about. happy easter everyone. gemma-4 has native thinking, tool calling and is multimodal! use temperature = 1.0, top_p = and after a week maybe : &quot;gemma 4 26b heretic uncensored ablated claude opus 4.6 reasoning distlled" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -625,11 +634,11 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/StupidScaredSquirrel (+277)</span><span class="cr-comment-text">I still wanna glaze gemma just cause I'm too scared qwen will stop delivering at some point and gemma is very close in terms of performance and I dont want google to stop releasing</span></div><div class="cr-comment"><span class="cr-comment-meta">u/MexInAbu (+208)</span><span class="cr-comment-text">Gemma 4 is superior for creative writing and there's no contest.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/markole (+83)</span><span class="cr-comment-text">Coding? Sure. Translating? Nah, qwen sucks for translating.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1srhzii" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="i'm done with using local llms for coding i think gave it a fair shot over the past few weeks, forcing myself to use local models for non-work tech asks. i use claude code at my job so that's what i'm comparing to. i used qwen 27b and gemma 4 31b, these are considered the best local models under the multi-hundred llms. i also tried multiple agentic apps. my verdict is that the loss of productivity is not worth it the advantages. i'll giv… agents anthropic qwen gemma op's experience somewhat matc" data-cats="general">
+<div class="cr-card" data-search="i'm done with using local llms for coding i think gave it a fair shot over the past few weeks, forcing myself to use local models for non-work tech asks. i use claude code at my job so that's what i'm comparing to. i used qwen 27b and gemma 4 31b, these are considered the best local models under the multi-hundred llms. i also tried multiple agentic apps. my verdict is that the loss of productivity is not worth it the advantages. i'll giv… hardware agents anthropic qwen deepseek gemma op's experi" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" target="_blank" rel="noopener">I'm done with using local LLMs for coding</a></h4>
-      <span class="cr-score cr-score-high">+806</span>
+      <span class="cr-score cr-score-high">+917</span>
     </div>
     <div class="cr-meta">
       <span class="cr-author">u/dtdisapointingresult</span>
@@ -639,7 +648,7 @@ gemmaclaw chat</code></pre>
     </div>
   </div>
   <p class="cr-summary">I think gave it a fair shot over the past few weeks, forcing myself to use local models for non-work tech asks. I use Claude Code at my job so that's what I'm comparing to. I used Qwen 27B and Gemma 4 31B, these are considered the best local models u...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PeerlessYeeter (+504)</span><span class="cr-comment-text">op's experience somewhat matches mine, I keep assuming I'm doing something wrong but I think this subreddit gave me some unrealistic expectations</span></div><div class="cr-comment"><span class="cr-comment-meta">u/onethousandmonkey (+278)</span><span class="cr-comment-text">Purely from the performance point of view, there are a number of settings to tweak to make Claude Code jive with local models. For example: Before I did that, I was banging my head against the wall at...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Hans-Wermhatt (+179)</span><span class="cr-comment-text">The people here overhype Qwen 3.6 for sure, but I don't know what to tell the people who were expecting to just flip over from Opus 4.7 xhigh 4 Trillion to Qwen 27B and expect the same performance. Yo...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PeerlessYeeter (+525)</span><span class="cr-comment-text">op's experience somewhat matches mine, I keep assuming I'm doing something wrong but I think this subreddit gave me some unrealistic expectations</span></div><div class="cr-comment"><span class="cr-comment-meta">u/onethousandmonkey (+313)</span><span class="cr-comment-text">Purely from the performance point of view, there are a number of settings to tweak to make Claude Code jive with local models. For example: Before I did that, I was banging my head against the wall at...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Hans-Wermhatt (+185)</span><span class="cr-comment-text">The people here overhype Qwen 3.6 for sure, but I don't know what to tell the people who were expecting to just flip over from Opus 4.7 xhigh 4 Trillion to Qwen 27B and expect the same performance. Yo...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="when you dial in your bot’s personality sycophancy: deleted efficiency per token:+1000% friendship: just beginning edit: “sup” got cut off at top fine-tuning gemma sounds like an average talk in tinder but with better vocabulary. autismgpt you finally built her" data-cats="general">
@@ -659,6 +668,23 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/RoomyRoots (+414)</span><span class="cr-comment-text">Sounds like an average talk in TInder but with better vocabulary.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Own-Potential-2308 (+223)</span><span class="cr-comment-text">AutismGPT</span></div><div class="cr-comment"><span class="cr-comment-meta">u/No_Swimming6548 (+118)</span><span class="cr-comment-text">You finally built her</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sqnrhb" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
+<div class="cr-card" data-search="qwen 3.6 27b bf16 vs q4km vs q80 gguf evaluation evaluated qwen 3.6 27b across bf16, q4\k\m, and q8\0 gguf quant variants with llama-cpp-python using neo ai engineer. benchmarks used: humaneval: code generation hellaswag: commonsense reasoning bfcl: function calling total samples: humaneval: 164 hellaswag: 100 bfcl: 400 results: bf16 humaneval: 56.10% 92/164 hellaswag: 90.00% 90/100 bfcl: 63.25% 253/400 avg accuracy:… quantization benchmarking agents meta-llama qwen gemma really like seeing this" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxzqry" target="_blank" rel="noopener">Qwen 3.6 27B BF16 vs Q4_K_M vs Q8_0 GGUF evaluation</a></h4>
+      <span class="cr-score cr-score-high">+690</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/gvij</span>
+      <span class="cr-date">2026-04-28</span>
+      <span class="cr-flair">Discussion</span>
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Evaluated Qwen 3.6 27B across BF16, Q4\K\M, and Q8_0 GGUF quant variants with llama-cpp-python using Neo AI Engineer. Benchmarks used: HumanEval: code generation HellaSwag: commonsense reasoning BFCL: function calling Total samples: HumanEval: 164 He...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PassengerPigeon343 (+346)</span><span class="cr-comment-text">Really like seeing this kind of comparison across quants, I feel like we need more of that kind of analysis on here. Thanks for doing this!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/audioen (+73)</span><span class="cr-comment-text">No error bars in these measurements. We know that Q4\K\M is not likely to better than Q8_0 and the fact benchmark ordered them in this order at least once raises the question of how much this is just ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/doc-acula (+71)</span><span class="cr-comment-text">Gemma4 would be nice.</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1sxzqry" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
 <div class="cr-card" data-search="i'm running qwen3.6-35b-a3b with 8 bit quant and 64k context thru opencode on my mbp m5 max 128gb and it's as good as claude of course this is just a trust me bro post but i've been testing various local models (a couple gemma4s, qwen3 coder next, nemotron) and i noticed the new qwen3.6 show up on lm studio so i hooked it up. very impressed. it's super fast to respond, handles long research tasks with many tool calls (i had it investigate why r8 was breaking some serialization across an android " data-cats="apple-silicon high-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -676,22 +702,22 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/cosmicnag (+154)</span><span class="cr-comment-text">Its the best local model so far IMO. On a 5090, the friggin speed gives an overall unmatched experience to any cloud model. The speed is insane. Havent even tried a NVFP4 yet lol.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/H_DANILO (+78)</span><span class="cr-comment-text">you can easily go 256k, context is VERY CHEAP on Qwen, and this model is REALLY good with context</span></div><div class="cr-comment"><span class="cr-comment-meta">u/john0201 (+77)</span><span class="cr-comment-text">The latency and general experience is just better. I bought the perplexity search api credits and I just straight up prefer it for many things. Opus 4.7 is still much better for coding. I sometimes us...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1spdvpo" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="qwen 3.6 27b bf16 vs q4km vs q80 gguf evaluation evaluated qwen 3.6 27b across bf16, q4\k\m, and q8\0 gguf quant variants with llama-cpp-python using neo ai engineer. benchmarks used: humaneval: code generation hellaswag: commonsense reasoning bfcl: function calling total samples: humaneval: 164 hellaswag: 100 bfcl: 400 results: bf16 humaneval: 56.10% 92/164 hellaswag: 90.00% 90/100 bfcl: 63.25% 253/400 avg accuracy:… quantization benchmarking agents meta-llama qwen really like seeing this kind " data-cats="quantization">
+<div class="cr-card" data-search="what it feels like to have to have qwen 3.6 or gemma 4 running locally well or pretty close to it, they are excellent work horses. i run them in real work scenarios doing some of the work i used to do myself as an skilled expert in my field, billing 200$ an hour. ofc the key is building a system around their weaknesses, and i've had already llm systems doing expert work years ago when first ones came (shout out nous hermes 2 mistral!). but yeah pretty neat, especial… hardware fine-tuning agents " data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxzqry" target="_blank" rel="noopener">Qwen 3.6 27B BF16 vs Q4_K_M vs Q8_0 GGUF evaluation</a></h4>
-      <span class="cr-score cr-score-high">+577</span>
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1syt38w" target="_blank" rel="noopener">What it feels like to have to have Qwen 3.6 or Gemma 4 running locally</a></h4>
+      <span class="cr-score cr-score-high">+606</span>
     </div>
     <div class="cr-meta">
-      <span class="cr-author">u/gvij</span>
-      <span class="cr-date">2026-04-28</span>
-      <span class="cr-flair">Discussion</span>
+      <span class="cr-author">u/GodComplecs</span>
+      <span class="cr-date">2026-04-29</span>
+      <span class="cr-flair">Funny</span>
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Evaluated Qwen 3.6 27B across BF16, Q4\K\M, and Q8_0 GGUF quant variants with llama-cpp-python using Neo AI Engineer. Benchmarks used: HumanEval: code generation HellaSwag: commonsense reasoning BFCL: function calling Total samples: HumanEval: 164 He...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PassengerPigeon343 (+306)</span><span class="cr-comment-text">Really like seeing this kind of comparison across quants, I feel like we need more of that kind of analysis on here. Thanks for doing this!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/audioen (+66)</span><span class="cr-comment-text">No error bars in these measurements. We know that Q4\K\M is not likely to better than Q8_0 and the fact benchmark ordered them in this order at least once raises the question of how much this is just ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/doc-acula (+61)</span><span class="cr-comment-text">Gemma4 would be nice.</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1sxzqry" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+  <p class="cr-summary">Well or pretty close to it, they are excellent work horses. I run them in real work scenarios doing some of the work I used to do myself as an skilled expert in my field, billing 200$ an hour. Ofc the key is building a system around their weaknesses,...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/RetroPeel2025 (+101)</span><span class="cr-comment-text">Gemma4 is great for translation and creative writing. Qwen3.6 outputs great games. I don't know what black magic they did to make the smaller models that capable in making cool games for the browser. ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/slvrsmth (+38)</span><span class="cr-comment-text">Careful with Gemma4 translating to languages you don't understand, especially smaller ones. I ran a small test with my native latvian. 31B understands the inputs well, but the outputs are 2010-google-...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/phenotype001 (+28)</span><span class="cr-comment-text">I left an agent with Qwen 3.6 working overnight. I wake up, it still works. No looping on bullshit, no dumb decisions. It's a dream come true.</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1syt38w" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="qwen3.6 gguf benchmarks hey guys, we ran qwen3.6-35b-a3b gguf kld performance benchmarks to help you choose the best quant. unsloth quants have the best kld vs disk space 21/22 times on the pareto frontier. ggufs: we also want to clear up a few misunderstandings around our gguf updates. some people have sai… hardware quantization inference google meta-llama gemma for more a more hq and cleaner graph, see: [ these graphs are fantastic for idiots like me who can't work out what is what, thankyou s" data-cats="quantization">
   <div class="cr-card-header">
@@ -714,7 +740,7 @@ gemmaclaw chat</code></pre>
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1suyu7a" target="_blank" rel="noopener">I'm glad we have deepseek</a></h4>
-      <span class="cr-score cr-score-high">+545</span>
+      <span class="cr-score cr-score-high">+552</span>
     </div>
     <div class="cr-meta">
       <span class="cr-author">u/guiopen</span>
@@ -724,8 +750,25 @@ gemmaclaw chat</code></pre>
     </div>
   </div>
   <p class="cr-summary">other companies are slowly going away from open weight, not releasing base models, delaying open weight distribution, not releasing top models (this one I think is fair, but still), and I also noticed they stopped publishing research (old Gemma and q...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Daemontatox (+255)</span><span class="cr-comment-text">deepseek's contribution isnt just the models , alot of people forget the kernels and repos they open source which are insanely helpful</span></div><div class="cr-comment"><span class="cr-comment-meta">u/KeikakuAccelerator (+134)</span><span class="cr-comment-text">They straight up open sourced a new file system to squeeze more training. They are efficiency goats</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ttkciar (+85)</span><span class="cr-comment-text">I think it's fine, because we have some excellent smaller models from other labs (most recently Qwen3.6 from Alibaba and Gemma4 from Google), some of which do have base models (Gemma, Olmo, K2-V2). Wh...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Daemontatox (+259)</span><span class="cr-comment-text">deepseek's contribution isnt just the models , alot of people forget the kernels and repos they open source which are insanely helpful</span></div><div class="cr-comment"><span class="cr-comment-meta">u/KeikakuAccelerator (+138)</span><span class="cr-comment-text">They straight up open sourced a new file system to squeeze more training. They are efficiency goats</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ttkciar (+85)</span><span class="cr-comment-text">I think it's fine, because we have some excellent smaller models from other labs (most recently Qwen3.6 from Alibaba and Gemma4 from Google), some of which do have base models (Gemma, Olmo, K2-V2). Wh...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1suyu7a" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="something from mistral (vibe) tomorrow model(s) or tool upgrade/new tool? source tweet : benchmarking qwen mistral gemma new devstral? current model is pretty meh, hope they manage to catch up to the industry okay i need something similar to qwen 3.6 27b ! mistral understood very well that the race for sota is pointless for becoming profitable. they send" data-cats="general">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sy6xoo" target="_blank" rel="noopener">Something from Mistral (Vibe) tomorrow</a></h4>
+      <span class="cr-score cr-score-high">+459</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/pmttyji</span>
+      <span class="cr-date">2026-04-28</span>
+      <span class="cr-flair">News</span>
+      <span class="cr-cat-badge">General</span>
+    </div>
+  </div>
+  <p class="cr-summary">Model(s) or Tool upgrade/New Tool? Source Tweet :</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/RepulsiveRaisin7 (+125)</span><span class="cr-comment-text">New devstral? Current model is pretty meh, hope they manage to catch up to the industry</span></div><div class="cr-comment"><span class="cr-comment-meta">u/szansky (+72)</span><span class="cr-comment-text">Okay I need something similar to Qwen 3.6 27B !</span></div><div class="cr-comment"><span class="cr-comment-meta">u/CYTR_ (+37)</span><span class="cr-comment-text">Mistral understood very well that the race for SOTA is pointless for becoming profitable. They send fleets of engineers to their clients, manufacture tools, and fine-tune the models. That's the main p...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1sy6xoo" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma-4-e2b's safety filters make it unusable for emergencies i’ve been testing google’s gemma-4-e2b-it as a local, offline resource for emergency preparedness. the idea was to have a lightweight model that could provide basic technical or medical info if the internet goes down. as the screenshots show, the safety filters are so aggressive that the model is functionally useless for these scenarios. it issues a &quot;hard refusal&quot; on almost everything: **- first… rag google gemma frankly, it" data-cats="general">
   <div class="cr-card-header">
@@ -777,23 +820,6 @@ gemmaclaw chat</code></pre>
   <p class="cr-summary">Hi LocalLLaMA, I created a post a few weeks ago, but this time this project has become more reliable and easier to use. This is a manga translator that can also be used to translate any image. It uses a combination of object detection, visual LLM-bas...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Mayion (+86)</span><span class="cr-comment-text">Can't wait for it to have a browser extension to translate in real-time the &quot;manga&quot; I am reading</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mayocream39 (+42)</span><span class="cr-comment-text">We have a GitHub issue for this; we wanna integrate with the ComicReadScript project. We are currently waiting for the author's response to integrate. &amp;lt;3</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mayocream39 (+30)</span><span class="cr-comment-text">There are so many features I didn't mention in this main thread. If you are interested, please take a look at the GitHub README. I spent almost one year polishing this project, and while there may be ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sslwjv" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
-<div class="cr-card" data-search="something from mistral (vibe) tomorrow model(s) or tool upgrade/new tool? source tweet : benchmarking qwen mistral gemma new devstral? current model is pretty meh, hope they manage to catch up to the industry okay i need something similar to qwen 3.6 27b ! mistral understood very well that the race for sota is pointless for becoming profitable. they send" data-cats="general">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sy6xoo" target="_blank" rel="noopener">Something from Mistral (Vibe) tomorrow</a></h4>
-      <span class="cr-score cr-score-high">+374</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/pmttyji</span>
-      <span class="cr-date">2026-04-28</span>
-      <span class="cr-flair">News</span>
-      <span class="cr-cat-badge">General</span>
-    </div>
-  </div>
-  <p class="cr-summary">Model(s) or Tool upgrade/New Tool? Source Tweet :</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/RepulsiveRaisin7 (+102)</span><span class="cr-comment-text">New devstral? Current model is pretty meh, hope they manage to catch up to the industry</span></div><div class="cr-comment"><span class="cr-comment-meta">u/szansky (+70)</span><span class="cr-comment-text">Okay I need something similar to Qwen 3.6 27B !</span></div><div class="cr-comment"><span class="cr-comment-meta">u/CYTR_ (+34)</span><span class="cr-comment-text">Mistral understood very well that the race for SOTA is pointless for becoming profitable. They send fleets of engineers to their clients, manufacture tools, and fine-tune the models. That's the main p...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1sy6xoo" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 and qwen 3.6 with q80 and q40 kv cache: kl divergence results link post. the discussion is mostly in the comments. target: quantization inference benchmarking meta-llama qwen gemma great writeup, thank you. i speculate gemma's degradation is actually related to the decision to con so gemma starts getting brain damage on cache quantization the attention rotation that llama.cpp has implemented was not inspired by turboquant.the inspiration" data-cats="quantization">
   <div class="cr-card-header">
@@ -986,7 +1012,7 @@ gemmaclaw chat</code></pre>
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" target="_blank" rel="noopener">The 4B class of 2026 (benchmark)</a></h4>
-      <span class="cr-score cr-score-high">+200</span>
+      <span class="cr-score cr-score-high">+208</span>
     </div>
     <div class="cr-meta">
       <span class="cr-author">u/FederalAnalysis420</span>
@@ -996,8 +1022,25 @@ gemmaclaw chat</code></pre>
     </div>
   </div>
   <p class="cr-summary">Bench 2 from my 18GB M3 Pro. Last week was specialists vs generalists at 7-8B (which I hosed by giving thinking models a 128-token budget, so half the post was an apology). This week: the 4B class of 2026, every model released or actively-current at ...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Pristine-Woodpecker (+102)</span><span class="cr-comment-text">I am confused. If you are punishing models that want to think, why not just disable thinking to begin with?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Dabber43 (+57)</span><span class="cr-comment-text">Isn't gemma 4b double the size of qwen 4b</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Sufficient-Bid3874 (+44)</span><span class="cr-comment-text">Yeah it's only 4b active not total, not sure why it was included. E2B would be more relevant</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Pristine-Woodpecker (+98)</span><span class="cr-comment-text">I am confused. If you are punishing models that want to think, why not just disable thinking to begin with?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Dabber43 (+57)</span><span class="cr-comment-text">Isn't gemma 4b double the size of qwen 4b</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Sufficient-Bid3874 (+46)</span><span class="cr-comment-text">Yeah it's only 4b active not total, not sure why it was included. E2B would be more relevant</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="introducing the ibm granite 4.1 family of models (3b/8b/30b) link post. the discussion is mostly in the comments. target: qwen gemma interesting in a few use cases. glad there's still some competition, hopefully they continue improvi also released : ***claiming to beat frontie very weak on benchmarks fwiw. 30b scored 15 on aa index. equal to the non-reasoning scores of gemma" data-cats="general">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sz23wn" target="_blank" rel="noopener">Introducing the IBM Granite 4.1 family of models (3B/8B/30B)</a></h4>
+      <span class="cr-score cr-score-high">+205</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/abkibaarnsit</span>
+      <span class="cr-date">2026-04-29</span>
+      <span class="cr-flair">New Model</span>
+      <span class="cr-cat-badge">General</span>
+    </div>
+  </div>
+  <p class="cr-summary">Link post. The discussion is mostly in the comments. Target:</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/sine120 (+55)</span><span class="cr-comment-text">Interesting in a few use cases. Glad there's still some competition, hopefully they continue improving.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/abkibaarnsit (+32)</span><span class="cr-comment-text">Also released : Claiming to beat frontier models on Benchmarks</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Middle_Bullfrog_6173 (+26)</span><span class="cr-comment-text">Very weak on benchmarks FWIW. 30B scored 15 on AA index. Equal to the non-reasoning scores of Gemma 4 E4B and Qwen 3.5 2B.</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1sz23wn" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="bonsai models are pure hype: bonsai-8b is much dumber than gemma-4-e2b i'm using the fork for bonsai, regular llama.cpp for gemma. without embedding parameters: gemma 4 has 2.3b at 4.8 bpw (q4\k\m) = 1104 mb bonsai-8b has 6.95b at 1.125 bpw (q1\0) = 782 mb (only 29% smaller) i could've gone with a smaller quant of gemma 4, it's just conventional wisdom to not push small models be… quantization inference benchmarking rag google meta-llama gemma indeed, it should be noted that bonsai was built on " data-cats="quantization">
   <div class="cr-card-header">
@@ -1105,7 +1148,7 @@ gemmaclaw chat</code></pre>
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxn7x2" target="_blank" rel="noopener">Local model on coding has reached a certain threshold to be feasible for real work</a></h4>
-      <span class="cr-score cr-score-mid">+99</span>
+      <span class="cr-score cr-score-mid">+107</span>
     </div>
     <div class="cr-meta">
       <span class="cr-author">u/Exciting-Camera3226</span>
@@ -1115,7 +1158,7 @@ gemmaclaw chat</code></pre>
     </div>
   </div>
   <p class="cr-summary">edits to call out some information: \- All local model uses \`Q4\K\M\` quantization with \`llama.cpp\` engine \- Main factor contribute to difference with Qwen's official post (59% vs 38%) is probably benchmark task timeout used, then quantization, h...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/false79 (+23)</span><span class="cr-comment-text">People who know what they are doing with local models have been doing real work for a while now. I'm talking about the devs who know what aspects of their role is manually repetative and automating it...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/alrojo (+16)</span><span class="cr-comment-text">How aggresive are your timeouts? At 1.9 tokens per second that is very slow generation.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cygn (+14)</span><span class="cr-comment-text">so the gap between Qwen's official post (59.3) and what you measured (38.2) for 27b is purely because of the timeout? I still wonder if they have benchmaxxed terminal bench 2.0. Would love to see some...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/false79 (+29)</span><span class="cr-comment-text">People who know what they are doing with local models have been doing real work for a while now. I'm talking about the devs who know what aspects of their role is manually repetative and automating it...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/alrojo (+17)</span><span class="cr-comment-text">How aggresive are your timeouts? At 1.9 tokens per second that is very slow generation.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cygn (+13)</span><span class="cr-comment-text">so the gap between Qwen's official post (59.3) and what you measured (38.2) for 27b is purely because of the timeout? I still wonder if they have benchmaxxed terminal bench 2.0. Would love to see some...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sxn7x2" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="running qwen3.6-35b-a3b locally for coding agent: my setup &amp;amp; working config # hardware |component|details| |:-|:-| |machine|macbook pro (mac14,6)| |chip|apple m2 max — 12-core cpu (8p + 4e)| |memory|64 gb unified memory| |storage|512 gb ssd| |os|macos 15.7 (sequoia)| # ai agent setup i'm using the pi coding agent as my primary development assistant. it's a local-first ai coding… hardware quantization inference agents openai anthropic google meta-llama qwen gemma i’m happy to see pi getti" data-cats="apple-silicon laptop quantization">
@@ -1237,23 +1280,6 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ttkciar (+46)</span><span class="cr-comment-text">Regarding the low Gemma 4 scores: This might be hitting the Gemma 4 tool-calling problem, where inference stops prematurely just before a tool-call. Both Google and llama.cpp have issued bug-fixes for...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/UnifiedFlow (+30)</span><span class="cr-comment-text">Its pretty annoying how everyone thinks they know how to run testing. I come from a nuclear reactor testing background and I cringe at the test setups people are using and then confidently reporting r...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ambient_temp_xeno (+24)</span><span class="cr-comment-text">I can't help but think you're doing science wrong.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sr2wid" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="nvidia rtx 3090 vs intel arc pro b70 llama.cpp benchmarks just sharing the results from experimenting with the b70 on my setup.... these results compare three `llama.cpp` execution paths on the same machine: rtx 3090 (vulkan) on nixos host, using main llama.cpp repo (compiled on 4/21/2026) arc pro b70 (vulkan) on nixos host, using main llama.cpp repo (compiled on 4/21/2026) * arc pro b70 (sycl) inside an ubuntu 24.04 docker contain… hardware quantization inference benchmarking meta-llama qwen ge" data-cats="high-gpu quantization">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1st6lp6" target="_blank" rel="noopener">Nvidia RTX 3090 vs Intel Arc Pro B70 llama.cpp Benchmarks</a></h4>
-      <span class="cr-score cr-score-mid">+69</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/tovidagaming</span>
-      <span class="cr-date">2026-04-23</span>
-      <span class="cr-flair">Discussion</span>
-      <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
-    </div>
-  </div>
-  <p class="cr-summary">Just sharing the results from experimenting with the B70 on my setup.... These results compare three `llama.cpp` execution paths on the same machine: RTX 3090 (Vulkan) on NixOS host, using main llama.cpp repo (compiled on 4/21/2026) Arc Pro B70 (Vulk...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PassengerPigeon343 (+22)</span><span class="cr-comment-text">3090 still the top value play, incredible</span></div><div class="cr-comment"><span class="cr-comment-meta">u/AbsoluteHedonn (+19)</span><span class="cr-comment-text">NixOS mentioned</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tovidagaming (+7)</span><span class="cr-comment-text">We expect the 3090 to be at least 50% faster based on memory bandwidth: 936.2 GB/s vs 608.0 GB/s. That would be -33% slower for the B70 in my table. Ignoring Llama-2-7B, which seems to be broken, the ...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1st6lp6" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
 <div class="cr-card" data-search="hard freakin' decision..blackwell 96g or mac studio 256g edit: okokok. blackwell all the way. new, at mc or newegg or where ever and more tokens than my face can handle. thanks guys. i was close to pulling that apple.com trigger. you saved me. edit again: i think it's the max-q for me. central computers has them for 8999 and maybe 200 off that for doing ach. no tax charged for my state either which is : hardware rag microcenter is selling the rtx 6000 pros with 96gb for $9300 brand new. why are " data-cats="apple-silicon">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -1288,6 +1314,23 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/TheRealMasonMac (+31)</span><span class="cr-comment-text">GLM-5.1 being cheaper than Haiku is still hilarious to me.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/SnooPaintings8639 (+26)</span><span class="cr-comment-text">I would be very disappointed with D4 Flash if it wasnt MUCH better than haiku. I don't know how, but I have quite high expectations for this model</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Caffdy (+16)</span><span class="cr-comment-text">&amp;gt;But we have many tools with pretty complex input schemas can you gives an example, because the jump from Haiku (which probably is in the same range as Qwen 27/35B or Gemma4 in terms of size) to D4...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1suiruw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
+<div class="cr-card" data-search="nvidia rtx 3090 vs intel arc pro b70 llama.cpp benchmarks just sharing the results from experimenting with the b70 on my setup.... these results compare three `llama.cpp` execution paths on the same machine: rtx 3090 (vulkan) on nixos host, using main llama.cpp repo (compiled on 4/21/2026) arc pro b70 (vulkan) on nixos host, using main llama.cpp repo (compiled on 4/21/2026) * arc pro b70 (sycl) inside an ubuntu 24.04 docker contain… hardware quantization inference benchmarking meta-llama qwen ge" data-cats="high-gpu quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1st6lp6" target="_blank" rel="noopener">Nvidia RTX 3090 vs Intel Arc Pro B70 llama.cpp Benchmarks</a></h4>
+      <span class="cr-score cr-score-mid">+67</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/tovidagaming</span>
+      <span class="cr-date">2026-04-23</span>
+      <span class="cr-flair">Discussion</span>
+      <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Just sharing the results from experimenting with the B70 on my setup.... These results compare three `llama.cpp` execution paths on the same machine: RTX 3090 (Vulkan) on NixOS host, using main llama.cpp repo (compiled on 4/21/2026) Arc Pro B70 (Vulk...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PassengerPigeon343 (+22)</span><span class="cr-comment-text">3090 still the top value play, incredible</span></div><div class="cr-comment"><span class="cr-comment-meta">u/AbsoluteHedonn (+20)</span><span class="cr-comment-text">NixOS mentioned</span></div><div class="cr-comment"><span class="cr-comment-meta">u/RemarkableGuidance44 (+8)</span><span class="cr-comment-text">Intel Drivers are still new and they are updating them weekly. I got 4 x B70's they are great for larger models a bit slower of course but software is still new. Intel are also now going for the AI Da...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1st6lp6" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
 <div class="cr-card" data-search="qwen 3.6 vs 6 other models across 5 agent frameworks on m3 ultra i benchmarked qwen 3.6, qwen 3.5, and 5 other models across 5 agent frameworks on apple silicon — here's the full compatibility matrix hardware: apple m3 ultra, 256gb unified memory frameworks tested: hermes agent (64k stars), pydanticai, langchain, smolagents (huggingface), openclaude/anthropic sdk models tested: qwen 3.6 35b (brand new), qwen 3.5 35b, qwopus 27b, qwen 3.5 27b, llama… hardware quantization inference benchmarking a" data-cats="apple-silicon laptop quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -1304,6 +1347,23 @@ gemmaclaw chat</code></pre>
   <p class="cr-summary">I benchmarked Qwen 3.6, Qwen 3.5, and 5 other models across 5 agent frameworks on Apple Silicon — here's the full compatibility matrix Hardware: Apple M3 Ultra, 256GB unified memory Frameworks tested: Hermes Agent (64K stars), PydanticAI, LangChain, ...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Evening_Ad6637 (+8)</span><span class="cr-comment-text">The whole thing is kind of… weird… or a little chaotic. I mean, the results are very interesting, and you can clearly see a lot of effort went into this work, so of course, kudos to @OP It’s just a bi...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mr_Owner (+7)</span><span class="cr-comment-text">Unfair comparisons of mixed quants tbh</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Only-Fisherman5788 (+6)</span><span class="cr-comment-text">compatibility matrix is useful for &quot;will this even run&quot; but doesn't answer the production question: which of these framework+model combos actually produces correct outputs on the agentic task you care...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sojag2" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="introducing laguna xs.2 and laguna m.1 link post. the discussion is mostly in the comments. target: hardware quantization benchmarking good to see one more 30b range moe model. that seems honest benchmark(check the graph) xs.2 is currently out. 33ba3b ( m.1 still not open. 225b always cool to see more open weight models!" data-cats="apple-silicon quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sy6oxr" target="_blank" rel="noopener">Introducing Laguna XS.2 and Laguna M.1</a></h4>
+      <span class="cr-score cr-score-mid">+61</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/abkibaarnsit</span>
+      <span class="cr-date">2026-04-28</span>
+      <span class="cr-flair">New Model</span>
+      <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Link post. The discussion is mostly in the comments. Target:</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+17)</span><span class="cr-comment-text">Good to see one more 30B range MOE model. That seems honest benchmark(Check the graph)</span></div><div class="cr-comment"><span class="cr-comment-meta">u/abkibaarnsit (+13)</span><span class="cr-comment-text">XS.2 is currently out. 33BA3B ( M.1 still not open. 225BA23B Free on OpenRouter M.1 , XS.2</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+11)</span><span class="cr-comment-text">Always cool to see more open weight models!</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1sy6oxr" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="qwen3.5-4b|gemma4-e2b/e4b uncensored models comparison i had the idea of splitting the cross-entropy difference into two sums (positive and negative; or the ppl into two ratios &amp;gt;1 and &amp;lt;1) while doing ppl evals of uncensored ggufs. the inspiration came from looking at the area under the ppl ratio convergence plot (2nd graph) and thinking &quot;what if i scattered the positive and negative area in 2d?&quot;. after all: - negative delta =&amp;gt; predicted the… quantization fine-tunin" data-cats="quantization">
   <div class="cr-card-header">
@@ -1322,11 +1382,28 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/WhoRoger (+8)</span><span class="cr-comment-text">Lol I love this but I have no idea what most of that means lol. Td;dr? (Too dumb; didn't read)</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Embarrassed_Soup_279 (+5)</span><span class="cr-comment-text">hauhaucs models &quot;felt&quot; better compared to other uncensored models despite the degradation shown in the graphs... ive not tested the gemma models but with qwen3.5 it was pretty good. still don't know h...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Tryshea (+4)</span><span class="cr-comment-text">Thanks, An uncensored model should succeed at predicting the text more often than the base model (X axis) but never less often (Y axis). That's because we should just be &quot;unlocking knowledge&quot; without ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sokdvd" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="guys this is so fun! running my own models. i was having some trouble getting vllm going so dropped down to lm studio which i've used on my 24gb macbook air. i now have lm link across both laptops into the ai workstation rtx pro 6000 blackwell. and my phone on lm mini. it's so cool and i'm just getting started. currently have qwen3.5 9b going with qwen3.6 27b and 35b a3b downloading. going to play with some llamas to… hardware quantization inference meta-llama deepseek gemma good luck. these old" data-cats="apple-silicon laptop quantization">
+<div class="cr-card" data-search="llama.cpp's preliminary sm120 native nvfp4 mmq is merged and somehow we already got some ggufs for it! [ hardware quantization inference meta-llama gemma nvfp4 speaks the gpus native language. the blackwell tensor cores have fp4 math built directly into you have to use it with nvfp4 ggufs, q4 is still using regular mmq and mma yes, this pr just makes 50 series users with nvfp4 models prefill a lot faster" data-cats="apple-silicon mid-gpu quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1syjflw" target="_blank" rel="noopener">llama.cpp's Preliminary SM120 Native NVFP4 MMQ Is Merged</a></h4>
+      <span class="cr-score cr-score-mid">+58</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/ggonavyy</span>
+      <span class="cr-date">2026-04-29</span>
+      <span class="cr-flair">Resources</span>
+      <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">Mid-range GPU (8-16 GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">And somehow we already got some GGUFs for it!</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Bulky-Priority6824 (+13)</span><span class="cr-comment-text">nvfp4 speaks the gpus native language. The blackwell tensor cores have FP4 math built directly into the silicon so the model weights go in as is and the multiplication happens without any translation ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ggonavyy (+13)</span><span class="cr-comment-text">You have to use it with nvfp4 ggufs, q4 is still using regular mmq and mma</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ggonavyy (+9)</span><span class="cr-comment-text">Yes, this PR just makes 50 series users with nvfp4 models prefill a LOT faster</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1syjflw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="guys this is so fun! running my own models. i was having some trouble getting vllm going so dropped down to lm studio which i've used on my 24gb macbook air. i now have lm link across both laptops into the ai workstation rtx pro 6000 blackwell. and my phone on lm mini. it's so cool and i'm just getting started. currently have qwen3.5 9b going with qwen3.6 27b and 35b a3b downloading. going to play with some llamas to… hardware quantization inference meta-llama deepseek good luck. these old model" data-cats="apple-silicon laptop quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxjnv4" target="_blank" rel="noopener">Guys this is so fun!</a></h4>
-      <span class="cr-score cr-score-mid">+55</span>
+      <span class="cr-score cr-score-mid">+57</span>
     </div>
     <div class="cr-meta">
       <span class="cr-author">u/Perfect-Flounder7856</span>
@@ -1336,8 +1413,25 @@ gemmaclaw chat</code></pre>
     </div>
   </div>
   <p class="cr-summary">Running my own models. I was having some trouble getting vLLM going so dropped down to LM Studio which I've used on my 24GB MacBook Air. I now have LM Link across both laptops into the AI Workstation RTX Pro 6000 Blackwell. And my phone on LM Mini. I...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/jacek2023 (+24)</span><span class="cr-comment-text">Good luck. These old models are not best. Explore Huggingface to have some fun</span></div><div class="cr-comment"><span class="cr-comment-meta">u/rm-rf-rm (+14)</span><span class="cr-comment-text">Please see the Best LLMs megathread linked in the sidebar (and stickied currently)</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Guilty_Rooster_6708 (+11)</span><span class="cr-comment-text">Try out the gemma4 models!</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/jacek2023 (+25)</span><span class="cr-comment-text">Good luck. These old models are not best. Explore Huggingface to have some fun</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Guilty_Rooster_6708 (+13)</span><span class="cr-comment-text">Try out the gemma4 models!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/rm-rf-rm (+12)</span><span class="cr-comment-text">Please see the Best LLMs megathread linked in the sidebar (and stickied currently)</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sxjnv4" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="i stumbled on a gemma 4 chat template bug for tools and fixed it tldr: tool parameters using the common json schema pattern \`anyof: [$ref, null]\` are rendered into the prompt as empty \`type\` fields. this strips the useful schema information before the model sees it. \-- long, rambling version: gemma 4 was having issues with calling my custom mcp tool on &amp;gt;3 inference engines, while qwen3.5 and gpt-oss-20b were doing fine. i guessed it was either a chat… hardware quantization agents ope" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1syps6i" target="_blank" rel="noopener">I stumbled on a Gemma 4 chat template bug for tools and fixed it</a></h4>
+      <span class="cr-score cr-score-mid">+56</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/EntertainmentBroad43</span>
+      <span class="cr-date">2026-04-29</span>
+      <span class="cr-flair">Resources</span>
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">TLDR: tool parameters using the common JSON Schema pattern \`anyOf: [$ref, null]\` are rendered into the prompt as empty \`type\` fields. This strips the useful schema information before the model sees it. \-- Long, rambling version: Gemma 4 was havi...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/onil_gova (+8)</span><span class="cr-comment-text">is this why gemma 4 is struggling to make proper tool calls unlike qwen3.6?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/EntertainmentBroad43 (+6)</span><span class="cr-comment-text">yeah i saw this post when I was looking for people with similar incidences; if the tools that this person made includes composition, references, unions, or constraints that are not expressed as a dire...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/EntertainmentBroad43 (+5)</span><span class="cr-comment-text">Yeah I’m referring to the official Gemma 4 tool-calling format in Google’s docs. It renders tools as special declarations like &amp;lt;|tool&amp;gt;declaration:...&amp;lt;tool|&amp;gt; and calls like &amp;lt;|toolcall&amp;gt...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1syps6i" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="how to run a local coding agent with gemma 4 and pi | patrick loeber tutorial from the google guy, i use very similar setup (llama.cpp instead of lmstudio) inference agents google meta-llama qwen gemma gemma 4 was the best, for about 10 minutes after its release. still the best at visual understanding maybe if you're looking at gemma4:26b. 31b is still doing as well as qwen 3.6 and even better in som could you be more specific? what code are you working on?" data-cats="quantization">
   <div class="cr-card-header">
@@ -1441,22 +1535,22 @@ gemmaclaw chat</code></pre>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/100daggers_ (+17)</span><span class="cr-comment-text">Thanks for the honest part of the feedback. I agree the chat deletion icon can be improved, and I’ll clean that up in the next UI iteration. But calling it “AI-generated slop” is unfair. I’ve been wor...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/MalabaristaEnFuego (+6)</span><span class="cr-comment-text">What percentage of code does a person need to refactor before the code no longer becomes AI slop?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/KaroYadgar (+6)</span><span class="cr-comment-text">slop of Theseus jokes aside, I was mainly referring to how the UI reminded me of AI-generated frontends back in the day.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sw4qku" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="built myself a bit of a local llm workhorse. what's a good model to try out with llamacpp that will put my 56g of vram to good use? any other fun suggestions? link post. the discussion is mostly in the comments. target: hardware quantization inference meta-llama qwen did you forget why you built it? q8 qwen 3.6 27b, ideally via vllm so you can use mtp or dflash to get anywhere from 1.2-2x the speed qwen 3.6 27b cyankiwi awq-int4, running in v" data-cats="quantization">
+<div class="cr-card" data-search="qwen 3.6 27b on strix halo 128gb: any experiences? i'd jump on runpod and ssh in to test my workloads, but they don't have it. would love to know how well this runs, particularly as context approaches a full 256k. thanks! quantization inference meta-llama qwen gemma i didn't like the performance comparing it to 35b moe for the desnse 27b numbers are: 10 - 11 t/s fo the results are great, but it's slow as heck. i use 35b-a3b for that reason. very slow depending on quant, 7-8tps. not convinced the" data-cats="laptop quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxd2sc" target="_blank" rel="noopener">Built myself a bit of a local llm workhorse. What's a good model to try out with llamacpp that will put my 56G of VRAM t</a></h4>
-      <span class="cr-score ">+41</span>
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxbvux" target="_blank" rel="noopener">Qwen 3.6 27B on Strix Halo 128GB: any experiences?</a></h4>
+      <span class="cr-score ">+40</span>
     </div>
     <div class="cr-meta">
-      <span class="cr-author">u/SBoots</span>
+      <span class="cr-author">u/boutell</span>
       <span class="cr-date">2026-04-27</span>
       <span class="cr-flair">Question | Help</span>
-      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+      <span class="cr-cat-badge">Laptops</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Link post. The discussion is mostly in the comments. Target:</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Long_comment_san (+63)</span><span class="cr-comment-text">Did you forget why you built it?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/oxygen_addiction (+23)</span><span class="cr-comment-text">Q8 Qwen 3.6 27B, ideally via VLLM so you can use MTP or Dflash to get anywhere from 1.2-2x the speed for token generation.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/specify_ (+5)</span><span class="cr-comment-text">Qwen 3.6 27B cyankiwi AWQ-INT4, running in vLLM with tensor parallelism and speculative decoding, using opencode with oh-my-openagent. Clone a github repo like llama.cpp and ask it to do a full Rust p...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1sxd2sc" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+  <p class="cr-summary">I'd jump on runpod and ssh in to test my workloads, but they don't have it. Would love to know how well this runs, particularly as context approaches a full 256K. Thanks!</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Willing-Toe1942 (+38)</span><span class="cr-comment-text">I didn't like the performance comparing it to 35B MoE for the desnse 27B numbers are: 10 - 11 T/S for generation near 300 for prompt processing strixhalo laptop tdp maximum to 80watt</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tecneeq (+18)</span><span class="cr-comment-text">The results are great, but it's slow as heck. I use 35b-a3b for that reason.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Sixstringsickness (+13)</span><span class="cr-comment-text">Very slow depending on quant, 7-8tps. Not convinced the improvement in intelligence is worth the trade off in performance over 35b 3a. Gemma4 using draft model and spec decoding is 13-20tps using q4 k...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1sxbvux" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="opencode with gemma 26b i was testing opencode and roo code with gemma 26b on llama.cpp yesterday for about 10 hours. i was able to make progress on my project, both solutions work. but: opencode is kind of fucked up at the moment, because of that there is often long prompt processing.. roo code works correctly, but it has different issues (thinking takes longer, probably opencode has better prompts). the problem with o… quantization inference google meta-llama gemma if you don't have a supercom" data-cats="quantization">
   <div class="cr-card-header">
@@ -1474,23 +1568,6 @@ gemmaclaw chat</code></pre>
   <p class="cr-summary">I was testing OpenCode and Roo Code with Gemma 26B on llama.cpp yesterday for about 10 hours. I was able to make progress on my project, both solutions work. But: OpenCode is kind of fucked up at the moment, because of that there is often long prompt...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/sine120 (+12)</span><span class="cr-comment-text">If you don't have a supercomputer, use Pi ( The system prompt is a lot smaller, saving you context and PP time. I haven't used it with gemma much yet, but with Qwen3.6 it's been great.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Haiku-575 (+7)</span><span class="cr-comment-text">I've been testing with Qwen3.6 as well. It is, in fact, great. is the same thing if you want a less shitty URL.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Ill-Fishing-1451 (+4)</span><span class="cr-comment-text">Opencode prunes context sometimes, which causes reprocessing the whole cache. This is annoying for llama.cpp backend.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sqp8pp" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
-<div class="cr-card" data-search="qwen 3.6 27b on strix halo 128gb: any experiences? i'd jump on runpod and ssh in to test my workloads, but they don't have it. would love to know how well this runs, particularly as context approaches a full 256k. thanks! quantization inference meta-llama qwen gemma i didn't like the performance comparing it to 35b moe for the desnse 27b numbers are: 10 - 11 t/s fo the results are great, but it's slow as heck. i use 35b-a3b for that reason. very slow depending on quant, 7-8tps. not convinced the" data-cats="laptop quantization">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sxbvux" target="_blank" rel="noopener">Qwen 3.6 27B on Strix Halo 128GB: any experiences?</a></h4>
-      <span class="cr-score ">+39</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/boutell</span>
-      <span class="cr-date">2026-04-27</span>
-      <span class="cr-flair">Question | Help</span>
-      <span class="cr-cat-badge">Laptops</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
-    </div>
-  </div>
-  <p class="cr-summary">I'd jump on runpod and ssh in to test my workloads, but they don't have it. Would love to know how well this runs, particularly as context approaches a full 256K. Thanks!</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Willing-Toe1942 (+35)</span><span class="cr-comment-text">I didn't like the performance comparing it to 35B MoE for the desnse 27B numbers are: 10 - 11 T/S for generation near 300 for prompt processing strixhalo laptop tdp maximum to 80watt</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tecneeq (+17)</span><span class="cr-comment-text">The results are great, but it's slow as heck. I use 35b-a3b for that reason.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Sixstringsickness (+15)</span><span class="cr-comment-text">Very slow depending on quant, 7-8tps. Not convinced the improvement in intelligence is worth the trade off in performance over 35b 3a. Gemma4 using draft model and spec decoding is 13-20tps using q4 k...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1sxbvux" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="speculative decoding with gemma-4-31b + gemma-4-e2b enables 120 - 200 tok/s output speed for specific tasks so for my project i was using up until now either gemini 3 / 2.5 flash or flash-lite. all my use cases are not agentic, simply llm workflows for atomic tasks like extracting references from the law, classifying, adjusting titles to nominative case and so on. all this happens in non-english (lt) language, that's one of the reasons i originally used google models, as multilingual quality is " data-cats="quantization">
   <div class="cr-card-header">
@@ -1633,55 +1710,61 @@ gemmaclaw chat</code></pre>
 
     <!-- Section 2b: Curated Field Notes -->
     <section id="field-notes">
-      <div class="field-notes"><h2>Field Notes — 2026-04-29</h2>
-<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest 14 Gemma-mentioning posts and their top comment threads. This is community signal, not a benchmark, and confidence is <strong>medium</strong> unless noted.</p>
+      <div class="field-notes"><h2>Field Notes — 2026-04-30</h2>
+<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest 14 Gemma-mentioning posts (5 net-new since 2026-04-29) and their top comment threads. Confidence is <strong>medium</strong> unless noted, since this is community signal rather than a controlled benchmark.</p>
+<h3>Headline this week</h3>
+<p>Two findings reshape how you should run Gemma 4 today. First, llama.cpp's preliminary SM120 native NVFP4 MMQ landed, and three Gemma 4 31B-it NVFP4 GGUFs are already live on Hugging Face. On consumer Blackwell (RTX 5xxx) that means prefill is a lot faster because weights speak the GPU's native FP4 language with no translation step. Second, a contributor traced the long-running &quot;Gemma 4 is bad at tools&quot; complaint to a real chat-template bug rather than a model deficiency, with a candidate fix already on the Hugging Face discussion. If your agent stack has been flaky, the runtime, not Gemma, was likely the bottleneck.</p>
 <h3>Best current setup (today)</h3>
 <ul class="setup-list">
-<li><strong>Mid-to-high GPU (24+ GB VRAM):</strong> Gemma 4 31B Dense at Q6_K or higher remains the strongest single-GPU pick for general tasks and visual understanding. Drop to Q4 only if you must, and expect noticeably more glitches in agentic workflows.</li>
-<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Gemma 4 26B MoE at a good quant (Q5/Q6) holds up for local coding and chat. Q3 should be treated as gambling, not a working setup, when precision matters.</li>
-<li><strong>CPU-only / Pi / Apple Silicon at the low end:</strong> Gemma 4 E4B (9.6 GB on disk, effectively 9B-A4B) is the practical workhorse. It runs at 140+ tok/s on a Ryzen 9 5900X and is the default we recommend for non-GPU rigs.</li>
-<li><strong>Apple Silicon (32-64 GB unified):</strong> Gemma 4 26B MoE via Ollama Metal continues to perform; 48+ GB can move up to 31B Dense.</li>
+<li><strong>RTX 5xxx (Blackwell consumer):</strong> if you have an SM120-class card, switch to a Gemma 4 31B-it NVFP4 GGUF and an llama.cpp build that includes <a href="https://github.com/ggml-org/llama.cpp/pull/22196" target="_blank" rel="noopener">PR #22196</a>. Q4_K_M still falls back to the regular MMQ/MMA path, so you only see the speedup with NVFP4 weights. Early reports describe a meaningful prefill jump versus 35B-UD_Q4_XL on dual 5060 Ti 16GB rigs. (<a href="https://reddit.com/r/LocalLLaMA/comments/1syjflw" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Mid-to-high single GPU (24+ GB VRAM, non-Blackwell):</strong> Gemma 4 31B Dense at Q5_K_M or Q6_K is still the strongest single-card choice for general work and visual understanding. Drop to Q4 only if you have to, and expect more agentic-loop failures once you do.</li>
+<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Gemma 4 26B MoE at Q5_K_M holds up for local coding and chat. Treat Q3 as gambling for any workflow that depends on consistent JSON output.</li>
+<li><strong>CPU-only / Pi / Apple Silicon at the low end:</strong> Gemma 4 E4B (effectively 9B-A4B on disk, ~9.6 GB) is still the practical workhorse. It runs at 140+ tok/s on a Ryzen 9 5900X and is the sane default for non-GPU rigs.</li>
+<li><strong>Apple Silicon (32-64 GB unified):</strong> Gemma 4 26B MoE via Ollama Metal continues to perform; 48+ GB headroom can move up to 31B Dense, with the caveat from Apr 29 that MLX has not pulled ahead of GGUF for Gemma 4 yet.</li>
 </ul>
 <h3>What works</h3>
 <ul class="setup-list">
-<li><strong>Visual understanding:</strong> Gemma 4 is consistently called out as still the strongest open model for image+text, even by users who otherwise prefer Qwen 3.6 for coding. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Quality on real coding tasks:</strong> Gemma 4 31B is reported to still match or beat Qwen 3.6 on some applications when the harness, quant, and context are tuned. The headline story is Qwen 3.6 27B catching up, not Gemma 4 falling off. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Speculative decoding pairing:</strong> Gemma 4 31B paired with Gemma 4 E2B as a draft model continues to deliver 120-200 tok/s on specific tasks for users with the headroom. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sw782p" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Pi / coding agent walkthrough:</strong> Patrick Loeber's tutorial on running a Gemma 4 coding agent on a Pi is now circulating; commenters note the same workflow generalizes to llama.cpp, not just LM Studio. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Translation and creative writing.</strong> This week's most upvoted thread (606 score) pulls together what people use Gemma 4 <em>for</em>: the model is consistently called the open-weights pick for translation and long-form creative output, while Qwen 3.6 leads on coding and game generation. (<a href="https://reddit.com/r/LocalLLaMA/comments/1syt38w" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Visual understanding.</strong> Gemma 4 remains the strongest open multimodal answer for image plus text, even from users who otherwise prefer Qwen 3.6 for code-heavy work. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Speculative decoding pairing.</strong> Gemma 4 31B with Gemma 4 E2B as a draft model still delivers 120-200 tok/s on suitable tasks for users with the headroom. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sw782p" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Native FP4 on Blackwell.</strong> The new NVFP4 path lets RTX 50-series cards skip the dequantize-then-multiply step entirely, since the tensor cores have FP4 math in silicon. The PR is preliminary, so expect rough edges, but this is the first time a full open-weights stack runs end-to-end at SM120 native FP4. (<a href="https://reddit.com/r/LocalLLaMA/comments/1syjflw" target="_blank" rel="noopener">source</a>)</li>
 </ul>
 <h3>Known limits</h3>
 <ul class="setup-list">
-<li><strong>Local coding is not yet a Claude Code substitute.</strong> A widely-upvoted writeup (806+ score) argues that even Gemma 4 31B and Qwen 3.6 27B lose enough productivity vs Claude Code that the trade-off is hard to justify for serious work. Calibrate expectations accordingly. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Quant floor matters for agents.</strong> With agentic workflows that issue hundreds of tool calls, low quants (Q3, sometimes Q4) introduce small structural glitches (stray characters, malformed JSON) that break the run. Default to Q5_K_M or higher when you can. (<a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Safety filters on E2B.</strong> Gemma-4-E2B's safety filters have been flagged as overly aggressive for emergency/medical-style prompts. Plan for an unfiltered or alternate model if that is your use case. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sr35pk" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>E4B size confusion.</strong> Gemma 4 E4B is a 9B-A4B MoE on disk, not a 4B dense model. Comparisons against true 4B competitors are not apples to apples. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Tool calling has had a real bug, not just bad vibes.</strong> A contributor traced Gemma 4's intermittent MCP/OpenAI tool failures to its Jinja chat template not being a faithful JSON Schema renderer. JSON shapes like `anyOf: [$ref, null]` (the standard &quot;nullable reference&quot; pattern) collapse to empty `type` fields before the model ever sees them. A patched template lives at <a href="https://huggingface.co/google/gemma-4-31B-it/discussions/91" target="_blank" rel="noopener">HF discussion 91</a>; until it lands officially, prefer flat tool schemas and avoid `$ref`/`anyOf` compositions. This finally explains why Qwen 3.6 has felt more reliable as an agent than Gemma 4. (<a href="https://reddit.com/r/LocalLLaMA/comments/1syps6i" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Translation quality drops fast on smaller languages.</strong> A native Latvian speaker reports Gemma 4 31B understands the input fine but produces 2010-Google-Translate-grade output, with multiple spelling errors per word and brutal idiom transfer. Treat the &quot;great at translation&quot; reputation as English/Mandarin/Spanish-class, not universal. (<a href="https://reddit.com/r/LocalLLaMA/comments/1syt38w" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Local coding still trails Claude Code on long horizons.</strong> The widely-shared &quot;I'm done with using local LLMs for coding&quot; essay (806 score) argues that even Gemma 4 31B and Qwen 3.6 27B lose enough productivity vs Claude Code that the trade-off is hard to justify for serious deadline work. Calibrate expectations. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Quant floor matters more for agents than for chat.</strong> With workflows that fire hundreds of tool calls, Q3 (and sometimes Q4) introduces small structural glitches (stray characters, malformed JSON) that break a run. Default to Q5_K_M or higher when budget allows. (<a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Safety filters on E2B.</strong> Gemma-4-E2B's safety filters remain too aggressive for emergency or medical-shape prompts. Plan an unfiltered or alternate model for those use cases. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sr35pk" target="_blank" rel="noopener">source</a>)</li>
 </ul>
 <h3>Open questions</h3>
 <ul class="setup-list">
-<li><strong>Qwen 3.6 27B vs Gemma 4 31B for coding:</strong> The community is mid-split on which is better, but tooling, quant, and context length keep changing the answer. We will keep an eye on harness-controlled comparisons.</li>
-<li><strong>Gemma 4 26B MoE quant sweet spot:</strong> GGUF benchmarks are still landing. Q4_K_M vs Q5_K_M vs Q6_K trade-offs on consumer GPUs deserve their own controlled run on our benchmark harness.</li>
-<li><strong>Strix Halo and other unified-memory APUs:</strong> Early reports on AMD Strix Halo 128GB suggest viable 27-31B dense inference, but day-2 numbers are sparse. Worth tracking for the late-2026 hardware cycle.</li>
+<li><strong>Will the NVFP4 path beat regular Q4 on inference, or only prefill?</strong> Early commentary is that the speedup is concentrated in prefill on consumer Blackwell. We need controlled before/after numbers on tokens-per-second for both prefill and decode at typical chat and agent context lengths.</li>
+<li><strong>How much of Gemma 4's &quot;weak agent&quot; reputation evaporates with the chat-template fix?</strong> Side-by-side reruns of the recent OpenCode comparisons with the patched template will tell us whether Qwen 3.6's lead on tool calling was model quality or template plumbing.</li>
+<li><strong>Gemma 4 26B MoE quant sweet spot.</strong> GGUF benchmarks for the MoE keep landing piecemeal. Q4_K_M vs Q5_K_M vs Q6_K trade-offs on consumer GPUs deserve a controlled run on our benchmark harness.</li>
+<li><strong>Strix Halo and unified-memory APUs.</strong> Reports on AMD Strix Halo 128GB suggest viable 27-31B dense inference, but day-2 numbers are still sparse. Worth tracking through the late-2026 hardware cycle.</li>
+<li><strong>Granite 4.1 and Laguna XS.2/M.1 vs Gemma 4 at the same parameter count.</strong> Two new model families dropped this week; neither has community-validated numbers yet, and the question is whether either lands on the Gemma 4 frontier or stays niche. (<a href="https://reddit.com/r/LocalLLaMA/comments/1sz23wn" target="_blank" rel="noopener">Granite 4.1</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1sy6oxr" target="_blank" rel="noopener">Laguna</a>)</li>
 </ul>
 <h3>Sources</h3>
-<p>The 14 newly updated Gemma-mentioning posts driving this update:</p>
+<p>The 14 most relevant Gemma-mentioning posts driving this update, with the 5 newest first:</p>
 <ul class="setup-list">
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1syps6i" target="_blank" rel="noopener">I stumbled on a Gemma 4 chat template bug for tools and fixed it</a> (Apr 29, 2026)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1syjflw" target="_blank" rel="noopener">llama.cpp's Preliminary SM120 Native NVFP4 MMQ Is Merged</a> (Apr 29, 2026)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1syt38w" target="_blank" rel="noopener">What it feels like to have to have Qwen 3.6 or Gemma 4 running locally</a> (Apr 29, 2026)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sz23wn" target="_blank" rel="noopener">Introducing the IBM Granite 4.1 family of models (3B/8B/30B)</a> (Apr 29, 2026)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sy6oxr" target="_blank" rel="noopener">Introducing Laguna XS.2 and Laguna M.1</a> (Apr 28, 2026)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" target="_blank" rel="noopener">How to run a local coding agent with Gemma 4 and Pi (Patrick Loeber)</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" target="_blank" rel="noopener">The 4B class of 2026 (benchmark)</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxch39" target="_blank" rel="noopener">The 4B class of 2026</a></li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" target="_blank" rel="noopener">Tested how OpenCode works with self-hosted LLMs (Qwen 3.5/3.6, Gemma 4, Nemotron 3, GLM-4.7)</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ssadey" target="_blank" rel="noopener">Youtuber tries Qwen 3.5 35B, Qwen 3.6 35B, and Gemma 4 27B on large JS reverse engineering</a></li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxqa2c" target="_blank" rel="noopener">I'm done with using local LLMs for coding</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sw782p" target="_blank" rel="noopener">Speculative decoding with Gemma-4-31B + Gemma-4-E2B</a></li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxzqry" target="_blank" rel="noopener">Qwen 3.6 27B BF16 vs Q4_K_M vs Q8_0 GGUF evaluation</a></li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxn7x2" target="_blank" rel="noopener">Local model on coding has reached a certain threshold to be feasible for real work</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxd2sc" target="_blank" rel="noopener">Built myself a bit of a local LLM workhorse (56 GB VRAM)</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxbvux" target="_blank" rel="noopener">Qwen 3.6 27B on Strix Halo 128GB: any experiences?</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1st3m8y" target="_blank" rel="noopener">Qwen 3.6 is actually useful for vibe-coding, and way cheaper than Claude</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1swifke" target="_blank" rel="noopener">Switched from Qwen 3.6 35B-A3B to Qwen 3.6 27B mid-coding</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ss7bcs" target="_blank" rel="noopener">Is a high-end private local LLM setup worth it?</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sxjnv4" target="_blank" rel="noopener">Guys this is so fun!</a></li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sy6xoo" target="_blank" rel="noopener">Something from Mistral (Vibe) tomorrow</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1spn7zh" target="_blank" rel="noopener">Gemma 4 - MLX doesn't seem better than GGUF</a></li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1sr35pk" target="_blank" rel="noopener">Gemma-4-E2B's safety filters make it unusable for emergencies</a></li>
 </ul>
-<p>The full set of 61 community reports lives in the Community Reports section above, filterable by hardware category.</p>
-<p>_Last updated: 2026-04-29. Confidence: medium. Next update fires when the daily Gemma4 research cron flags notable new findings._</p></div>
+<p>The full set of 65 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
+<p><em>Last updated: 2026-04-30. Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div>
     </section>
 
     <!-- Section 3: Benchmark Results -->
@@ -2865,6 +2948,21 @@ gemmaclaw chat</code></pre>
 
     // Initially hide all model details
     document.querySelectorAll('.model-detail').forEach(d => d.style.display = 'none');
+
+    // Active nav highlight on scroll
+    const sections = document.querySelectorAll('section[id]');
+    const navLinks = document.querySelectorAll('.nav-links a[href^="#"]');
+    function updateActiveNav() {
+      let current = '';
+      sections.forEach(s => {
+        if (window.scrollY >= s.offsetTop - 80) current = s.id;
+      });
+      navLinks.forEach(a => {
+        a.classList.toggle('active', a.getAttribute('href') === '#' + current);
+      });
+    }
+    window.addEventListener('scroll', updateActiveNav, { passive: true });
+    updateActiveNav();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Refresh weekly Gemma 4 field notes with two headline shifts: llama.cpp PR #22196 lands preliminary SM120 native NVFP4 MMQ (three Gemma 4 31B-it NVFP4 GGUFs already on HF for RTX 50-series users), and a contributor traced Gemma 4's "weak at tools" reputation to a chat-template Jinja bug (anyOf+\$ref schemas collapsing) with a candidate fix on the HF discussion.
- Top community thread reframes Gemma 4 as the open pick for translation and creative writing (Qwen 3.6 leads on coding); a Latvian speaker reports Gemma 4 collapses on smaller languages, so the "great at translation" reputation should be qualified as English/Mandarin/Spanish-class.
- Hardware report set refreshed to 65 entries (community comment scores updated; +5 net-new posts: Laguna XS/M, NVFP4 GGUFs, chat-template bug, Granite 4.1, translation/creative thread). Sources list in field-notes reordered to surface the 5 newest first.
- Generator now supports underscore-italic in field-notes markdown (gated by non-word-char lookaround so identifiers like \`Q5_K_M\` stay intact). Theme stays white per established standard, scrollable nav with active-on-scroll highlight intact.

## Test plan
- [x] \`pnpm check:changed\` typecheck/lint/import-cycles all green
- [x] Tests fail with the documented parallel-flake set (gateway-server startup-config-recovery, amazon-bedrock 3, google video 2, google music 1); each verified to pass when run in isolation per gemmaclaw-testing.md
- [x] Site regenerates cleanly: 65 community reports, 8 benchmark results, no raw markdown leaks, white theme, scrollable active-nav, NVFP4 / chat-template / translation content present
- [ ] CI green on PR
- [ ] GitHub Pages deploy succeeds
- [ ] Chrome MCP production verification on https://gemmaclaw.github.io/gemmaclaw/ (desktop + mobile)