### PR TITLE
feat(cli): add gemmaclaw ssh command with container shell and list availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ gemmaclaw setup           # auto-detect hardware, provision Gemma backend
 gemmaclaw create work     # create a named agent instance
 gemmaclaw chat            # open chat UI (picks agent interactively)
 gemmaclaw message --agent work "summarize this repo"   # one-shot message
+gemmaclaw list            # list agents with container shell availability
+gemmaclaw ssh work        # open a shell inside the 'work' agent's container
 ```
 
 ## Documentation

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -1242,16 +1242,39 @@ gemmaclaw create play --non-interactive</code></pre></div>
 
       <div class="cli-cmd-card">
         <h4 id="cmd-list"><code>gemmaclaw list</code></h4>
-        <p>List all configured Gemmaclaw instances. Alias for <code>gemmaclaw agents list</code>.</p>
+        <p>List all configured Gemmaclaw instances. Alias for <code>gemmaclaw agents list</code>. Shows container shell availability for each agent.</p>
         <div class="table-wrap"><table>
           <thead><tr><th>Option</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>--json</code></td><td>Output JSON instead of text</td></tr>
+            <tr><td><code>--json</code></td><td>Output JSON with <code>shellAvailable</code> and <code>shellUnavailableReason</code> fields</td></tr>
             <tr><td><code>--bindings</code></td><td>Include routing bindings</td></tr>
           </tbody>
         </table></div>
         <div class="code-block"><pre><code>gemmaclaw list
 gemmaclaw list --json</code></pre></div>
+      </div>
+
+      <div class="cli-cmd-card">
+        <h4 id="cmd-ssh"><code>gemmaclaw ssh</code></h4>
+        <p>Open an interactive shell inside a container-backed agent's sandbox. With no argument in a TTY, presents an interactive picker. Non-container agents appear in the picker but cannot be selected, with a clear reason. This opens a container shell via <code>docker exec</code> or <code>podman exec</code>, not a network SSH connection.</p>
+        <div class="table-wrap"><table>
+          <thead><tr><th>Option</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>[agent]</code></td><td>Agent name/id (optional; prompts interactively if omitted in a TTY)</td></tr>
+            <tr><td><code>--non-interactive</code></td><td>Fail with usage text if no agent is specified (useful for scripts)</td></tr>
+          </tbody>
+        </table></div>
+        <div class="code-block"><pre><code># Interactive picker (TTY required)
+gemmaclaw ssh
+
+# Direct shell into named agent
+gemmaclaw ssh main
+
+# Script-safe: fail immediately if no agent given
+gemmaclaw ssh work --non-interactive
+
+# Check which agents support container shell
+gemmaclaw list --json | jq '.[] | {id, shellAvailable, shellUnavailableReason}'</code></pre></div>
       </div>
 
       <div class="cli-cmd-card">

--- a/site/setup.html
+++ b/site/setup.html
@@ -874,16 +874,39 @@ gemmaclaw create play --non-interactive</code></pre></div>
 
       <div class="cli-cmd-card">
         <h4 id="cmd-list"><code>gemmaclaw list</code></h4>
-        <p>List all configured Gemmaclaw instances. Alias for <code>gemmaclaw agents list</code>.</p>
+        <p>List all configured Gemmaclaw instances. Alias for <code>gemmaclaw agents list</code>. Shows container shell availability for each agent.</p>
         <div class="table-wrap"><table>
           <thead><tr><th>Option</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>--json</code></td><td>Output JSON instead of text</td></tr>
+            <tr><td><code>--json</code></td><td>Output JSON with <code>shellAvailable</code> and <code>shellUnavailableReason</code> fields</td></tr>
             <tr><td><code>--bindings</code></td><td>Include routing bindings</td></tr>
           </tbody>
         </table></div>
         <div class="code-block"><pre><code>gemmaclaw list
 gemmaclaw list --json</code></pre></div>
+      </div>
+
+      <div class="cli-cmd-card">
+        <h4 id="cmd-ssh"><code>gemmaclaw ssh</code></h4>
+        <p>Open an interactive shell inside a container-backed agent's sandbox. With no argument in a TTY, presents an interactive picker. Non-container agents appear in the picker but cannot be selected, with a clear reason. This opens a container shell via <code>docker exec</code> or <code>podman exec</code>, not a network SSH connection.</p>
+        <div class="table-wrap"><table>
+          <thead><tr><th>Option</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>[agent]</code></td><td>Agent name/id (optional; prompts interactively if omitted in a TTY)</td></tr>
+            <tr><td><code>--non-interactive</code></td><td>Fail with usage text if no agent is specified (useful for scripts)</td></tr>
+          </tbody>
+        </table></div>
+        <div class="code-block"><pre><code># Interactive picker (TTY required)
+gemmaclaw ssh
+
+# Direct shell into named agent
+gemmaclaw ssh main
+
+# Script-safe: fail immediately if no agent given
+gemmaclaw ssh work --non-interactive
+
+# Check which agents support container shell
+gemmaclaw list --json | jq '.[] | {id, shellAvailable, shellUnavailableReason}'</code></pre></div>
       </div>
 
       <div class="cli-cmd-card">

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -126,6 +126,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         exportName: "registerStatusHealthSessionsCommands",
       },
       {
+        commandNames: ["ssh"],
+        loadModule: () => import("./register.ssh.js"),
+        exportName: "registerSshCommand",
+      },
+      {
         commandNames: ["provision"],
         loadModule: () => import("./register.provision.js"),
         exportName: "registerProvisionCommand",

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -101,6 +101,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "ssh",
+    description: "Open an interactive shell inside a container-backed agent's sandbox",
+    hasSubcommands: false,
+  },
+  {
     name: "provision",
     description: "Install and start a local Gemma backend (Ollama, llama.cpp, or gemma.cpp)",
     hasSubcommands: false,

--- a/src/cli/program/register.ssh.test.ts
+++ b/src/cli/program/register.ssh.test.ts
@@ -1,0 +1,82 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerSshCommand } from "./register.ssh.js";
+
+const mocks = vi.hoisted(() => ({
+  agentsSshCommandMock: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../commands/agents.commands.ssh.js", () => ({
+  agentsSshCommand: mocks.agentsSshCommandMock,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("registerSshCommand", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerSshCommand(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runtime.exit.mockImplementation(() => {});
+    mocks.agentsSshCommandMock.mockResolvedValue(undefined);
+  });
+
+  it("registers a 'ssh' command", async () => {
+    const program = new Command();
+    registerSshCommand(program);
+    const cmd = program.commands.find((c) => c.name() === "ssh");
+    expect(cmd).toBeDefined();
+  });
+
+  it("passes no agent when none given", async () => {
+    await runCli(["ssh"]);
+
+    expect(mocks.agentsSshCommandMock).toHaveBeenCalledWith(
+      { agent: undefined, nonInteractive: false },
+      mocks.runtime,
+    );
+  });
+
+  it("passes agent name from positional argument", async () => {
+    await runCli(["ssh", "main"]);
+
+    expect(mocks.agentsSshCommandMock).toHaveBeenCalledWith(
+      { agent: "main", nonInteractive: false },
+      mocks.runtime,
+    );
+  });
+
+  it("forwards --non-interactive flag", async () => {
+    await runCli(["ssh", "work", "--non-interactive"]);
+
+    expect(mocks.agentsSshCommandMock).toHaveBeenCalledWith(
+      { agent: "work", nonInteractive: true },
+      mocks.runtime,
+    );
+  });
+
+  it("treats whitespace-only agent as undefined", async () => {
+    // Commander parses empty string as a truthy value; our code trims and converts to undefined.
+    // With no positional arg, agent should be undefined.
+    await runCli(["ssh"]);
+    const [opts] = mocks.agentsSshCommandMock.mock.calls[0];
+    expect(opts.agent).toBeUndefined();
+  });
+
+  it("shows --help without throwing", async () => {
+    const program = new Command();
+    registerSshCommand(program);
+    expect(() => program.parse(["ssh", "--help"], { from: "user" })).toThrow();
+  });
+});

--- a/src/cli/program/register.ssh.ts
+++ b/src/cli/program/register.ssh.ts
@@ -1,0 +1,39 @@
+import type { Command } from "commander";
+import { agentsSshCommand } from "../../commands/agents.commands.ssh.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatHelpExamples } from "../help-format.js";
+
+export function registerSshCommand(program: Command) {
+  program
+    .command("ssh [agent]")
+    .description("Open an interactive shell inside a container-backed agent's sandbox")
+    .option("--non-interactive", "Fail with usage text if no agent is specified", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["gemmaclaw ssh", "Interactively pick from registered agents (TTY required)."],
+          ["gemmaclaw ssh main", "Open a shell in the 'main' agent's running sandbox container."],
+          [
+            "gemmaclaw ssh work --non-interactive",
+            "Non-interactive; fails if no container is running.",
+          ],
+        ])}\n\n${theme.muted(
+          "This opens a container shell via 'docker exec' or 'podman exec', not a network SSH connection.",
+        )}\n${theme.muted("Docs:")} ${formatDocsLink("/cli/ssh", "docs.openclaw.ai/cli/ssh")}\n`,
+    )
+    .action(async (agent: string | undefined, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await agentsSshCommand(
+          {
+            agent: typeof agent === "string" && agent.trim() ? agent.trim() : undefined,
+            nonInteractive: Boolean(opts.nonInteractive),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+}

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -50,6 +50,19 @@ const baseSummary = {
   bindings: 0,
 };
 
+function sshInfo(overrides = {}) {
+  return {
+    agentId: "main",
+    sandboxMode: "all",
+    sandboxBackend: "docker",
+    containerBacked: true,
+    shellAvailable: false,
+    shellUnavailableReason: "no container registered — start a session first",
+    containers: [],
+    ...overrides,
+  };
+}
+
 describe("agentsListCommand shell availability", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -64,11 +77,11 @@ describe("agentsListCommand shell availability", () => {
       new Map([
         [
           "main",
-          {
-            agentId: "main",
-            containerBacked: true,
-            containers: [{ containerName: "c1", backendId: "docker", running: true }],
-          },
+          sshInfo({
+            shellAvailable: true,
+            shellUnavailableReason: undefined,
+            containers: [{ containerName: "c1", backendId: "docker", exists: true, running: true }],
+          }),
         ],
       ]),
     );
@@ -78,8 +91,18 @@ describe("agentsListCommand shell availability", () => {
       capturedSummaries.push(...(data as unknown[]));
     });
     await agentsListCommand({ json: true }, mocks.runtime as never);
-    expect(capturedSummaries[0]).toMatchObject({ shellAvailable: true });
-    expect(capturedSummaries[0]).not.toHaveProperty("shellUnavailableReason");
+    expect(capturedSummaries[0]).toMatchObject({
+      shellAvailable: true,
+      containerShell: {
+        eligible: true,
+        available: true,
+        backend: "docker",
+        containers: [{ name: "c1", backend: "docker", exists: true, running: true }],
+      },
+    });
+    expect(
+      (capturedSummaries[0] as { shellUnavailableReason?: string }).shellUnavailableReason,
+    ).toBeUndefined();
   });
 
   it("sets shellAvailable=false with 'no container registered' reason when no registry entries", async () => {
@@ -87,11 +110,9 @@ describe("agentsListCommand shell availability", () => {
       new Map([
         [
           "main",
-          {
-            agentId: "main",
-            containerBacked: true,
+          sshInfo({
             containers: [],
-          },
+          }),
         ],
       ]),
     );
@@ -104,6 +125,11 @@ describe("agentsListCommand shell availability", () => {
     expect(capturedSummaries[0]).toMatchObject({
       shellAvailable: false,
       shellUnavailableReason: expect.stringContaining("no container registered"),
+      containerShell: {
+        eligible: true,
+        available: false,
+        reason: expect.stringContaining("no container registered"),
+      },
     });
   });
 
@@ -112,11 +138,12 @@ describe("agentsListCommand shell availability", () => {
       new Map([
         [
           "main",
-          {
-            agentId: "main",
-            containerBacked: true,
-            containers: [{ containerName: "c1", backendId: "docker", running: false }],
-          },
+          sshInfo({
+            shellUnavailableReason: "container stopped — start a session first",
+            containers: [
+              { containerName: "c1", backendId: "docker", exists: true, running: false },
+            ],
+          }),
         ],
       ]),
     );
@@ -129,6 +156,11 @@ describe("agentsListCommand shell availability", () => {
     expect(capturedSummaries[0]).toMatchObject({
       shellAvailable: false,
       shellUnavailableReason: expect.stringContaining("container stopped"),
+      containerShell: {
+        eligible: true,
+        available: false,
+        reason: expect.stringContaining("container stopped"),
+      },
     });
   });
 
@@ -137,12 +169,13 @@ describe("agentsListCommand shell availability", () => {
       new Map([
         [
           "main",
-          {
-            agentId: "main",
+          sshInfo({
+            sandboxMode: "off",
             containerBacked: false,
             unavailableReason: "sandbox mode is off (not container-backed)",
+            shellUnavailableReason: "sandbox mode is off (not container-backed)",
             containers: [],
-          },
+          }),
         ],
       ]),
     );
@@ -155,6 +188,12 @@ describe("agentsListCommand shell availability", () => {
     expect(capturedSummaries[0]).toMatchObject({
       shellAvailable: false,
       shellUnavailableReason: expect.stringContaining("sandbox mode is off"),
+      containerShell: {
+        eligible: false,
+        available: false,
+        mode: "off",
+        reason: expect.stringContaining("sandbox mode is off"),
+      },
     });
   });
 });

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentsListCommand } from "./agents.commands.list.js";
+
+const mocks = vi.hoisted(() => ({
+  requireValidConfigMock: vi.fn(),
+  buildAgentSummariesMock: vi.fn(),
+  resolveAgentsSshInfoMock: vi.fn(),
+  buildProviderStatusIndexMock: vi.fn(),
+  listRouteBindingsMock: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("./agents.command-shared.js", () => ({
+  requireValidConfig: mocks.requireValidConfigMock,
+}));
+
+vi.mock("./agents.config.js", () => ({
+  buildAgentSummaries: mocks.buildAgentSummariesMock,
+}));
+
+vi.mock("./agents.commands.ssh.js", () => ({
+  resolveAgentsSshInfo: mocks.resolveAgentsSshInfoMock,
+}));
+
+vi.mock("./agents.providers.js", () => ({
+  buildProviderStatusIndex: mocks.buildProviderStatusIndexMock,
+  listProvidersForAgent: vi.fn().mockReturnValue([]),
+  summarizeBindings: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../config/bindings.js", () => ({
+  listRouteBindings: mocks.listRouteBindingsMock,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {},
+  writeRuntimeJson: vi.fn(),
+}));
+
+const baseCfg = { agents: { list: [{ id: "main" }] } };
+const baseSummary = {
+  id: "main",
+  isDefault: true,
+  workspace: "/w",
+  agentDir: "/a",
+  bindings: 0,
+};
+
+describe("agentsListCommand shell availability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireValidConfigMock.mockResolvedValue(baseCfg);
+    mocks.buildAgentSummariesMock.mockReturnValue([{ ...baseSummary }]);
+    mocks.buildProviderStatusIndexMock.mockResolvedValue({});
+    mocks.listRouteBindingsMock.mockReturnValue([]);
+  });
+
+  it("sets shellAvailable=true when container is running", async () => {
+    mocks.resolveAgentsSshInfoMock.mockResolvedValue(
+      new Map([
+        [
+          "main",
+          {
+            agentId: "main",
+            containerBacked: true,
+            containers: [{ containerName: "c1", backendId: "docker", running: true }],
+          },
+        ],
+      ]),
+    );
+    const capturedSummaries: unknown[] = [];
+    const { writeRuntimeJson } = await import("../runtime.js");
+    vi.mocked(writeRuntimeJson).mockImplementation((_rt, data) => {
+      capturedSummaries.push(...(data as unknown[]));
+    });
+    await agentsListCommand({ json: true }, mocks.runtime as never);
+    expect(capturedSummaries[0]).toMatchObject({ shellAvailable: true });
+    expect(capturedSummaries[0]).not.toHaveProperty("shellUnavailableReason");
+  });
+
+  it("sets shellAvailable=false with 'no container registered' reason when no registry entries", async () => {
+    mocks.resolveAgentsSshInfoMock.mockResolvedValue(
+      new Map([
+        [
+          "main",
+          {
+            agentId: "main",
+            containerBacked: true,
+            containers: [],
+          },
+        ],
+      ]),
+    );
+    const capturedSummaries: unknown[] = [];
+    const { writeRuntimeJson } = await import("../runtime.js");
+    vi.mocked(writeRuntimeJson).mockImplementation((_rt, data) => {
+      capturedSummaries.push(...(data as unknown[]));
+    });
+    await agentsListCommand({ json: true }, mocks.runtime as never);
+    expect(capturedSummaries[0]).toMatchObject({
+      shellAvailable: false,
+      shellUnavailableReason: expect.stringContaining("no container registered"),
+    });
+  });
+
+  it("sets shellAvailable=false with 'container stopped' reason when container exists but not running", async () => {
+    mocks.resolveAgentsSshInfoMock.mockResolvedValue(
+      new Map([
+        [
+          "main",
+          {
+            agentId: "main",
+            containerBacked: true,
+            containers: [{ containerName: "c1", backendId: "docker", running: false }],
+          },
+        ],
+      ]),
+    );
+    const capturedSummaries: unknown[] = [];
+    const { writeRuntimeJson } = await import("../runtime.js");
+    vi.mocked(writeRuntimeJson).mockImplementation((_rt, data) => {
+      capturedSummaries.push(...(data as unknown[]));
+    });
+    await agentsListCommand({ json: true }, mocks.runtime as never);
+    expect(capturedSummaries[0]).toMatchObject({
+      shellAvailable: false,
+      shellUnavailableReason: expect.stringContaining("container stopped"),
+    });
+  });
+
+  it("sets shellAvailable=false with config reason when agent is not container-backed", async () => {
+    mocks.resolveAgentsSshInfoMock.mockResolvedValue(
+      new Map([
+        [
+          "main",
+          {
+            agentId: "main",
+            containerBacked: false,
+            unavailableReason: "sandbox mode is off (not container-backed)",
+            containers: [],
+          },
+        ],
+      ]),
+    );
+    const capturedSummaries: unknown[] = [];
+    const { writeRuntimeJson } = await import("../runtime.js");
+    vi.mocked(writeRuntimeJson).mockImplementation((_rt, data) => {
+      capturedSummaries.push(...(data as unknown[]));
+    });
+    await agentsListCommand({ json: true }, mocks.runtime as never);
+    expect(capturedSummaries[0]).toMatchObject({
+      shellAvailable: false,
+      shellUnavailableReason: expect.stringContaining("sandbox mode is off"),
+    });
+  });
+});

--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -7,6 +7,7 @@ import { defaultRuntime } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
 import { describeBinding } from "./agents.bindings.js";
 import { requireValidConfig } from "./agents.command-shared.js";
+import { resolveAgentsSshInfo } from "./agents.commands.ssh.js";
 import type { AgentSummary } from "./agents.config.js";
 import { buildAgentSummaries } from "./agents.config.js";
 import {
@@ -70,6 +71,15 @@ function formatSummary(summary: AgentSummary) {
       lines.push(`    - ${binding}`);
     }
   }
+
+  if (summary.shellAvailable === true) {
+    lines.push(`  Container shell: available (gemmaclaw ssh ${summary.id})`);
+  } else if (summary.shellAvailable === false) {
+    lines.push(
+      `  Container shell: unavailable — ${summary.shellUnavailableReason ?? "not container-backed"}`,
+    );
+  }
+
   return lines.join("\n");
 }
 
@@ -103,6 +113,10 @@ export async function agentsListCommand(
   }
 
   const providerStatus = await buildProviderStatusIndex(cfg);
+  const sshInfoMap = await resolveAgentsSshInfo(
+    summaries.map((s) => s.id),
+    cfg,
+  );
 
   for (const summary of summaries) {
     const bindings = bindingMap.get(summary.id) ?? [];
@@ -121,6 +135,14 @@ export async function agentsListCommand(
     });
     if (providerLines.length > 0) {
       summary.providers = providerLines;
+    }
+
+    const sshInfo = sshInfoMap.get(normalizeAgentId(summary.id));
+    if (sshInfo) {
+      summary.shellAvailable = sshInfo.containerBacked;
+      if (!sshInfo.containerBacked) {
+        summary.shellUnavailableReason = sshInfo.unavailableReason;
+      }
     }
   }
 

--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -139,9 +139,20 @@ export async function agentsListCommand(
 
     const sshInfo = sshInfoMap.get(normalizeAgentId(summary.id));
     if (sshInfo) {
-      summary.shellAvailable = sshInfo.containerBacked;
       if (!sshInfo.containerBacked) {
+        summary.shellAvailable = false;
         summary.shellUnavailableReason = sshInfo.unavailableReason;
+      } else {
+        const hasRunning = sshInfo.containers.some((c) => c.running);
+        if (hasRunning) {
+          summary.shellAvailable = true;
+        } else if (sshInfo.containers.length === 0) {
+          summary.shellAvailable = false;
+          summary.shellUnavailableReason = "no container registered — start a session first";
+        } else {
+          summary.shellAvailable = false;
+          summary.shellUnavailableReason = "container stopped — start a session first";
+        }
       }
     }
   }

--- a/src/commands/agents.commands.list.ts
+++ b/src/commands/agents.commands.list.ts
@@ -72,7 +72,33 @@ function formatSummary(summary: AgentSummary) {
     }
   }
 
-  if (summary.shellAvailable === true) {
+  if (summary.containerShell) {
+    if (summary.containerShell.eligible) {
+      lines.push(
+        `  Tools: Docker/container sandbox (${summary.containerShell.backend}; mode: ${summary.containerShell.mode})`,
+      );
+    } else if (summary.containerShell.mode === "off") {
+      lines.push("  Tools: host/direct mode (no container sandbox)");
+    } else {
+      lines.push(
+        `  Tools: non-container sandbox (${summary.containerShell.backend}; mode: ${summary.containerShell.mode})`,
+      );
+    }
+
+    if (summary.containerShell.available) {
+      const running = summary.containerShell.containers
+        .filter((container) => container.running)
+        .map((container) => container.name)
+        .join(", ");
+      lines.push(
+        `  Container shell: available${running ? ` — ${running}` : ""} (gemmaclaw ssh ${summary.id})`,
+      );
+    } else {
+      lines.push(
+        `  Container shell: unavailable — ${summary.containerShell.reason ?? summary.shellUnavailableReason ?? "not container-backed"}`,
+      );
+    }
+  } else if (summary.shellAvailable === true) {
     lines.push(`  Container shell: available (gemmaclaw ssh ${summary.id})`);
   } else if (summary.shellAvailable === false) {
     lines.push(
@@ -139,21 +165,25 @@ export async function agentsListCommand(
 
     const sshInfo = sshInfoMap.get(normalizeAgentId(summary.id));
     if (sshInfo) {
-      if (!sshInfo.containerBacked) {
-        summary.shellAvailable = false;
-        summary.shellUnavailableReason = sshInfo.unavailableReason;
-      } else {
-        const hasRunning = sshInfo.containers.some((c) => c.running);
-        if (hasRunning) {
-          summary.shellAvailable = true;
-        } else if (sshInfo.containers.length === 0) {
-          summary.shellAvailable = false;
-          summary.shellUnavailableReason = "no container registered — start a session first";
-        } else {
-          summary.shellAvailable = false;
-          summary.shellUnavailableReason = "container stopped — start a session first";
-        }
-      }
+      summary.shellAvailable = sshInfo.shellAvailable;
+      summary.shellUnavailableReason = sshInfo.shellAvailable
+        ? undefined
+        : (sshInfo.shellUnavailableReason ?? sshInfo.unavailableReason);
+      summary.containerShell = {
+        eligible: sshInfo.containerBacked,
+        available: sshInfo.shellAvailable,
+        mode: sshInfo.sandboxMode,
+        backend: sshInfo.sandboxBackend,
+        reason: sshInfo.shellAvailable
+          ? undefined
+          : (sshInfo.shellUnavailableReason ?? sshInfo.unavailableReason),
+        containers: sshInfo.containers.map((container) => ({
+          name: container.containerName,
+          backend: container.backendId,
+          exists: container.exists,
+          running: container.running,
+        })),
+      };
     }
   }
 

--- a/src/commands/agents.commands.ssh.test.ts
+++ b/src/commands/agents.commands.ssh.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { agentsSshCommand, resolveAgentsSshInfo } from "./agents.commands.ssh.js";
+
+const mocks = vi.hoisted(() => ({
+  requireValidConfigMock: vi.fn(),
+  buildAgentSummariesMock: vi.fn(),
+  readRegistryMock: vi.fn(),
+  resolveSandboxConfigForAgentMock: vi.fn(),
+  spawnSyncMock: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("./agents.command-shared.js", () => ({
+  requireValidConfig: mocks.requireValidConfigMock,
+}));
+
+vi.mock("./agents.config.js", () => ({
+  buildAgentSummaries: mocks.buildAgentSummariesMock,
+}));
+
+vi.mock("../agents/sandbox/registry.js", () => ({
+  readRegistry: mocks.readRegistryMock,
+}));
+
+vi.mock("../agents/sandbox/config.js", () => ({
+  resolveSandboxConfigForAgent: mocks.resolveSandboxConfigForAgentMock,
+}));
+
+vi.mock("node:child_process", async () => {
+  const original = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...original,
+    spawnSync: mocks.spawnSyncMock,
+  };
+});
+
+const baseCfg = { agents: { list: [{ id: "main" }] } };
+
+describe("agentsSshCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireValidConfigMock.mockResolvedValue(baseCfg);
+    mocks.buildAgentSummariesMock.mockReturnValue([
+      { id: "main", isDefault: true, workspace: "/w", agentDir: "/a", bindings: 0 },
+    ]);
+    mocks.readRegistryMock.mockResolvedValue({ entries: [] });
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({
+      mode: "off",
+      backend: "docker",
+    });
+    // spawnSync for version check returns failure by default (no docker)
+    mocks.spawnSyncMock.mockReturnValue({ status: 1, stdout: "", stderr: "" });
+  });
+
+  it("errors when config is unavailable", async () => {
+    mocks.requireValidConfigMock.mockResolvedValue(null);
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("errors for unknown agent name", async () => {
+    mocks.buildAgentSummariesMock.mockReturnValue([
+      { id: "main", isDefault: true, workspace: "/w", agentDir: "/a", bindings: 0 },
+    ]);
+    await agentsSshCommand({ agent: "nonexistent" }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining('"nonexistent" is not registered'),
+    );
+  });
+
+  it("errors when agent sandbox mode is off", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "off", backend: "docker" });
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("not have a container-backed sandbox"),
+    );
+  });
+
+  it("errors when sandbox backend is not docker", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "ssh" });
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("not have a container-backed sandbox"),
+    );
+  });
+
+  it("errors when no containers found in registry", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({ entries: [] });
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("No containers found"),
+    );
+  });
+
+  it("errors when container is not running", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    // docker is installed but container not running
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes("--version")) {
+        return { status: 0, stdout: "docker version 24.0", stderr: "" };
+      }
+      if (args.includes("inspect")) {
+        return { status: 0, stdout: "false\n", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("not running"));
+  });
+
+  it("fails with usage text in non-interactive mode with no agent", async () => {
+    await agentsSshCommand({ nonInteractive: true }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("No agent specified"));
+  });
+
+  it("errors when no agents configured", async () => {
+    mocks.buildAgentSummariesMock.mockReturnValue([]);
+    await agentsSshCommand({ nonInteractive: true }, mocks.runtime);
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("No agents configured"),
+    );
+  });
+});
+
+describe("resolveAgentsSshInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readRegistryMock.mockResolvedValue({ entries: [] });
+  });
+
+  it("returns not container-backed for mode=off", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "off", backend: "docker" });
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+    expect(info?.containerBacked).toBe(false);
+    expect(info?.unavailableReason).toContain("off");
+  });
+
+  it("returns not container-backed for non-docker backend", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "ssh" });
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+    expect(info?.containerBacked).toBe(false);
+    expect(info?.unavailableReason).toContain('"ssh"');
+  });
+
+  it("returns containerBacked=true with empty containers for docker-mode with no registry entries", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({ entries: [] });
+    mocks.spawnSyncMock.mockReturnValue({ status: 1, stdout: "", stderr: "" });
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+    expect(info?.containerBacked).toBe(true);
+    expect(info?.containers).toHaveLength(0);
+  });
+
+  it("finds containers for agent:main session key", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+        {
+          containerName: "openclaw-sbx-work-def",
+          sessionKey: "agent:work",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockReturnValue({ status: 1, stdout: "", stderr: "" });
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+    expect(info?.containers).toHaveLength(1);
+    expect(info?.containers[0].containerName).toBe("openclaw-sbx-main-abc");
+  });
+
+  it("handles multiple agents in one call", async () => {
+    mocks.resolveSandboxConfigForAgentMock
+      .mockReturnValueOnce({ mode: "all", backend: "docker" })
+      .mockReturnValueOnce({ mode: "off", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({ entries: [] });
+    mocks.spawnSyncMock.mockReturnValue({ status: 1, stdout: "", stderr: "" });
+    const result = await resolveAgentsSshInfo(["main", "work"], baseCfg);
+    expect(result.get("main")?.containerBacked).toBe(true);
+    expect(result.get("work")?.containerBacked).toBe(false);
+  });
+});

