### PR TITLE
sandbox: auto-mount ~/.gemmaclaw/shared in Docker containers

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -924,6 +924,7 @@ corepack enable &amp;&amp; pnpm install
 pnpm build
 npm install -g .</code></pre></div>
       <p>Requires Node.js 22+. Docker is recommended for sandboxed tool execution but not required.</p>
+      <p><strong>Shared files:</strong> When Docker sandbox is enabled, <code>~/.gemmaclaw/shared/</code> on your machine is automatically mounted at <code>/shared</code> inside the container. Drop files there for the agent to use, or find agent output there after a task completes. Created automatically on first run.</p>
 
       <h3 id="path-gemini">Path 1: Gemini API (Cloud, fastest)</h3>
       <p>Use Google's hosted Gemini API. No local GPU needed, no model downloads. Get an API key from <a href="https://aistudio.google.com/apikey" class="inline">Google AI Studio</a> (free tier available).</p>

--- a/site/setup.html
+++ b/site/setup.html
@@ -630,6 +630,7 @@ corepack enable &amp;&amp; pnpm install
 pnpm build
 npm install -g .</code></pre></div>
       <p>Requires Node.js 22+. Docker is recommended for sandboxed tool execution but not required.</p>
+      <p><strong>Shared files:</strong> When Docker sandbox is enabled, <code>~/.gemmaclaw/shared/</code> on your machine is automatically mounted at <code>/shared</code> inside the container. Drop files there for the agent to use, or find agent output there after a task completes. Created automatically on first run.</p>
 
       <h3 id="path-gemini">Path 1: Gemini API (Cloud, fastest)</h3>
       <p>Use Google's hosted Gemini API. No local GPU needed, no model downloads. Get an API key from <a href="https://aistudio.google.com/apikey" class="inline">Google AI Studio</a> (free tier available).</p>

--- a/src/agents/sandbox-merge.test.ts
+++ b/src/agents/sandbox-merge.test.ts
@@ -50,7 +50,9 @@ describe("sandbox config merges", () => {
           },
         },
         assert: (resolved: ReturnType<typeof resolveSandboxDockerConfig>) => {
+          const sharedBind = `${process.env.HOME ?? "/root"}/.gemmaclaw/shared:/shared`;
           expect(resolved.binds).toEqual([
+            sharedBind,
             "/var/run/docker.sock:/var/run/docker.sock",
             "/home/user/source:/source:rw",
           ]);
@@ -64,7 +66,8 @@ describe("sandbox config merges", () => {
           agentDocker: {},
         },
         assert: (resolved: ReturnType<typeof resolveSandboxDockerConfig>) => {
-          expect(resolved.binds).toBeUndefined();
+          const sharedBind = `${process.env.HOME ?? "/root"}/.gemmaclaw/shared:/shared`;
+          expect(resolved.binds).toEqual([sharedBind]);
         },
       },
       {
@@ -79,7 +82,8 @@ describe("sandbox config merges", () => {
           },
         },
         assert: (resolved: ReturnType<typeof resolveSandboxDockerConfig>) => {
-          expect(resolved.binds).toEqual(["/var/run/docker.sock:/var/run/docker.sock"]);
+          const sharedBind = `${process.env.HOME ?? "/root"}/.gemmaclaw/shared:/shared`;
+          expect(resolved.binds).toEqual([sharedBind, "/var/run/docker.sock:/var/run/docker.sock"]);
         },
       },
       {

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SandboxSshSettings } from "../../config/types.sandbox.js";
 import { normalizeSecretInputString } from "../../config/types.secrets.js";
@@ -96,7 +98,16 @@ export function resolveSandboxDockerConfig(params: {
     ? { ...globalDocker?.ulimits, ...agentDocker.ulimits }
     : globalDocker?.ulimits;
 
-  const binds = [...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
+  // Default shared directory: ~/.gemmaclaw/shared on host maps to /shared in container.
+  // This lets users drop files in for the agent and retrieve output files.
+  const sharedDir = path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
+  try {
+    fs.mkdirSync(sharedDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+  const defaultSharedBind = `${sharedDir}:/shared`;
+  const binds = [defaultSharedBind, ...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
 
   return {
     image: agentDocker?.image ?? globalDocker?.image ?? DEFAULT_SANDBOX_IMAGE,

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SandboxSshSettings } from "../../config/types.sandbox.js";
@@ -101,11 +100,6 @@ export function resolveSandboxDockerConfig(params: {
   // Default shared directory: ~/.gemmaclaw/shared on host maps to /shared in container.
   // This lets users drop files in for the agent and retrieve output files.
   const sharedDir = path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
-  try {
-    fs.mkdirSync(sharedDir, { recursive: true });
-  } catch {
-    /* best effort */
-  }
   const defaultSharedBind = `${sharedDir}:/shared`;
   const binds = [defaultSharedBind, ...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
 

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -328,6 +328,15 @@ export async function setupGemmaCommand(
 
       if (enableSandbox) {
         runtime.log(`  Sandbox: Docker (tools run in isolated containers)`);
+        // Create shared directory for host-container file exchange
+        const sharedDir = path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
+        try {
+          const { mkdirSync } = await import("node:fs");
+          mkdirSync(sharedDir, { recursive: true });
+          runtime.log(`  Shared: ${sharedDir} (mounted at /shared in containers)`);
+        } catch {
+          runtime.log(`  Shared: could not create ${sharedDir}`);
+        }
       } else {
         runtime.log(`  Sandbox: off (tools run on host)`);
       }


### PR DESCRIPTION
Auto-mounts ~/.gemmaclaw/shared at /shared in all Docker sandbox containers. Bidirectional file sharing. Tested E2E.