### PR TITLE
fix(setup): honor OPENCLAW_SETUP_DRY_RUN env var when --dry-run flag absent

### DIFF
--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -59,6 +59,15 @@ describe("registerSetupCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
+  it("passes dryRun: false when --dry-run flag is absent (env-var override handled inside setupGemmaCommand)", async () => {
+    await runCli(["setup"]);
+
+    expect(setupGemmaCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: false }),
+      runtime,
+    );
+  });
+
   it("runs Gemma setup wizard in advanced mode with --advanced", async () => {
     await runCli(["setup", "--advanced"]);
 

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -241,7 +241,7 @@ export async function setupGemmaCommand(
     runtime.exit(1);
   }
 
-  const dryRun = opts.dryRun ?? process.env.OPENCLAW_SETUP_DRY_RUN === "1";
+  const dryRun = opts.dryRun || process.env.OPENCLAW_SETUP_DRY_RUN === "1";
 
   // Build onboarding choices either from CLI flags (non-interactive) or from
   // the interactive wizard. The wizard accepts presets so flags partially


### PR DESCRIPTION
## Summary

- The `--dry-run` CLI option defaults to `false` (not `undefined`), so `opts.dryRun ?? env_check` evaluates to `false` even when `OPENCLAW_SETUP_DRY_RUN=1` — the env var was silently ignored
- Changed `??` to `||` on line 244 of `setup-gemma.ts` so a `false` default defers to the env var
- The E2E Docker CI job sets `OPENCLAW_SETUP_DRY_RUN=1` to skip the Docker availability check inside the container; with `??` this was ignored, causing `assertDockerForContainerMode` to call `exit(1)` on every E2E run

## Test plan

- [x] `setup-gemma.test.ts`: 12/12 pass (all Docker validation tests from PR #87)
- [x] `register.setup.test.ts`: 10/10 pass (includes new test asserting `dryRun: false` forwarded from CLI, documenting env-var override is handled inside `setupGemmaCommand`)
- [x] Full `vitest.commands.config.ts` shard: 993/993 pass
- [x] Type-check clean (`tsgo:core`)
- [x] Lint clean (`oxlint`)