### PR TITLE
ci: verify public installer package

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -199,6 +199,7 @@ jobs:
         env:
           OPENCLAW_INSTALL_URL: https://openclaw.ai/install.sh
           OPENCLAW_INSTALL_CLI_URL: https://openclaw.ai/install-cli.sh
+          OPENCLAW_INSTALL_PACKAGE: openclaw
           OPENCLAW_NO_ONBOARD: "1"
           OPENCLAW_INSTALL_SMOKE_SKIP_CLI: "1"
           OPENCLAW_INSTALL_SMOKE_SKIP_IMAGE_BUILD: "1"


### PR DESCRIPTION
## Summary
- Set the public install.sh Docker smoke job to verify the published openclaw package instead of gemmaclaw.

## Verification
- bash -n scripts/test-install-sh-docker.sh
- Docker non-root public install smoke with OPENCLAW_INSTALL_PACKAGE=openclaw