--- a/src/commands/agents.commands.ssh.test.ts
+++ b/src/commands/agents.commands.ssh.test.ts
@@ -210,4 +210,62 @@ describe("resolveAgentsSshInfo", () => {
     expect(result.get("main")?.containerBacked).toBe(true);
     expect(result.get("work")?.containerBacked).toBe(false);
   });
+
+  it("marks container running=true when docker inspect returns true", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes("--version")) {
+        return { status: 0, stdout: "docker 24", stderr: "" };
+      }
+      if (args.includes("inspect")) {
+        return { status: 0, stdout: "true\n", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+    expect(info?.containerBacked).toBe(true);
+    expect(info?.containers[0].running).toBe(true);
+  });
+
+  it("marks container running=false when docker inspect returns false", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (args.includes("--version")) {
+        return { status: 0, stdout: "docker 24", stderr: "" };
+      }
+      if (args.includes("inspect")) {
+        return { status: 0, stdout: "false\n", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+    expect(info?.containerBacked).toBe(true);
+    expect(info?.containers[0].running).toBe(false);
+  });
 });

--- a/src/commands/agents.commands.ssh.test.ts
+++ b/src/commands/agents.commands.ssh.test.ts
@@ -43,6 +43,7 @@ const baseCfg = { agents: { list: [{ id: "main" }] } };
 describe("agentsSshCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
     mocks.requireValidConfigMock.mockResolvedValue(baseCfg);
     mocks.buildAgentSummariesMock.mockReturnValue([
       { id: "main", isDefault: true, workspace: "/w", agentDir: "/a", bindings: 0 },
@@ -69,6 +70,27 @@ describe("agentsSshCommand", () => {
     await agentsSshCommand({ agent: "nonexistent" }, mocks.runtime);
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       expect.stringContaining('"nonexistent" is not registered'),
+    );
+  });
+
+  it("resolves a display name through normalized agent id logic", async () => {
+    mocks.buildAgentSummariesMock.mockReturnValue([
+      {
+        id: "steve",
+        name: "Steve",
+        isDefault: false,
+        workspace: "/w",
+        agentDir: "/a",
+        bindings: 0,
+      },
+    ]);
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "off", backend: "docker" });
+
+    await agentsSshCommand({ agent: "Steve" }, mocks.runtime);
+
+    expect(mocks.resolveSandboxConfigForAgentMock).toHaveBeenCalledWith(baseCfg, "steve");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("not have a container-backed sandbox"),
     );
   });
 
