### PR TITLE
site: fix mobile nav brand colliding with first link

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -1034,16 +1034,18 @@ CSS = """
     .nav-inner {
       max-width: 960px; margin: 0 auto;
       display: flex; align-items: center; justify-content: space-between;
+      gap: 1rem;
       padding: 0.75rem 1.5rem;
     }
     .logo {
       font-size: 1.1rem; font-weight: 700; color: var(--accent);
-      text-decoration: none;
+      text-decoration: none; flex-shrink: 0;
     }
     .nav-links {
       display: flex; gap: 1.5rem;
       overflow-x: auto; -webkit-overflow-scrolling: touch;
       scrollbar-width: none; -ms-overflow-style: none;
+      min-width: 0;
     }
     .nav-links::-webkit-scrollbar { display: none; }
     .nav-links a {

--- a/site/index.html
+++ b/site/index.html
@@ -41,16 +41,18 @@
     .nav-inner {
       max-width: 960px; margin: 0 auto;
       display: flex; align-items: center; justify-content: space-between;
+      gap: 1rem;
       padding: 0.75rem 1.5rem;
     }
     .logo {
       font-size: 1.1rem; font-weight: 700; color: var(--accent);
-      text-decoration: none;
+      text-decoration: none; flex-shrink: 0;
     }
     .nav-links {
       display: flex; gap: 1.5rem;
       overflow-x: auto; -webkit-overflow-scrolling: touch;
       scrollbar-width: none; -ms-overflow-style: none;
+      min-width: 0;
     }
     .nav-links::-webkit-scrollbar { display: none; }
     .nav-links a {


### PR DESCRIPTION
## Summary
- Mobile screenshot from PR #63 showed "GemmaclawSetup" rendering with no gap between the brand and the first nav link.
- Root cause: \`.nav-inner\` used \`justify-content: space-between\` but had no \`gap\`. Once \`.nav-links\` overflowed, the flex container ran out of free space and the logo collided with the first link.
- Adds \`gap: 1rem\` on \`.nav-inner\`, \`flex-shrink: 0\` on \`.logo\`, and \`min-width: 0\` on \`.nav-links\` so the brand always has breathing room and the nav scrolls horizontally without squeezing the logo.

## Test plan
- [x] Regenerate site, confirm only 6 lines change (3 in generator, 3 in rendered HTML)
- [ ] CI green
- [ ] GitHub Pages deploy succeeds
- [ ] Chrome MCP mobile (390x844) screenshot shows brand and first nav link with daylight between them