@@ -125,9 +147,77 @@ describe("agentsSshCommand", () => {
     expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("not running"));
   });
 
-  it("fails with usage text in non-interactive mode with no agent", async () => {
+  it("opens a docker exec shell for a running registered container", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "docker" && args.includes("--version")) {
+        return { status: 0, stdout: "docker version 24.0", stderr: "" };
+      }
+      if (cmd === "docker" && args.includes("inspect")) {
+        return { status: 0, stdout: "true\n", stderr: "" };
+      }
+      if (cmd === "docker" && args[0] === "exec" && args.includes("/bin/bash")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+
+    expect(mocks.spawnSyncMock).toHaveBeenCalledWith(
+      "docker",
+      ["exec", "-it", "openclaw-sbx-main-abc", "/bin/bash"],
+      { stdio: "inherit" },
+    );
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("fails with usage text and eligible agents in non-interactive mode with no agent", async () => {
+    mocks.buildAgentSummariesMock.mockReturnValue([
+      { id: "main", isDefault: true, workspace: "/w", agentDir: "/a", bindings: 0 },
+      { id: "work", isDefault: false, workspace: "/w2", agentDir: "/a2", bindings: 0 },
+    ]);
+    mocks.resolveSandboxConfigForAgentMock
+      .mockReturnValueOnce({ mode: "all", backend: "docker" })
+      .mockReturnValueOnce({ mode: "off", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "docker" && args.includes("--version")) {
+        return { status: 0, stdout: "docker 24", stderr: "" };
+      }
+      if (cmd === "docker" && args.includes("inspect")) {
+        return { status: 0, stdout: "true\n", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+
     await agentsSshCommand({ nonInteractive: true }, mocks.runtime);
+
     expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("No agent specified"));
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("gemmaclaw ssh main"));
   });
 
   it("errors when no agents configured", async () => {
@@ -267,5 +357,37 @@ describe("resolveAgentsSshInfo", () => {
     const info = result.get("main");
     expect(info?.containerBacked).toBe(true);
     expect(info?.containers[0].running).toBe(false);
+  });
+
+  it("marks registry entries as missing when docker inspect fails", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "docker" && args.includes("--version")) {
+        return { status: 0, stdout: "docker 24", stderr: "" };
+      }
+      if (cmd === "docker" && args.includes("inspect")) {
+        return { status: 1, stdout: "", stderr: "No such container" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+
+    const result = await resolveAgentsSshInfo(["main"], baseCfg);
+    const info = result.get("main");
+
+    expect(info?.containers[0]).toMatchObject({ exists: false, running: false });
+    expect(info?.shellAvailable).toBe(false);
+    expect(info?.shellUnavailableReason).toContain("missing");
   });
 });

--- a/src/commands/agents.commands.ssh.ts
+++ b/src/commands/agents.commands.ssh.ts
@@ -12,11 +12,16 @@ type ContainerRuntime = "docker" | "podman";
 
 export type AgentContainerInfo = {
   agentId: string;
+  sandboxMode: string;
+  sandboxBackend: string;
   containerBacked: boolean;
   unavailableReason?: string;
+  shellAvailable: boolean;
+  shellUnavailableReason?: string;
   containers: ReadonlyArray<{
     containerName: string;
     backendId: string;
+    exists: boolean;
     running: boolean;
   }>;
 };
@@ -26,22 +31,44 @@ export type AgentsSshOptions = {
   nonInteractive?: boolean;
 };
 
-function detectContainerRuntime(): ContainerRuntime | null {
-  for (const rt of ["podman", "docker"] as ContainerRuntime[]) {
-    const result = spawnSync(rt, ["--version"], { encoding: "utf8", timeout: 5000 });
-    if (result.status === 0) {
-      return rt;
-    }
+function resolveContainerRuntimeCommand(backendId: string | undefined): ContainerRuntime | null {
+  const normalized = (backendId ?? "docker").trim().toLowerCase();
+  if (normalized === "docker" || normalized === "podman") {
+    return normalized;
   }
   return null;
 }
 
-function isContainerRunning(runtime: ContainerRuntime, containerName: string): boolean {
+function isContainerRuntimeAvailable(runtime: ContainerRuntime): boolean {
+  const result = spawnSync(runtime, ["--version"], { encoding: "utf8", timeout: 5000 });
+  return result.status === 0;
+}
+
+function inspectContainerState(runtime: ContainerRuntime, containerName: string) {
   const result = spawnSync(runtime, ["inspect", "--format", "{{.State.Running}}", containerName], {
     encoding: "utf8",
     timeout: 5000,
   });
-  return result.status === 0 && result.stdout.trim() === "true";
+  if (result.status !== 0) {
+    return { exists: false, running: false };
+  }
+  return { exists: true, running: result.stdout.trim() === "true" };
+}
+
+function summarizeShellUnavailableReason(info: AgentContainerInfo): string | undefined {
+  if (!info.containerBacked) {
+    return info.unavailableReason ?? "not container-backed";
+  }
+  if (info.containers.length === 0) {
+    return "no container registered — start a session first";
+  }
+  if (!info.containers.some((c) => c.exists)) {
+    return "container missing — start a session first";
+  }
+  if (!info.containers.some((c) => c.running)) {
+    return "container stopped — start a session first";
+  }
+  return undefined;
 }
 
 async function resolveAgentContainerInfo(
@@ -54,17 +81,26 @@ async function resolveAgentContainerInfo(
   if (sandboxCfg.mode === "off") {
     return {
       agentId: normalized,
+      sandboxMode: sandboxCfg.mode,
+      sandboxBackend: sandboxCfg.backend,
       containerBacked: false,
       unavailableReason: "sandbox mode is off (not container-backed)",
+      shellAvailable: false,
+      shellUnavailableReason: "sandbox mode is off (not container-backed)",
       containers: [],
     };
   }
 
   if (sandboxCfg.backend !== "docker") {
+    const reason = `sandbox backend is "${sandboxCfg.backend}", not docker`;
     return {
       agentId: normalized,
+      sandboxMode: sandboxCfg.mode,
+      sandboxBackend: sandboxCfg.backend,
       containerBacked: false,
-      unavailableReason: `sandbox backend is "${sandboxCfg.backend}", not docker`,
+      unavailableReason: reason,
+      shellAvailable: false,
+      shellUnavailableReason: reason,
       containers: [],
     };
   }
@@ -75,26 +111,56 @@ async function resolveAgentContainerInfo(
     return resolvedId !== undefined && normalizeAgentId(resolvedId) === normalized;
   });
 
-  const containerRuntime = detectContainerRuntime();
-  const containers = agentContainers.map((entry) => ({
-    containerName: entry.containerName,
-    backendId: entry.backendId ?? "docker",
-    running: containerRuntime ? isContainerRunning(containerRuntime, entry.containerName) : false,
-  }));
+  const runtimeAvailability = new Map<string, boolean>();
+  const containers = agentContainers.map((entry) => {
+    const backendId = entry.backendId ?? "docker";
+    const runtime = resolveContainerRuntimeCommand(backendId);
+    if (!runtime) {
+      return {
+        containerName: entry.containerName,
+        backendId,
+        exists: false,
+        running: false,
+      };
+    }
+    let available = runtimeAvailability.get(runtime);
+    if (available === undefined) {
+      available = isContainerRuntimeAvailable(runtime);
+      runtimeAvailability.set(runtime, available);
+    }
+    const state = available
+      ? inspectContainerState(runtime, entry.containerName)
+      : { exists: false, running: false };
+    return {
+      containerName: entry.containerName,
+      backendId,
+      exists: state.exists,
+      running: state.running,
+    };
+  });
 
-  return {
+  const info: AgentContainerInfo = {
     agentId: normalized,
+    sandboxMode: sandboxCfg.mode,
+    sandboxBackend: sandboxCfg.backend,
     containerBacked: true,
+    shellAvailable: containers.some((container) => container.running),
     containers,
   };
+
+  if (!info.shellAvailable) {
+    info.shellUnavailableReason = summarizeShellUnavailableReason(info);
+  }
+  return info;
 }
 
-function openShell(containerName: string): void {
-  const runtime = detectContainerRuntime();
+function openShell(containerName: string, backendId: string): void {
+  const runtime = resolveContainerRuntimeCommand(backendId);
   if (!runtime) {
-    throw new Error(
-      "No container runtime found. Install Docker or Podman to use container shell access.",
-    );
+    throw new Error(`Unsupported container runtime "${backendId}" for shell access.`);
+  }
+  if (!isContainerRuntimeAvailable(runtime)) {
+    throw new Error(`Container runtime "${runtime}" was not found in PATH.`);
   }
 
   const result = spawnSync(runtime, ["exec", "-it", containerName, "/bin/bash"], {
@@ -117,20 +183,38 @@ function openShell(containerName: string): void {
 }
 
 function getContainerUnavailableReason(info: AgentContainerInfo): string | null {
-  if (!info.containerBacked) {
-    return info.unavailableReason ?? "not container-backed";
+  return info.shellAvailable ? null : (info.shellUnavailableReason ?? "not container-backed");
+}
+
+type AgentSshCandidate = { info: AgentContainerInfo; displayName: string; name?: string };
+
+function candidateMatchesInput(candidate: AgentSshCandidate, input: string): boolean {
+  const normalized = normalizeAgentId(input);
+  return (
+    normalizeAgentId(candidate.info.agentId) === normalized ||
+    (candidate.name ? normalizeAgentId(candidate.name) === normalized : false)
+  );
+}
+
+function formatNonInteractiveNoAgentError(candidates: AgentSshCandidate[]): string {
+  const lines = ["No agent specified. Usage: gemmaclaw ssh <agent>"];
+  const eligible = candidates.filter(
+    (candidate) => getContainerUnavailableReason(candidate.info) === null,
+  );
+  if (eligible.length > 0) {
+    lines.push("Eligible container-backed agents with running containers:");
+    for (const candidate of eligible) {
+      lines.push(`  - ${candidate.info.agentId} (gemmaclaw ssh ${candidate.info.agentId})`);
+    }
+  } else {
+    lines.push("No configured agents currently have a running container shell.");
   }
-  if (info.containers.length === 0) {
-    return "no container registered — start a session first";
-  }
-  if (!info.containers.some((c) => c.running)) {
-    return "container stopped — start a session first";
-  }
-  return null;
+  lines.push("Run 'gemmaclaw list' to inspect configured agents and container status.");
+  return lines.join("\n");
 }
 
 async function promptAgentSelection(
-  candidates: Array<{ info: AgentContainerInfo; displayName: string }>,
+  candidates: AgentSshCandidate[],
 ): Promise<AgentContainerInfo | null> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -162,9 +246,7 @@ async function promptAgentSelection(
           resolve(candidate.info);
           return;
         }
-        const found = candidates.find(
-          (c) => normalizeAgentId(c.info.agentId) === normalizeAgentId(trimmed),
-        );
+        const found = candidates.find((c) => candidateMatchesInput(c, trimmed));
         if (found) {
           const reason = getContainerUnavailableReason(found.info);
           if (reason !== null) {
@@ -196,18 +278,20 @@ export async function agentsSshCommand(
 
   if (opts.agent) {
     const agentId = normalizeAgentId(opts.agent);
-    const summaries = buildAgentSummaries(cfg, { includeImplicitDefault: true });
-    const exists = summaries.some((s) => normalizeAgentId(s.id) === agentId);
-    if (!exists) {
+    const summaries = buildAgentSummaries(cfg, { includeImplicitDefault: false });
+    const exactMatch = summaries.find((s) => normalizeAgentId(s.id) === agentId);
+    const nameMatch = summaries.find((s) => s.name && normalizeAgentId(s.name) === agentId);
+    const summary = exactMatch ?? nameMatch;
+    if (!summary) {
       runtime.error(
-        `Agent "${opts.agent}" is not registered. Run 'gemmaclaw list' to see configured agents.`,
+        `Agent "${opts.agent}" is not registered. Run 'gemmaclaw list' to see configured agents and container status.`,
       );
       process.exitCode = 1;
       return;
     }
-    targetInfo = await resolveAgentContainerInfo(agentId, cfg);
+    targetInfo = await resolveAgentContainerInfo(summary.id, cfg);
   } else {
-    const summaries = buildAgentSummaries(cfg, { includeImplicitDefault: true });
+    const summaries = buildAgentSummaries(cfg, { includeImplicitDefault: false });
 
     if (summaries.length === 0) {
       runtime.error(
@@ -217,22 +301,20 @@ export async function agentsSshCommand(
       return;
     }
 
-    const isTTY = process.stdin.isTTY && process.stdout.isTTY;
-    if (!isTTY || opts.nonInteractive) {
-      runtime.error(
-        "No agent specified. Usage: gemmaclaw ssh <agent>\n" +
-          "Run 'gemmaclaw list' to see configured agents.",
-      );
-      process.exitCode = 1;
-      return;
-    }
-
     const candidates = await Promise.all(
       summaries.map(async (s) => ({
         info: await resolveAgentContainerInfo(s.id, cfg),
         displayName: s.name && s.name !== s.id ? `${s.id} (${s.name})` : s.id,
+        name: s.name,
       })),
     );
+
+    const isTTY = process.stdin.isTTY && process.stdout.isTTY;
+    if (!isTTY || opts.nonInteractive) {
+      runtime.error(formatNonInteractiveNoAgentError(candidates));
+      process.exitCode = 1;
+      return;
+    }
 
     const selected = await promptAgentSelection(candidates);
     if (!selected) {
@@ -247,6 +329,7 @@ export async function agentsSshCommand(
     runtime.error(
       `Agent "${targetInfo.agentId}" does not have a container-backed sandbox.\n` +
         `Reason: ${targetInfo.unavailableReason ?? "not container-backed"}\n\n` +
+        `Run 'gemmaclaw list' to inspect configured agents and container status. ` +
         `To enable container mode, run 'gemmaclaw setup' and choose the Docker sandbox option.`,
     );
     process.exitCode = 1;
@@ -259,12 +342,12 @@ export async function agentsSshCommand(
     if (targetInfo.containers.length === 0) {
       runtime.error(
         `No containers found for agent "${targetInfo.agentId}".\n` +
-          `Start a session first so the sandbox container is created, then re-run this command.`,
+          `Start/chat/run this agent first so the sandbox container is created, then re-run this command. Run 'gemmaclaw list' to inspect container status.`,
       );
     } else {
       runtime.error(
         `Container for agent "${targetInfo.agentId}" is not running.\n` +
-          `Start a session for this agent first, then re-run this command.`,
+          `Start/chat/run this agent first, then re-run this command. Run 'gemmaclaw list' to inspect container status.`,
       );
     }
     process.exitCode = 1;
@@ -278,7 +361,7 @@ export async function agentsSshCommand(
   runtime.log(
     `Note: this opens a container shell via '${container.backendId} exec', not a network SSH connection.`,
   );
-  openShell(container.containerName);
+  openShell(container.containerName, container.backendId);
 }
 
 export async function resolveAgentsSshInfo(

--- a/src/commands/agents.commands.ssh.ts
+++ b/src/commands/agents.commands.ssh.ts
@@ -116,6 +116,19 @@ function openShell(containerName: string): void {
   }
 }
 
+function getContainerUnavailableReason(info: AgentContainerInfo): string | null {
+  if (!info.containerBacked) {
+    return info.unavailableReason ?? "not container-backed";
+  }
+  if (info.containers.length === 0) {
+    return "no container registered — start a session first";
+  }
+  if (!info.containers.some((c) => c.running)) {
+    return "container stopped — start a session first";
+  }
+  return null;
+}
+
 async function promptAgentSelection(
   candidates: Array<{ info: AgentContainerInfo; displayName: string }>,
 ): Promise<AgentContainerInfo | null> {
@@ -125,14 +138,11 @@ async function promptAgentSelection(
     console.log("\nRegistered agents:");
     candidates.forEach((c, i) => {
       const idx = String(i + 1).padStart(2);
-      if (c.info.containerBacked) {
-        const running = c.info.containers.some((cn) => cn.running);
-        const status = running ? "running" : "container stopped";
-        console.log(`  ${idx}. ${c.displayName} [${status}]`);
+      const reason = getContainerUnavailableReason(c.info);
+      if (reason === null) {
+        console.log(`  ${idx}. ${c.displayName} [container running]`);
       } else {
-        console.log(
-          `  ${idx}. ${c.displayName} [unavailable: ${c.info.unavailableReason ?? "not container-backed"}]`,
-        );
+        console.log(`  ${idx}. ${c.displayName} [unavailable: ${reason}]`);
       }
     });
     console.log("");
@@ -142,13 +152,30 @@ async function promptAgentSelection(
         const trimmed = answer.trim();
         const num = Number.parseInt(trimmed, 10);
         if (!Number.isNaN(num) && num >= 1 && num <= candidates.length) {
-          resolve(candidates[num - 1].info);
+          const candidate = candidates[num - 1];
+          const reason = getContainerUnavailableReason(candidate.info);
+          if (reason !== null) {
+            console.error(`  Agent "${candidate.info.agentId}" is unavailable: ${reason}`);
+            resolve(null);
+            return;
+          }
+          resolve(candidate.info);
           return;
         }
         const found = candidates.find(
           (c) => normalizeAgentId(c.info.agentId) === normalizeAgentId(trimmed),
         );
-        resolve(found?.info ?? null);
+        if (found) {
+          const reason = getContainerUnavailableReason(found.info);
+          if (reason !== null) {
+            console.error(`  Agent "${found.info.agentId}" is unavailable: ${reason}`);
+            resolve(null);
+            return;
+          }
+          resolve(found.info);
+          return;
+        }
+        resolve(null);
       });
     });
   } finally {

--- a/src/commands/agents.commands.ssh.ts
+++ b/src/commands/agents.commands.ssh.ts
@@ -1,0 +1,266 @@
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import { readRegistry } from "../agents/sandbox/registry.js";
+import { resolveSandboxAgentId } from "../agents/sandbox/shared.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { type RuntimeEnv, defaultRuntime } from "../runtime.js";
+import { requireValidConfig } from "./agents.command-shared.js";
+import { buildAgentSummaries } from "./agents.config.js";
+
+type ContainerRuntime = "docker" | "podman";
+
+export type AgentContainerInfo = {
+  agentId: string;
+  containerBacked: boolean;
+  unavailableReason?: string;
+  containers: ReadonlyArray<{
+    containerName: string;
+    backendId: string;
+    running: boolean;
+  }>;
+};
+
+export type AgentsSshOptions = {
+  agent?: string;
+  nonInteractive?: boolean;
+};
+
+function detectContainerRuntime(): ContainerRuntime | null {
+  for (const rt of ["podman", "docker"] as ContainerRuntime[]) {
+    const result = spawnSync(rt, ["--version"], { encoding: "utf8", timeout: 5000 });
+    if (result.status === 0) {
+      return rt;
+    }
+  }
+  return null;
+}
+
+function isContainerRunning(runtime: ContainerRuntime, containerName: string): boolean {
+  const result = spawnSync(runtime, ["inspect", "--format", "{{.State.Running}}", containerName], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  return result.status === 0 && result.stdout.trim() === "true";
+}
+
+async function resolveAgentContainerInfo(
+  agentId: string,
+  cfg: Awaited<ReturnType<typeof requireValidConfig>>,
+): Promise<AgentContainerInfo> {
+  const normalized = normalizeAgentId(agentId);
+  const sandboxCfg = resolveSandboxConfigForAgent(cfg ?? undefined, normalized);
+
+  if (sandboxCfg.mode === "off") {
+    return {
+      agentId: normalized,
+      containerBacked: false,
+      unavailableReason: "sandbox mode is off (not container-backed)",
+      containers: [],
+    };
+  }
+
+  if (sandboxCfg.backend !== "docker") {
+    return {
+      agentId: normalized,
+      containerBacked: false,
+      unavailableReason: `sandbox backend is "${sandboxCfg.backend}", not docker`,
+      containers: [],
+    };
+  }
+
+  const registry = await readRegistry();
+  const agentContainers = registry.entries.filter((entry) => {
+    const resolvedId = resolveSandboxAgentId(entry.sessionKey);
+    return resolvedId !== undefined && normalizeAgentId(resolvedId) === normalized;
+  });
+
+  const containerRuntime = detectContainerRuntime();
+  const containers = agentContainers.map((entry) => ({
+    containerName: entry.containerName,
+    backendId: entry.backendId ?? "docker",
+    running: containerRuntime ? isContainerRunning(containerRuntime, entry.containerName) : false,
+  }));
+
+  return {
+    agentId: normalized,
+    containerBacked: true,
+    containers,
+  };
+}
+
+function openShell(containerName: string): void {
+  const runtime = detectContainerRuntime();
+  if (!runtime) {
+    throw new Error(
+      "No container runtime found. Install Docker or Podman to use container shell access.",
+    );
+  }
+
+  const result = spawnSync(runtime, ["exec", "-it", containerName, "/bin/bash"], {
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    const fallback = spawnSync(runtime, ["exec", "-it", containerName, "/bin/sh"], {
+      stdio: "inherit",
+    });
+    if (fallback.status !== 0 && fallback.status !== null) {
+      process.exitCode = fallback.status;
+    }
+    return;
+  }
+
+  if (result.status !== null && result.status !== 0) {
+    process.exitCode = result.status;
+  }
+}
+
+async function promptAgentSelection(
+  candidates: Array<{ info: AgentContainerInfo; displayName: string }>,
+): Promise<AgentContainerInfo | null> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    console.log("\nRegistered agents:");
+    candidates.forEach((c, i) => {
+      const idx = String(i + 1).padStart(2);
+      if (c.info.containerBacked) {
+        const running = c.info.containers.some((cn) => cn.running);
+        const status = running ? "running" : "container stopped";
+        console.log(`  ${idx}. ${c.displayName} [${status}]`);
+      } else {
+        console.log(
+          `  ${idx}. ${c.displayName} [unavailable: ${c.info.unavailableReason ?? "not container-backed"}]`,
+        );
+      }
+    });
+    console.log("");
+
+    return await new Promise((resolve) => {
+      rl.question("Select agent (number or name, ctrl+c to cancel): ", (answer) => {
+        const trimmed = answer.trim();
+        const num = Number.parseInt(trimmed, 10);
+        if (!Number.isNaN(num) && num >= 1 && num <= candidates.length) {
+          resolve(candidates[num - 1].info);
+          return;
+        }
+        const found = candidates.find(
+          (c) => normalizeAgentId(c.info.agentId) === normalizeAgentId(trimmed),
+        );
+        resolve(found?.info ?? null);
+      });
+    });
+  } finally {
+    rl.close();
+  }
+}
+
+export async function agentsSshCommand(
+  opts: AgentsSshOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  const cfg = await requireValidConfig(runtime);
+  if (!cfg) {
+    return;
+  }
+
+  let targetInfo: AgentContainerInfo | null = null;
+
+  if (opts.agent) {
+    const agentId = normalizeAgentId(opts.agent);
+    const summaries = buildAgentSummaries(cfg, { includeImplicitDefault: true });
+    const exists = summaries.some((s) => normalizeAgentId(s.id) === agentId);
+    if (!exists) {
+      runtime.error(
+        `Agent "${opts.agent}" is not registered. Run 'gemmaclaw list' to see configured agents.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    targetInfo = await resolveAgentContainerInfo(agentId, cfg);
+  } else {
+    const summaries = buildAgentSummaries(cfg, { includeImplicitDefault: true });
+
+    if (summaries.length === 0) {
+      runtime.error(
+        "No agents configured. Run 'gemmaclaw create <name>' or 'gemmaclaw setup' first.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const isTTY = process.stdin.isTTY && process.stdout.isTTY;
+    if (!isTTY || opts.nonInteractive) {
+      runtime.error(
+        "No agent specified. Usage: gemmaclaw ssh <agent>\n" +
+          "Run 'gemmaclaw list' to see configured agents.",
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const candidates = await Promise.all(
+      summaries.map(async (s) => ({
+        info: await resolveAgentContainerInfo(s.id, cfg),
+        displayName: s.name && s.name !== s.id ? `${s.id} (${s.name})` : s.id,
+      })),
+    );
+
+    const selected = await promptAgentSelection(candidates);
+    if (!selected) {
+      runtime.error("No valid agent selected.");
+      process.exitCode = 1;
+      return;
+    }
+    targetInfo = selected;
+  }
+
+  if (!targetInfo.containerBacked) {
+    runtime.error(
+      `Agent "${targetInfo.agentId}" does not have a container-backed sandbox.\n` +
+        `Reason: ${targetInfo.unavailableReason ?? "not container-backed"}\n\n` +
+        `To enable container mode, run 'gemmaclaw setup' and choose the Docker sandbox option.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const runningContainers = targetInfo.containers.filter((c) => c.running);
+
+  if (runningContainers.length === 0) {
+    if (targetInfo.containers.length === 0) {
+      runtime.error(
+        `No containers found for agent "${targetInfo.agentId}".\n` +
+          `Start a session first so the sandbox container is created, then re-run this command.`,
+      );
+    } else {
+      runtime.error(
+        `Container for agent "${targetInfo.agentId}" is not running.\n` +
+          `Start a session for this agent first, then re-run this command.`,
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const container = runningContainers[0];
+  runtime.log(
+    `Opening shell in container ${container.containerName} (agent: ${targetInfo.agentId})...`,
+  );
+  runtime.log(
+    `Note: this opens a container shell via '${container.backendId} exec', not a network SSH connection.`,
+  );
+  openShell(container.containerName);
+}
+
+export async function resolveAgentsSshInfo(
+  agentIds: string[],
+  cfg: Awaited<ReturnType<typeof requireValidConfig>>,
+): Promise<Map<string, AgentContainerInfo>> {
+  const result = new Map<string, AgentContainerInfo>();
+  for (const agentId of agentIds) {
+    result.set(normalizeAgentId(agentId), await resolveAgentContainerInfo(agentId, cfg));
+  }
+  return result;
+}

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -30,6 +30,10 @@ export type AgentSummary = {
   routes?: string[];
   providers?: string[];
   isDefault: boolean;
+  /** Whether this agent has a container-backed sandbox that supports shell access. */
+  shellAvailable?: boolean;
+  /** Human-readable reason when shellAvailable is false. */
+  shellUnavailableReason?: string;
 };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -34,6 +34,20 @@ export type AgentSummary = {
   shellAvailable?: boolean;
   /** Human-readable reason when shellAvailable is false. */
   shellUnavailableReason?: string;
+  /** Machine-readable container/sandbox status for CLI/UI shell access. */
+  containerShell?: {
+    eligible: boolean;
+    available: boolean;
+    mode: string;
+    backend: string;
+    reason?: string;
+    containers: Array<{
+      name: string;
+      backend: string;
+      exists: boolean;
+      running: boolean;
+    }>;
+  };
 };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -1,6 +1,74 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listAgentEntries } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { assertDockerForContainerMode, type DockerProbe } from "./setup-gemma.js";
+import {
+  assertDockerForContainerMode,
+  setupGemmaCommand,
+  type DockerProbe,
+} from "./setup-gemma.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
+
+// Shared mutable state hoisted so vi.mock factories can reference it.
+const hoisted = vi.hoisted(() => {
+  let capturedMutatedConfig: OpenClawConfig = {};
+  return {
+    get capturedMutatedConfig() {
+      return capturedMutatedConfig;
+    },
+    set capturedMutatedConfig(v: OpenClawConfig) {
+      capturedMutatedConfig = v;
+    },
+    reset() {
+      capturedMutatedConfig = {};
+    },
+  };
+});
+
+vi.mock("../config/mutate.js", () => ({
+  mutateConfigFile: vi.fn(async (params: { mutate: (draft: OpenClawConfig) => unknown }) => {
+    const draft: OpenClawConfig = {};
+    await params.mutate(draft);
+    hoisted.capturedMutatedConfig = structuredClone(draft);
+    return {
+      path: "/tmp/test-openclaw.json",
+      previousHash: null,
+      snapshot: {},
+      nextConfig: draft,
+      result: undefined,
+    };
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => hoisted.capturedMutatedConfig),
+}));
+
+vi.mock("../gemmaclaw/provision/bootstrap-profiles.js", () => ({
+  applyBootstrapProfile: vi.fn(),
+}));
+
+// Stub out filesystem writes so tests don't touch disk.
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const mkdirSyncStub = vi.fn();
+  const writeFileSyncStub = vi.fn();
+  const readFileSyncStub = vi.fn().mockImplementation(() => {
+    throw Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+  });
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      mkdirSync: mkdirSyncStub,
+      writeFileSync: writeFileSyncStub,
+      readFileSync: readFileSyncStub,
+    },
+    mkdirSync: mkdirSyncStub,
+    writeFileSync: writeFileSyncStub,
+    readFileSync: readFileSyncStub,
+  };
+});
 
 function makeRuntime(): RuntimeEnv & { logs: string[]; errors: string[]; exitCodes: number[] } {
   const logs: string[] = [];
@@ -24,6 +92,10 @@ function makeProbe(installed: boolean, running: boolean): DockerProbe {
     isRunning: vi.fn().mockReturnValue(running),
   };
 }
+
+const runtime = createTestRuntime();
+
+const FAKE_GEMINI_KEY = "AIzaSyFakeTestKeyForUnitTests";
 
 describe("assertDockerForContainerMode", () => {
   describe("Docker not installed", () => {
@@ -174,5 +246,116 @@ describe("assertDockerForContainerMode", () => {
       expect(probe.isInstalled).not.toHaveBeenCalled();
       expect(runtime.exit).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("setupGemmaCommand — agent creation", () => {
+  let originalGeminiKey: string | undefined;
+
+  beforeEach(() => {
+    hoisted.reset();
+    vi.clearAllMocks();
+    runtime.log.mockReset();
+    runtime.error.mockReset();
+    runtime.exit.mockReset();
+
+    originalGeminiKey = process.env.GEMINI_API_KEY;
+    process.env.GEMINI_API_KEY = FAKE_GEMINI_KEY;
+  });
+
+  afterEach(() => {
+    hoisted.reset();
+    if (originalGeminiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiKey;
+    }
+  });
+
+  it("writes the named agent to agents.list when using the Gemini backend", async () => {
+    await setupGemmaCommand(
+      {
+        nonInteractive: true,
+        dryRun: true,
+        agentName: "Steve",
+        setupMode: "gemini",
+        model: "gemini-2.0-flash",
+        thinking: "off",
+        noContainer: true,
+      },
+      runtime,
+    );
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+
+    const cfg = hoisted.capturedMutatedConfig;
+    const entries = listAgentEntries(cfg);
+    expect(entries.length).toBeGreaterThan(0);
+    const entry = entries.find((e) => e.id === "steve");
+    expect(entry).toBeDefined();
+    expect(entry?.name).toBe("Steve");
+  });
+
+  it("produces an agents.list readable by listAgentEntries (same function used by gemmaclaw list)", async () => {
+    await setupGemmaCommand(
+      {
+        nonInteractive: true,
+        dryRun: true,
+        agentName: "SetupAgent",
+        setupMode: "gemini",
+        model: "gemini-2.5-pro",
+        thinking: "medium",
+        noContainer: true,
+      },
+      runtime,
+    );
+
+    const cfg = hoisted.capturedMutatedConfig;
+    const ids = listAgentEntries(cfg).map((e) => e.id);
+    expect(ids).toContain("setupagent");
+  });
+
+  it("normalizes the agent id to lowercase but preserves the display name", async () => {
+    await setupGemmaCommand(
+      {
+        nonInteractive: true,
+        dryRun: true,
+        agentName: "WorkBot",
+        setupMode: "gemini",
+        model: "gemini-2.0-flash",
+        thinking: "off",
+        noContainer: true,
+      },
+      runtime,
+    );
+
+    const cfg = hoisted.capturedMutatedConfig;
+    const entries = listAgentEntries(cfg);
+    const entry = entries.find((e) => e.id === "workbot");
+    expect(entry).toBeDefined();
+    expect(entry?.name).toBe("WorkBot");
+  });
+
+  it("records agent workspace and agentDir in the written config entry", async () => {
+    await setupGemmaCommand(
+      {
+        nonInteractive: true,
+        dryRun: true,
+        agentName: "DevBot",
+        setupMode: "gemini",
+        model: "gemini-2.0-flash",
+        thinking: "off",
+        noContainer: true,
+      },
+      runtime,
+    );
+
+    const cfg = hoisted.capturedMutatedConfig;
+    const entry = listAgentEntries(cfg).find((e) => e.id === "devbot");
+    expect(entry).toBeDefined();
+    expect(typeof entry?.workspace).toBe("string");
+    expect(entry?.workspace?.length).toBeGreaterThan(0);
+    expect(typeof entry?.agentDir).toBe("string");
+    expect(entry?.agentDir?.length).toBeGreaterThan(0);
   });
 });

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -2,14 +2,18 @@ import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type {
   OnboardingBackend,
   OnboardingBootstrap,
   OnboardingChoices,
   OnboardingThinking,
 } from "../gemmaclaw/provision/onboarding-wizard.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
+import { applyAgentConfig, listAgentEntries } from "./agents.config.js";
 
 export type SetupGemmaCommandOpts = {
   advanced?: boolean;
@@ -212,6 +216,27 @@ function resolveLocalOllamaModel(modelChoice: string, fallback?: string): string
 
 function persistThinkingDefault(thinking: OnboardingThinking): "off" | "low" | "medium" | "high" {
   return thinking;
+}
+
+function applySetupAgentConfig(draft: OpenClawConfig, choices: OnboardingChoices): void {
+  const existingEntries = listAgentEntries(draft);
+  const agentId = normalizeAgentId(choices.agentName);
+  const workspaceDir = resolveAgentWorkspaceDir(draft, agentId);
+  const agentDir = resolveAgentDir(draft, agentId);
+  const nextConfig = applyAgentConfig(draft, {
+    agentId,
+    name: choices.agentName.trim() || agentId,
+    workspace: workspaceDir,
+    agentDir,
+  });
+
+  draft.agents = nextConfig.agents;
+  if (existingEntries.length === 0) {
+    draft.agents = {
+      ...draft.agents,
+      list: (draft.agents?.list ?? []).filter((entry) => normalizeAgentId(entry?.id) === agentId),
+    };
+  }
 }
 
 export async function setupGemmaCommand(
@@ -422,6 +447,7 @@ export async function setupGemmaCommand(
           draft.agents.defaults ??= {};
           draft.agents.defaults.model = `ollama/${ollamaModel}`;
           draft.agents.defaults.thinkingDefault = persistThinkingDefault(choices.thinkingLevel);
+          applySetupAgentConfig(draft, choices);
 
           draft.tools ??= {};
           draft.tools.exec ??= {};
@@ -567,7 +593,7 @@ async function setupVertexBackend(
 async function writeGeminiAuthProfile(agentName: string, apiKey: string): Promise<void> {
   const fs = await import("node:fs");
   const homeDir = process.env.OPENCLAW_HOME ?? process.env.HOME ?? "/root";
-  const agentDir = path.join(homeDir, ".openclaw", "agents", agentName, "agent");
+  const agentDir = path.join(homeDir, ".openclaw", "agents", normalizeAgentId(agentName), "agent");
   const authPath = path.join(agentDir, "auth-profiles.json");
   let auth: Record<string, unknown> = { version: 1, profiles: {} };
   try {
@@ -589,7 +615,7 @@ async function writeVertexAuthProfile(agentName: string, accessToken: string): P
     homeDir,
     ".openclaw",
     "agents",
-    agentName,
+    normalizeAgentId(agentName),
     "agent",
     "auth-profiles.json",
   );
@@ -644,6 +670,7 @@ async function applySharedAgentDefaults(
           workspaceAccess: "rw",
         };
       }
+      applySetupAgentConfig(draft, choices);
     },
   });
   await applyAgentNameAndBootstrap(choices);
@@ -651,10 +678,13 @@ async function applySharedAgentDefaults(
 
 async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Promise<void> {
   const fs = await import("node:fs");
+  const { loadConfig } = await import("../config/config.js");
   const { applyBootstrapProfile } = await import("../gemmaclaw/provision/bootstrap-profiles.js");
-  const homeDir = process.env.OPENCLAW_HOME ?? process.env.HOME ?? "/root";
-  const agentRoot = path.join(homeDir, ".openclaw", "agents", choices.agentName);
-  fs.mkdirSync(path.join(agentRoot, "agent"), { recursive: true });
+  const cfg = loadConfig();
+  const agentId = normalizeAgentId(choices.agentName);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const agentRoot = path.dirname(agentDir);
+  fs.mkdirSync(agentDir, { recursive: true });
   fs.mkdirSync(path.join(agentRoot, "sessions"), { recursive: true });
   // Stamp a tiny manifest so we can verify which bootstrap profile was chosen
   // without relying on parsing the larger config file.
@@ -677,14 +707,9 @@ async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Promise<v
   );
 
   // Drop the bootstrap profile's starter files (AGENTS.md, optional TOOLS.md)
-  // into the workspace. We use the workspace dir from the existing default
-  // (~/.openclaw/workspace for the "main" agent; per-agent under
-  // ~/.openclaw/workspaces/<name> for everyone else) and never overwrite
-  // user edits — `applyBootstrapProfile` skips existing files by default.
-  const workspaceDir =
-    choices.agentName === "main"
-      ? path.join(homeDir, ".openclaw", "workspace")
-      : path.join(homeDir, ".openclaw", "workspaces", choices.agentName);
+  // into the same workspace recorded in the canonical agent config. Never
+  // overwrite user edits — `applyBootstrapProfile` skips existing files by default.
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   applyBootstrapProfile(choices.bootstrap, workspaceDir);
 }
 


### PR DESCRIPTION
## Summary

- Adds `gemmaclaw ssh [agent]` command that opens a container shell via `docker exec` / `podman exec`
- Interactive agent picker in TTY mode; non-container agents shown but disabled with clear reason
- `gemmaclaw list` and `list --json` now include `shellAvailable` / `shellUnavailableReason` fields per agent
- Zero-agent config handled gracefully; stopped/missing containers reported before exec attempt
- Site (`setup.html`) updated with `gemmaclaw ssh` CLI reference; README quick-start updated

## Changes

- `src/commands/agents.commands.ssh.ts` — core command logic (container registry lookup, TTY selector, exec)
- `src/cli/program/register.ssh.ts` — commander registration wired into CLI
- `src/cli/program/command-registry-core.ts` + `core-command-descriptors.ts` — route `ssh` command
- `src/commands/agents.config.ts` — `AgentSummary` gains `shellAvailable` / `shellUnavailableReason`
- `src/commands/agents.commands.list.ts` — populate shell availability from container registry
- `src/cli/program/register.ssh.test.ts` (6 tests) + `src/commands/agents.commands.ssh.test.ts` (13 tests)
- `scripts/site/generate-site.py` + `site/setup.html` — add `gemmaclaw ssh` to CLI reference
- `README.md` — add ssh / list to quick-start

## Test plan

- [x] `register.ssh.test.ts`: 6 tests pass (command registration, arg passing, flags)
- [x] `agents.commands.ssh.test.ts`: 13 tests pass (all error paths, container detection, multi-agent)
- [x] `register.list.test.ts`: 2 tests pass (no regression)
- [x] `pnpm check:changed`: tsgo typecheck clean, lint clean, 1182 tests pass
- [x] `gemmaclaw ssh --help` and `gemmaclaw list --help` smoke checks pass