### PR TITLE
feat(tui): gemmaclaw tui [agent] command with per-agent ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ npm install -g .
 
 gemmaclaw setup           # auto-detect hardware, provision Gemma backend
 gemmaclaw create work     # create a named agent instance
-gemmaclaw chat            # open chat UI (picks agent interactively)
+gemmaclaw tui work        # open local TUI/chat for the "work" agent
+gemmaclaw tui             # pick an agent interactively (TTY only)
+gemmaclaw chat            # open browser chat UI (picks agent interactively)
 gemmaclaw message --agent work "summarize this repo"   # one-shot message
 gemmaclaw list            # list agents with container shell availability
 gemmaclaw ssh work        # open a shell inside the 'work' agent's container
 ```
+
+`gemmaclaw tui <agent>` targets exactly that named agent. Host-local agents open the terminal TUI directly. Docker-backed agents start or reuse browser chat on `127.0.0.1` with a persistent, collision-safe per-agent port recorded in `~/.gemmaclaw/state/tui-ports.json`, so `work` and `play` can run side by side.
 
 ## Documentation
 

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -1015,7 +1015,7 @@ npm install -g .</code></pre></div>
       <p>Running <code>gemmaclaw setup</code> kicks off a six-question wizard. Press Enter at any prompt to keep the bracketed default. Every question is also exposed as a CLI flag so you can script the whole flow.</p>
 
       <ol class="setup-steps">
-        <li><strong>Agent name</strong> &mdash; the identity for this assistant. Each agent has its own workspace and memory under <code>~/.openclaw/agents/&lt;name&gt;/</code>. Use <code>main</code> if you only run one. Flag: <code>--agent-name &lt;name&gt;</code>.</li>
+        <li><strong>Agent name</strong> &mdash; the identity for this assistant. Each agent has its own workspace and memory under <code>~/.gemmaclaw/agents/&lt;name&gt;/</code>. Use <code>main</code> if you only run one. Flag: <code>--agent-name &lt;name&gt;</code>.</li>
         <li><strong>Run environment</strong> &mdash; do tools (shell, files, browser) execute inside a Docker sandbox or directly on your host? Container is the safer default; host is faster but the agent can read and modify your real files. Flag: <code>--no-container</code>.</li>
         <li><strong>Backend / provider</strong> &mdash; Local Gemma on this machine, the hosted Gemini API, or Google Cloud Vertex AI. Flag: <code>--setup-mode local|gemini|vertex</code>.</li>
         <li><strong>Model</strong> &mdash; for Local you can pick auto (recommended) or a specific Gemma size. Gemini and Vertex offer their own catalogs. Flag: <code>--model &lt;id&gt;</code>.</li>
@@ -1058,9 +1058,9 @@ Setup complete. Try it now:
 
       <p><strong>Where things get written:</strong></p>
       <ul class="setup-list">
-        <li>Per-agent state: <code>~/.openclaw/agents/&lt;name&gt;/</code> (manifest, sessions, auth profile)</li>
-        <li>Workspace bootstrap files: <code>~/.openclaw/workspace/AGENTS.md</code> for the <code>main</code> agent, or <code>~/.openclaw/workspaces/&lt;name&gt;/AGENTS.md</code> for everyone else (the bootstrap profile drops AGENTS.md and, for the coding profile, TOOLS.md)</li>
-        <li>Global config: <code>~/.openclaw/openclaw.json</code> (model defaults, thinking level, sandbox toggle)</li>
+        <li>Per-agent state: <code>~/.gemmaclaw/agents/&lt;name&gt;/</code> (manifest, sessions, auth profile)</li>
+        <li>Workspace bootstrap files: <code>~/.gemmaclaw/workspace/AGENTS.md</code> for the <code>main</code> agent, or <code>~/.gemmaclaw/workspaces/&lt;name&gt;/AGENTS.md</code> for everyone else (the bootstrap profile drops AGENTS.md and, for the coding profile, TOOLS.md)</li>
+        <li>Global config: <code>~/.gemmaclaw/openclaw.json</code> (model defaults, thinking level, sandbox toggle)</li>
       </ul>
 
       <p><strong>Non-interactive / CI:</strong> combine <code>--non-interactive</code> with the per-question flags to script the whole wizard without prompts. Add <code>--dry-run</code> to skip backend provisioning, gateway start, and smoke tests &mdash; useful for CI smoke tests of the wizard itself. Example:</p>
@@ -1171,21 +1171,27 @@ gemmaclaw setup --vertex --vertex-project my-project</code></pre></div>
       <div class="code-block"><pre><code># Create a named agent instance
 gemmaclaw create work
 
-# Open chat UI in your browser
+# Open local TUI/chat for the "work" agent
+gemmaclaw tui work
+
+# Pick an agent interactively (TTY only)
+gemmaclaw tui
+
+# Docker-backed agents open browser chat on a persistent 127.0.0.1 port
+gemmaclaw tui play --no-open
+
+# Open browser chat UI directly
 gemmaclaw chat
 
 # One-shot message from the command line
-gemmaclaw message --agent work "summarize today's news"
-
-# Terminal UI (for SSH sessions)
-gemmaclaw tui</code></pre></div>
+gemmaclaw message --agent work "summarize today's news"</code></pre></div>
       <h3 id="cli-reference">CLI Reference</h3>
       <p>Global options available on all commands:</p>
       <div class="table-wrap"><table>
         <thead><tr><th>Option</th><th>Description</th></tr></thead>
         <tbody>
-          <tr><td><code>--profile &lt;name&gt;</code></td><td>Use a named profile (isolates state under <code>~/.openclaw-&lt;name&gt;</code>)</td></tr>
-          <tr><td><code>--dev</code></td><td>Dev profile: isolate state under <code>~/.openclaw-dev</code>, use port 19001</td></tr>
+          <tr><td><code>--profile &lt;name&gt;</code></td><td>Use a named profile (isolates state under <code>~/.gemmaclaw-&lt;name&gt;</code>)</td></tr>
+          <tr><td><code>--dev</code></td><td>Dev profile: isolate state under <code>~/.gemmaclaw-dev</code>, use port 19001</td></tr>
           <tr><td><code>--log-level &lt;level&gt;</code></td><td>Log level: silent, fatal, error, warn, info, debug, trace</td></tr>
           <tr><td><code>--no-color</code></td><td>Disable ANSI colors</td></tr>
           <tr><td><code>-V, --version</code></td><td>Print version and commit hash</td></tr>
@@ -1203,7 +1209,7 @@ gemmaclaw tui</code></pre></div>
             <tr><td><code>--non-interactive</code></td><td>Run without prompts (uses safe defaults)</td></tr>
             <tr><td><code>--accept-risk</code></td><td>Required with <code>--non-interactive</code>; acknowledges local agent system-access risk</td></tr>
             <tr><td><code>--wizard</code></td><td>Run interactive workspace config onboarding</td></tr>
-            <tr><td><code>--workspace &lt;dir&gt;</code></td><td>Agent workspace directory (default: <code>~/.openclaw/workspace</code>)</td></tr>
+            <tr><td><code>--workspace &lt;dir&gt;</code></td><td>Agent workspace directory (default: <code>~/.gemmaclaw/workspace</code>)</td></tr>
             <tr><td><code>--workspace-only</code></td><td>Only initialize workspace config, skip Gemma provisioning</td></tr>
           </tbody>
         </table></div>
@@ -1234,7 +1240,7 @@ gemmaclaw setup --non-interactive --accept-risk --no-container</code></pre></div
 gemmaclaw create work
 
 # Non-interactive with model
-gemmaclaw create dev --model ollama/gemma3:4b --workspace ~/.openclaw/workspace/dev
+gemmaclaw create dev --model ollama/gemma3:4b --workspace ~/.gemmaclaw/workspace/dev
 
 # Scripted/CI
 gemmaclaw create play --non-interactive</code></pre></div>
@@ -1318,20 +1324,32 @@ gemmaclaw message --agent dev --text "hi" --json</code></pre></div>
       </div>
 
       <div class="cli-cmd-card">
-        <h4 id="cmd-tui"><code>gemmaclaw tui</code></h4>
-        <p>Terminal-based chat UI. Useful for SSH sessions or when you prefer the terminal.</p>
+        <h4 id="cmd-tui"><code>gemmaclaw tui [agent]</code></h4>
+        <p>Open a local TUI/chat for a named Gemmaclaw agent. Host-local agents open the terminal TUI directly. Docker-backed agents start or reuse browser chat on <code>127.0.0.1</code> using a persistent, collision-safe per-agent port recorded under <code>~/.gemmaclaw/state/tui-ports.json</code>.</p>
         <div class="table-wrap"><table>
           <thead><tr><th>Option</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>--message &lt;text&gt;</code></td><td>Send an initial message after connecting</td></tr>
-            <tr><td><code>--session &lt;key&gt;</code></td><td>Session key (default: "main")</td></tr>
-            <tr><td><code>--local</code></td><td>Run against the local embedded agent runtime</td></tr>
-            <tr><td><code>--url &lt;url&gt;</code></td><td>Gateway WebSocket URL (for remote gateways)</td></tr>
+            <tr><td><code>[agent]</code></td><td>Agent name (positional, or use <code>--agent</code>)</td></tr>
+            <tr><td><code>--agent &lt;id&gt;</code></td><td>Agent id (alias for the positional argument)</td></tr>
+            <tr><td><code>--port &lt;port&gt;</code></td><td>Host port override for container-backed agents</td></tr>
+            <tr><td><code>--no-open</code></td><td>Print URL but do not open browser (container agents)</td></tr>
           </tbody>
         </table></div>
-        <div class="code-block"><pre><code>gemmaclaw tui
-gemmaclaw tui --message "summarize my last meeting"
-gemmaclaw tui --url ws://192.168.1.50:3001</code></pre></div>
+        <div class="code-block"><pre><code># Direct named launch
+gemmaclaw tui work
+
+# Interactive agent picker (requires a TTY)
+gemmaclaw tui
+
+# Container-backed local access: print/open the per-agent localhost URL
+gemmaclaw tui play --no-open
+
+# Override the container-backed localhost port after cleanup
+gemmaclaw tui play --port 9150
+
+# Separate agents keep separate persisted ports
+gemmaclaw tui work
+gemmaclaw tui play</code></pre></div>
       </div>
 
       <div class="cli-cmd-card">
@@ -1507,12 +1525,12 @@ gemmaclaw provision --backend gemma-cpp</code></pre></div>
       </table></div>
 
       <h3>Configuration</h3>
-      <p>Config lives at <code>~/.openclaw/openclaw.json</code>. Edit directly or use the CLI:</p>
+      <p>Config lives at <code>~/.gemmaclaw/openclaw.json</code>. Edit directly or use the CLI:</p>
       <div class="code-block"><pre><code>gemmaclaw config get gateway.port
 gemmaclaw config set gateway.port 3001
 gemmaclaw config validate
 gemmaclaw configure</code></pre></div>
-      <p>Named profiles (<code>--profile mytest</code>) isolate all state under <code>~/.openclaw-mytest/</code>, useful for testing or running multiple instances.</p>
+      <p>Named profiles (<code>--profile mytest</code>) isolate all state under <code>~/.gemmaclaw-mytest/</code>, useful for testing or running multiple instances.</p>
 
       <h3 id="troubleshooting">Troubleshooting</h3>
       <ul class="setup-list">

--- a/site/setup.html
+++ b/site/setup.html
@@ -803,14 +803,20 @@ gemmaclaw setup --vertex --vertex-project my-project</code></pre></div>
       <div class="code-block"><pre><code># Create a named agent instance
 gemmaclaw create work
 
-# Open chat UI in your browser
+# Open local TUI/chat for the "work" agent
+gemmaclaw tui work
+
+# Pick an agent interactively (TTY only)
+gemmaclaw tui
+
+# Docker-backed agents open browser chat on a persistent 127.0.0.1 port
+gemmaclaw tui play --no-open
+
+# Open browser chat UI directly
 gemmaclaw chat
 
 # One-shot message from the command line
-gemmaclaw message --agent work "summarize today's news"
-
-# Terminal UI (for SSH sessions)
-gemmaclaw tui</code></pre></div>
+gemmaclaw message --agent work "summarize today's news"</code></pre></div>
       <h3 id="cli-reference">CLI Reference</h3>
       <p>Global options available on all commands:</p>
       <div class="table-wrap"><table>
@@ -950,20 +956,32 @@ gemmaclaw message --agent dev --text "hi" --json</code></pre></div>
       </div>
 
       <div class="cli-cmd-card">
-        <h4 id="cmd-tui"><code>gemmaclaw tui</code></h4>
-        <p>Terminal-based chat UI. Useful for SSH sessions or when you prefer the terminal.</p>
+        <h4 id="cmd-tui"><code>gemmaclaw tui [agent]</code></h4>
+        <p>Open a local TUI/chat for a named Gemmaclaw agent. Host-local agents open the terminal TUI directly. Docker-backed agents start or reuse browser chat on <code>127.0.0.1</code> using a persistent, collision-safe per-agent port recorded under <code>~/.gemmaclaw/state/tui-ports.json</code>.</p>
         <div class="table-wrap"><table>
           <thead><tr><th>Option</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>--message &lt;text&gt;</code></td><td>Send an initial message after connecting</td></tr>
-            <tr><td><code>--session &lt;key&gt;</code></td><td>Session key (default: "main")</td></tr>
-            <tr><td><code>--local</code></td><td>Run against the local embedded agent runtime</td></tr>
-            <tr><td><code>--url &lt;url&gt;</code></td><td>Gateway WebSocket URL (for remote gateways)</td></tr>
+            <tr><td><code>[agent]</code></td><td>Agent name (positional, or use <code>--agent</code>)</td></tr>
+            <tr><td><code>--agent &lt;id&gt;</code></td><td>Agent id (alias for the positional argument)</td></tr>
+            <tr><td><code>--port &lt;port&gt;</code></td><td>Host port override for container-backed agents</td></tr>
+            <tr><td><code>--no-open</code></td><td>Print URL but do not open browser (container agents)</td></tr>
           </tbody>
         </table></div>
-        <div class="code-block"><pre><code>gemmaclaw tui
-gemmaclaw tui --message "summarize my last meeting"
-gemmaclaw tui --url ws://192.168.1.50:3001</code></pre></div>
+        <div class="code-block"><pre><code># Direct named launch
+gemmaclaw tui work
+
+# Interactive agent picker (requires a TTY)
+gemmaclaw tui
+
+# Container-backed local access: print/open the per-agent localhost URL
+gemmaclaw tui play --no-open
+
+# Override the container-backed localhost port after cleanup
+gemmaclaw tui play --port 9150
+
+# Separate agents keep separate persisted ports
+gemmaclaw tui work
+gemmaclaw tui play</code></pre></div>
       </div>
 
       <div class="cli-cmd-card">

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -5,7 +5,6 @@ import {
   ensureConfigReady,
   installBaseProgramMocks,
   installSmokeProgramMocks,
-  runTui,
   runtime,
   setupCommand,
   setupWizardCommand,
@@ -13,6 +12,11 @@ import {
 
 installBaseProgramMocks();
 installSmokeProgramMocks();
+
+const launchTuiAgent = vi.fn();
+vi.mock("../commands/agents.commands.tui.js", () => ({
+  launchTuiAgent,
+}));
 
 vi.mock("./config-cli.js", () => ({
   registerConfigCli: (program: {
@@ -38,7 +42,7 @@ describe("cli program (smoke)", () => {
   beforeEach(() => {
     program = createProgram();
     vi.clearAllMocks();
-    runTui.mockResolvedValue(undefined);
+    launchTuiAgent.mockResolvedValue(undefined);
     ensureConfigReady.mockResolvedValue(undefined);
   });
 
@@ -48,15 +52,14 @@ describe("cli program (smoke)", () => {
     expect(names).toContain("status");
   });
 
-  it("runs tui with explicit timeout override", async () => {
-    await runProgram(["tui", "--timeout-ms", "45000"]);
-    expect(runTui).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 45000 }));
+  it("runs tui with a named agent", async () => {
+    await runProgram(["tui", "myagent"]);
+    expect(launchTuiAgent).toHaveBeenCalledWith(expect.objectContaining({ agentArg: "myagent" }));
   });
 
-  it("warns and ignores invalid tui timeout override", async () => {
-    await runProgram(["tui", "--timeout-ms", "nope"]);
-    expect(runtime.error).toHaveBeenCalledWith('warning: invalid --timeout-ms "nope"; ignoring');
-    expect(runTui).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: undefined }));
+  it("runs tui without agent arg (picker)", async () => {
+    await runProgram(["tui"]);
+    expect(launchTuiAgent).toHaveBeenCalledWith(expect.objectContaining({ agentArg: undefined }));
   });
 
   it("runs setup wizard when wizard flags are present", async () => {

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -140,6 +140,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         loadModule: () => import("./register.benchmark.js"),
         exportName: "registerBenchmarkCommand",
       },
+      {
+        commandNames: ["tui"],
+        loadModule: () => import("./register.tui.js"),
+        exportName: "registerTuiCommand",
+      },
     ]),
   ),
 ];

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -115,6 +115,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Run the benchmark suite against your local Gemma model",
     hasSubcommands: false,
   },
+  {
+    name: "tui",
+    description: "Open a local terminal UI for a named Gemmaclaw agent",
+    hasSubcommands: false,
+  },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);
 
 export const CORE_CLI_COMMAND_DESCRIPTORS = coreCliCommandCatalog.descriptors;

--- a/src/cli/program/register.tui.test.ts
+++ b/src/cli/program/register.tui.test.ts
@@ -1,0 +1,122 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerTuiCommand } from "./register.tui.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+  launchTuiAgent: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../commands/agents.commands.tui.js", () => ({
+  launchTuiAgent: mocks.launchTuiAgent,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+vi.mock("../../wizard/clack-prompter.js", () => ({
+  createClackPrompter: vi.fn(() => ({
+    select: vi.fn().mockResolvedValue("work"),
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function runCli(args: string[]) {
+  const program = new Command();
+  program.exitOverride(); // Prevent process.exit during tests
+  registerTuiCommand(program);
+  await program.parseAsync(args, { from: "user" });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("registerTuiCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runtime.exit.mockImplementation(() => {
+      throw new Error("exit called");
+    });
+    mocks.launchTuiAgent.mockResolvedValue(undefined);
+  });
+
+  it("calls launchTuiAgent with positional agent", async () => {
+    await runCli(["tui", "work"]);
+    expect(mocks.launchTuiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentArg: "work" }),
+    );
+  });
+
+  it("calls launchTuiAgent with --agent flag", async () => {
+    await runCli(["tui", "--agent", "play"]);
+    expect(mocks.launchTuiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentArg: "play" }),
+    );
+  });
+
+  it("prefers positional arg over --agent flag", async () => {
+    await runCli(["tui", "work", "--agent", "play"]);
+    expect(mocks.launchTuiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentArg: "work" }),
+    );
+  });
+
+  it("calls launchTuiAgent without agent when omitted (picker will run)", async () => {
+    await runCli(["tui"]);
+    expect(mocks.launchTuiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentArg: undefined }),
+    );
+  });
+
+  it("exits with friendly error when no agents configured", async () => {
+    mocks.launchTuiAgent.mockRejectedValue(
+      new Error("No agents configured. Run 'gemmaclaw create <name>' to create an instance first."),
+    );
+    await expect(runCli(["tui"])).rejects.toThrow("exit called");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("No agents configured"),
+    );
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("gemmaclaw setup"));
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with hint when agent is omitted in non-TTY mode", async () => {
+    mocks.launchTuiAgent.mockRejectedValue(
+      new Error(
+        "No agent specified. Usage: gemmaclaw tui <agent>. Run 'gemmaclaw list' to see configured agents.",
+      ),
+    );
+    await expect(runCli(["tui"])).rejects.toThrow("exit called");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("No agent specified"));
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("gemmaclaw list"));
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("forwards --port as numeric override", async () => {
+    await runCli(["tui", "work", "--port", "9120"]);
+    expect(mocks.launchTuiAgent).toHaveBeenCalledWith(expect.objectContaining({ port: 9120 }));
+  });
+
+  it("passes openBrowser=false when --no-open is given", async () => {
+    await runCli(["tui", "work", "--no-open"]);
+    expect(mocks.launchTuiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ openBrowser: false }),
+    );
+  });
+
+  it("exits with error on invalid --port", async () => {
+    await expect(runCli(["tui", "work", "--port", "notanumber"])).rejects.toThrow("exit called");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("Invalid --port"));
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/cli/program/register.tui.ts
+++ b/src/cli/program/register.tui.ts
@@ -1,0 +1,82 @@
+import type { Command } from "commander";
+import { launchTuiAgent } from "../../commands/agents.commands.tui.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { createClackPrompter } from "../../wizard/clack-prompter.js";
+
+async function defaultPickAgent(agents: string[]): Promise<string | undefined> {
+  const prompter = createClackPrompter();
+  const choice = await prompter.select({
+    message: "Pick a Gemmaclaw instance to open",
+    options: agents.map((id) => ({ value: id, label: id })),
+  });
+  return typeof choice === "string" ? choice : undefined;
+}
+
+export function registerTuiCommand(program: Command) {
+  program
+    .command("tui [agent]")
+    .description("Open a local TUI/chat for a named Gemmaclaw agent")
+    .option("--agent <id>", "Agent id (alias for the positional argument)")
+    .option(
+      "--port <port>",
+      "Host port for container-backed agents (default: derived from agent id)",
+    )
+    .option("--no-open", "For container agents: print URL but do not open browser automatically")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Examples:")}\n` +
+        `  ${theme.muted("gemmaclaw tui work              # terminal TUI for host-local agent 'work'")}\n` +
+        `  ${theme.muted("gemmaclaw tui                   # interactive picker (when multiple agents configured)")}\n` +
+        `  ${theme.muted("gemmaclaw tui play --port 9120  # override container localhost port for 'play'")}\n\n` +
+        `  ${theme.muted("Host-local agents open the terminal TUI; Docker-backed agents open browser chat on 127.0.0.1.")}\n` +
+        `  ${theme.muted("Separate agents get persistent ports in ~/.gemmaclaw/state/tui-ports.json.")}\n` +
+        `\n${theme.muted("Docs:")} ${formatDocsLink("https://gemmaclaw.github.io/gemmaclaw/#cmd-tui", "gemmaclaw.github.io/gemmaclaw/#cmd-tui")}\n`,
+    )
+    .action(async (positionalAgent: string | undefined, opts) => {
+      try {
+        // Accept positional arg OR --agent flag.
+        const rawAgent =
+          (typeof positionalAgent === "string" && positionalAgent.trim()
+            ? positionalAgent.trim()
+            : undefined) ??
+          (typeof opts.agent === "string" && opts.agent.trim() ? opts.agent.trim() : undefined);
+
+        const overridePort = opts.port ? Number.parseInt(String(opts.port), 10) : undefined;
+        if (opts.port !== undefined && (overridePort === undefined || Number.isNaN(overridePort))) {
+          defaultRuntime.error(`Invalid --port: "${String(opts.port)}"`);
+          defaultRuntime.exit(1);
+          return;
+        }
+
+        const isTty = (process.stdin.isTTY ?? false) && (process.stdout.isTTY ?? false);
+
+        await launchTuiAgent({
+          agentArg: rawAgent,
+          port: overridePort,
+          openBrowser: opts.open !== false,
+          deps: { isTty, pickAgent: defaultPickAgent },
+        });
+      } catch (err) {
+        const msg = String(err);
+        // Surface user-friendly hints for common errors.
+        if (msg.includes("No agents configured")) {
+          defaultRuntime.error(msg);
+          defaultRuntime.error("  Run: gemmaclaw setup");
+          defaultRuntime.error("  Or:  gemmaclaw create <name>");
+        } else if (
+          msg.includes("Pass --agent") ||
+          msg.includes("Multiple agents") ||
+          msg.includes("No agent specified")
+        ) {
+          defaultRuntime.error(msg);
+          defaultRuntime.error("  Run: gemmaclaw list  to see available agents");
+        } else {
+          defaultRuntime.error(msg);
+        }
+        defaultRuntime.exit(1);
+      }
+    });
+}

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -63,16 +63,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Manage sandbox containers for agent isolation",
     hasSubcommands: true,
   },
-  {
-    name: "tui",
-    description: "Open a terminal UI connected to the Gateway",
-    hasSubcommands: false,
-  },
-  {
-    name: "terminal",
-    description: "Open a local terminal UI (alias for tui --local)",
-    hasSubcommands: false,
-  },
+
   {
     name: "chat",
     description: "Open a browser-based chat UI for your Gemma assistant",

--- a/src/commands/agents.commands.tui.test.ts
+++ b/src/commands/agents.commands.tui.test.ts
@@ -1,0 +1,308 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  buildTuiAgentLaunchResult,
+  deriveAgentTuiPort,
+  findProcessesOnPort,
+  isContainerBackedAgent,
+  launchTuiAgent,
+  resolveAgentTuiPort,
+  resolveTuiAgent,
+  resolveTuiPortRegistryPath,
+  TUI_AGENT_PORT_END,
+  TUI_AGENT_PORT_START,
+} from "./agents.commands.tui.js";
+
+const mocks = vi.hoisted(() => ({
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+function cfgWithAgents(
+  agents: Array<{ id: string; name?: string; sandbox?: Record<string, unknown> }>,
+  defaults: Record<string, unknown> = {},
+): OpenClawConfig {
+  return {
+    agents: {
+      defaults,
+      list: agents,
+    },
+  } as OpenClawConfig;
+}
+
+function makeTempEnv(): NodeJS.ProcessEnv {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "gemmaclaw-tui-test-"));
+  return { ...process.env, HOME: home, GEMMACLAW_HOME: path.join(home, ".gemmaclaw") };
+}
+
+function findHashCollision(): [string, string] {
+  const seen = new Map<number, string>();
+  for (let i = 0; i < 10_000; i += 1) {
+    const id = `agent-${String(i)}`;
+    const port = deriveAgentTuiPort(id);
+    const previous = seen.get(port);
+    if (previous) {
+      return [previous, id];
+    }
+    seen.set(port, id);
+  }
+  throw new Error("test fixture could not find hash collision");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("deriveAgentTuiPort", () => {
+  it("returns a deterministic port in [9100, 9199]", () => {
+    for (const id of ["work", "play", "main", "steve", "x"]) {
+      const port = deriveAgentTuiPort(id);
+      expect(port).toBeGreaterThanOrEqual(TUI_AGENT_PORT_START);
+      expect(port).toBeLessThanOrEqual(TUI_AGENT_PORT_END);
+      expect(deriveAgentTuiPort(id)).toBe(port);
+    }
+  });
+
+  it("normalises agent ids the same way as other helpers", () => {
+    expect(deriveAgentTuiPort("Work")).toBe(deriveAgentTuiPort("work"));
+    expect(deriveAgentTuiPort("  play  ")).toBe(deriveAgentTuiPort("play"));
+  });
+});
+
+describe("resolveAgentTuiPort", () => {
+  it("persists the same agent port under ~/.gemmaclaw", () => {
+    const env = makeTempEnv();
+    const first = resolveAgentTuiPort({ agentId: "work", env });
+    const second = resolveAgentTuiPort({ agentId: "work", env });
+
+    expect(second).toBe(first);
+    const registryPath = resolveTuiPortRegistryPath(env);
+    expect(registryPath).toContain(".gemmaclaw");
+    const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8")) as {
+      agents: Record<string, { port: number }>;
+    };
+    expect(registry.agents.work.port).toBe(first);
+  });
+
+  it("linearly probes when two agents hash to the same preferred port", () => {
+    const env = makeTempEnv();
+    const [firstId, secondId] = findHashCollision();
+
+    const first = resolveAgentTuiPort({ agentId: firstId, env });
+    const second = resolveAgentTuiPort({ agentId: secondId, env });
+
+    expect(deriveAgentTuiPort(firstId)).toBe(deriveAgentTuiPort(secondId));
+    expect(second).not.toBe(first);
+    expect(second).toBeGreaterThanOrEqual(TUI_AGENT_PORT_START);
+    expect(second).toBeLessThanOrEqual(TUI_AGENT_PORT_END);
+  });
+
+  it("rejects an override assigned to another agent", () => {
+    const env = makeTempEnv();
+    resolveAgentTuiPort({ agentId: "work", overridePort: 9123, env });
+
+    expect(() => resolveAgentTuiPort({ agentId: "play", overridePort: 9123, env })).toThrow(
+      /already assigned to agent "work"/,
+    );
+  });
+});
+
+describe("isContainerBackedAgent", () => {
+  it("returns false for undefined config or sandbox mode off", () => {
+    expect(isContainerBackedAgent(undefined, "work")).toBe(false);
+    expect(isContainerBackedAgent({} as OpenClawConfig, "work")).toBe(false);
+    expect(
+      isContainerBackedAgent(
+        cfgWithAgents([{ id: "work" }], { sandbox: { mode: "off", backend: "docker" } }),
+        "work",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for an effective docker sandbox", () => {
+    const cfg = cfgWithAgents([{ id: "work" }], {
+      sandbox: { mode: "all", backend: "docker" },
+    });
+    expect(isContainerBackedAgent(cfg, "work")).toBe(true);
+  });
+
+  it("honors agent-specific sandbox overrides", () => {
+    const cfg = cfgWithAgents(
+      [
+        { id: "host", sandbox: { mode: "off", backend: "docker" } },
+        { id: "box", sandbox: { mode: "all", backend: "docker" } },
+      ],
+      { sandbox: { mode: "off", backend: "docker" } },
+    );
+    expect(isContainerBackedAgent(cfg, "host")).toBe(false);
+    expect(isContainerBackedAgent(cfg, "box")).toBe(true);
+  });
+});
+
+describe("resolveTuiAgent", () => {
+  it("resolves a configured agent named Steve", async () => {
+    const cfg = cfgWithAgents([{ id: "steve", name: "Steve" }]);
+
+    await expect(resolveTuiAgent(cfg, "Steve", { isTty: false })).resolves.toBe("steve");
+  });
+
+  it("fails without an agent in non-TTY mode", async () => {
+    const cfg = cfgWithAgents([{ id: "work" }]);
+
+    await expect(resolveTuiAgent(cfg, undefined, { isTty: false })).rejects.toThrow(
+      /gemmaclaw tui <agent>/,
+    );
+  });
+
+  it("lists registered agents through the interactive picker", async () => {
+    const cfg = cfgWithAgents([{ id: "work" }, { id: "play" }]);
+    const pickAgent = vi.fn().mockResolvedValue("play");
+
+    await expect(resolveTuiAgent(cfg, undefined, { isTty: true, pickAgent })).resolves.toBe("play");
+    expect(pickAgent).toHaveBeenCalledWith(["work", "play"]);
+  });
+
+  it("prints setup/create guidance when zero agents are configured", async () => {
+    await expect(resolveTuiAgent({} as OpenClawConfig, "work", { isTty: false })).rejects.toThrow(
+      /gemmaclaw setup/,
+    );
+  });
+});
+
+describe("buildTuiAgentLaunchResult", () => {
+  it("returns terminal mode for non-container agent", () => {
+    const result = buildTuiAgentLaunchResult(cfgWithAgents([{ id: "work" }]), "work");
+    expect(result.mode).toBe("terminal");
+    if (result.mode === "terminal") {
+      expect(result.opts.local).toBe(true);
+      expect(result.opts.session).toContain("work");
+    }
+  });
+
+  it("returns browser mode for container-backed agent", () => {
+    const cfg = cfgWithAgents([{ id: "work" }], {
+      sandbox: { mode: "all", backend: "docker" },
+    });
+    const result = buildTuiAgentLaunchResult(cfg, "work", 9150);
+    expect(result.mode).toBe("browser");
+    if (result.mode === "browser") {
+      expect(result.url).toBe("http://127.0.0.1:9150/?agent=work");
+      expect(result.port).toBe(9150);
+    }
+  });
+});
+
+describe("launchTuiAgent", () => {
+  it("launches host-local terminal TUI with the selected agent session", async () => {
+    const cfg = cfgWithAgents([{ id: "steve", name: "Steve" }]);
+    const runTui = vi.fn().mockResolvedValue(undefined);
+
+    await launchTuiAgent({
+      agentArg: "Steve",
+      deps: { readConfig: async () => cfg, isTty: false, runTui },
+    });
+
+    expect(runTui).toHaveBeenCalledWith(
+      expect.objectContaining({ local: true, session: expect.stringContaining("steve") }),
+    );
+  });
+
+  it("starts a loopback gateway for a container-backed agent on its persisted port", async () => {
+    const env = makeTempEnv();
+    const cfg = cfgWithAgents([{ id: "work" }], {
+      sandbox: { mode: "all", backend: "docker" },
+    });
+    const spawnGateway = vi.fn(() => 1234);
+
+    await launchTuiAgent({
+      agentArg: "work",
+      openBrowser: false,
+      deps: {
+        readConfig: async () => cfg,
+        isTty: false,
+        env,
+        probeGatewayHealth: vi.fn().mockResolvedValue(false),
+        findPortOccupants: vi.fn().mockReturnValue([]),
+        isPortOccupied: vi.fn().mockResolvedValue(false),
+        spawnGateway,
+        waitForGatewayReady: vi.fn().mockResolvedValue(true),
+      },
+    });
+
+    const port = resolveAgentTuiPort({ agentId: "work", env });
+    expect(spawnGateway).toHaveBeenCalledWith(port, "work");
+    expect(mocks.runtime.log).toHaveBeenCalledWith(expect.stringContaining("127.0.0.1"));
+  });
+
+  it("reuses a healthy gateway on the selected agent port", async () => {
+    const env = makeTempEnv();
+    const cfg = cfgWithAgents([{ id: "work" }], {
+      sandbox: { mode: "all", backend: "docker" },
+    });
+    const spawnGateway = vi.fn(() => 1234);
+
+    await launchTuiAgent({
+      agentArg: "work",
+      openBrowser: false,
+      deps: {
+        readConfig: async () => cfg,
+        isTty: false,
+        env,
+        probeGatewayHealth: vi.fn().mockResolvedValue(true),
+        spawnGateway,
+      },
+    });
+
+    expect(spawnGateway).not.toHaveBeenCalled();
+    expect(mocks.runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Reusing existing Gemmaclaw gateway"),
+    );
+  });
+
+  it("fails clearly when the selected port is occupied by another process", async () => {
+    const env = makeTempEnv();
+    const cfg = cfgWithAgents([{ id: "work" }], {
+      sandbox: { mode: "all", backend: "docker" },
+    });
+    const spawnGateway = vi.fn(() => 1234);
+
+    await expect(
+      launchTuiAgent({
+        agentArg: "work",
+        openBrowser: false,
+        deps: {
+          readConfig: async () => cfg,
+          isTty: false,
+          env,
+          probeGatewayHealth: vi.fn().mockResolvedValue(false),
+          findPortOccupants: vi.fn().mockReturnValue(["4321"]),
+          isPortOccupied: vi.fn().mockResolvedValue(true),
+          spawnGateway,
+        },
+      }),
+    ).rejects.toThrow(/occupied/);
+
+    expect(spawnGateway).not.toHaveBeenCalled();
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("--port <free-port>"));
+  });
+});
+
+describe("findProcessesOnPort", () => {
+  it("returns an array", () => {
+    expect(Array.isArray(findProcessesOnPort(1))).toBe(true);
+  });
+});

--- a/src/commands/agents.commands.tui.ts
+++ b/src/commands/agents.commands.tui.ts
@@ -1,0 +1,488 @@
+import { execSync, spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { listAgentEntries } from "../agents/agent-scope.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import type { ChatAgentResolveDeps } from "../cli/webchat-cli.js";
+import { readBestEffortConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openUrl, resolveBrowserOpenCommand } from "../infra/browser-open.js";
+import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
+import { defaultRuntime } from "../runtime.js";
+import type { TuiOptions } from "../tui/tui-types.js";
+import { runTui } from "../tui/tui.js";
+import { createClackPrompter } from "../wizard/clack-prompter.js";
+
+export type TuiAgentLaunchMode = "terminal" | "browser";
+
+export type TuiAgentLaunchResult =
+  | { mode: "terminal"; opts: TuiOptions }
+  | { mode: "browser"; url: string; port: number };
+
+export const TUI_AGENT_PORT_START = 9100;
+export const TUI_AGENT_PORT_END = 9199;
+
+export type TuiPortRegistry = {
+  version: 1;
+  agents: Record<string, { port: number; updatedAt: string }>;
+};
+
+export type TuiAgentLaunchDeps = ChatAgentResolveDeps & {
+  readConfig?: () => Promise<OpenClawConfig | undefined>;
+  runTui?: (opts: TuiOptions) => Promise<void>;
+  probeGatewayHealth?: (port: number) => Promise<boolean>;
+  findPortOccupants?: (port: number) => string[] | Promise<string[]>;
+  isPortOccupied?: (port: number) => boolean | Promise<boolean>;
+  spawnGateway?: (port: number, agentId: string) => number | undefined;
+  waitForGatewayReady?: (port: number) => Promise<boolean>;
+  openUrl?: (url: string) => Promise<boolean>;
+  resolveBrowserOpenCommand?: typeof resolveBrowserOpenCommand;
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+};
+
+/**
+ * Derive a deterministic per-agent local port in range [9100, 9199].
+ * The launcher persists assignments and linearly probes from this preferred
+ * slot, so hash collisions do not make two agents fight over one port.
+ */
+export function deriveAgentTuiPort(agentId: string): number {
+  const id = normalizeAgentId(agentId);
+  let h = 5381;
+  for (let i = 0; i < id.length; i++) {
+    h = (((h << 5) + h) ^ id.charCodeAt(i)) >>> 0; // djb2 bitwise hash step
+  }
+  return TUI_AGENT_PORT_START + (h % (TUI_AGENT_PORT_END - TUI_AGENT_PORT_START + 1));
+}
+
+/**
+ * Return true when the selected agent's effective sandbox is Docker-backed.
+ * Agent-specific sandbox settings override global defaults.
+ */
+export function isContainerBackedAgent(cfg: OpenClawConfig | undefined, agentId: string): boolean {
+  if (!cfg) {
+    return false;
+  }
+  const sandbox = resolveSandboxConfigForAgent(cfg, agentId);
+  return sandbox.mode !== "off" && sandbox.backend === "docker";
+}
+
+type TuiAgentChoice = { id: string; name?: string };
+
+function listConfiguredTuiAgents(cfg: OpenClawConfig | undefined): TuiAgentChoice[] {
+  if (!cfg) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const choices: TuiAgentChoice[] = [];
+  for (const entry of listAgentEntries(cfg)) {
+    const id = normalizeAgentId(entry?.id);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    choices.push({ id, name: typeof entry.name === "string" ? entry.name.trim() : undefined });
+  }
+  return choices;
+}
+
+function findConfiguredTuiAgent(agents: TuiAgentChoice[], rawAgent: string): string | undefined {
+  const normalized = normalizeAgentId(rawAgent);
+  return (
+    agents.find((agent) => agent.id === normalized)?.id ??
+    agents.find((agent) => agent.name && normalizeAgentId(agent.name) === normalized)?.id
+  );
+}
+
+export async function resolveTuiAgent(
+  cfg: OpenClawConfig | undefined,
+  rawAgent: string | undefined,
+  deps: ChatAgentResolveDeps = {},
+): Promise<string> {
+  const agents = listConfiguredTuiAgents(cfg);
+  const trimmed = rawAgent?.trim();
+
+  if (agents.length === 0) {
+    throw new Error(
+      "No agents configured. Run 'gemmaclaw setup' or 'gemmaclaw create <name>' first.",
+    );
+  }
+
+  if (trimmed) {
+    const resolved = findConfiguredTuiAgent(agents, trimmed);
+    if (!resolved) {
+      throw new Error(
+        `Unknown agent id "${trimmed}". Run 'gemmaclaw list' to see configured agents.`,
+      );
+    }
+    return resolved;
+  }
+
+  const isTty = deps.isTty ?? ((process.stdin.isTTY ?? false) && (process.stdout.isTTY ?? false));
+  if (!isTty) {
+    throw new Error(
+      "No agent specified. Usage: gemmaclaw tui <agent>. Run 'gemmaclaw list' to see configured agents.",
+    );
+  }
+
+  if (!deps.pickAgent) {
+    throw new Error("No agent picker available. Usage: gemmaclaw tui <agent>.");
+  }
+
+  const ids = agents.map((agent) => agent.id);
+  const picked = await deps.pickAgent(ids);
+  if (!picked) {
+    throw new Error("No agent selected. Usage: gemmaclaw tui <agent>.");
+  }
+  const normalized = findConfiguredTuiAgent(agents, picked);
+  if (!normalized) {
+    throw new Error(`Unknown agent id "${picked}". Run 'gemmaclaw list' to see configured agents.`);
+  }
+  return normalized;
+}
+
+function resolveGemmaclawHomeForEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env.GEMMACLAW_HOME?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  return path.join(env.HOME?.trim() || "/tmp", ".gemmaclaw");
+}
+
+export function resolveTuiPortRegistryPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveGemmaclawHomeForEnv(env), "state", "tui-ports.json");
+}
+
+function createEmptyPortRegistry(): TuiPortRegistry {
+  return { version: 1, agents: {} };
+}
+
+function readTuiPortRegistry(registryPath: string): TuiPortRegistry {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(registryPath, "utf-8")) as Partial<TuiPortRegistry>;
+    const agents =
+      parsed && typeof parsed.agents === "object" && parsed.agents !== null ? parsed.agents : {};
+    const registry = createEmptyPortRegistry();
+    for (const [rawId, rawAssignment] of Object.entries(agents)) {
+      const id = normalizeAgentId(rawId);
+      const assignment = rawAssignment as { port?: unknown; updatedAt?: unknown } | undefined;
+      const port = typeof assignment?.port === "number" ? assignment.port : Number.NaN;
+      if (id && Number.isInteger(port) && port >= 1 && port <= 65535) {
+        registry.agents[id] = {
+          port,
+          updatedAt:
+            typeof assignment?.updatedAt === "string"
+              ? assignment.updatedAt
+              : new Date(0).toISOString(),
+        };
+      }
+    }
+    return registry;
+  } catch {
+    return createEmptyPortRegistry();
+  }
+}
+
+function writeTuiPortRegistry(registryPath: string, registry: TuiPortRegistry): void {
+  fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+  fs.writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function validateTcpPort(port: number): void {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${String(port)}`);
+  }
+}
+
+function findAgentAssignedToPort(
+  registry: TuiPortRegistry,
+  port: number,
+  exceptAgentId: string,
+): string | undefined {
+  return Object.entries(registry.agents).find(
+    ([agentId, assignment]) => agentId !== exceptAgentId && assignment.port === port,
+  )?.[0];
+}
+
+export function resolveAgentTuiPort(params: {
+  agentId: string;
+  overridePort?: number;
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+}): number {
+  const agentId = normalizeAgentId(params.agentId);
+  const registryPath = resolveTuiPortRegistryPath(params.env);
+  const registry = readTuiPortRegistry(registryPath);
+  const updatedAt = (params.now ?? (() => new Date()))().toISOString();
+
+  if (params.overridePort !== undefined) {
+    validateTcpPort(params.overridePort);
+    const owner = findAgentAssignedToPort(registry, params.overridePort, agentId);
+    if (owner) {
+      throw new Error(
+        `Port ${String(params.overridePort)} is already assigned to agent "${owner}". ` +
+          "Choose a different --port or remove ~/.gemmaclaw/state/tui-ports.json after cleanup.",
+      );
+    }
+    registry.agents[agentId] = { port: params.overridePort, updatedAt };
+    writeTuiPortRegistry(registryPath, registry);
+    return params.overridePort;
+  }
+
+  const existing = registry.agents[agentId]?.port;
+  if (
+    existing !== undefined &&
+    Number.isInteger(existing) &&
+    existing >= TUI_AGENT_PORT_START &&
+    existing <= TUI_AGENT_PORT_END &&
+    !findAgentAssignedToPort(registry, existing, agentId)
+  ) {
+    registry.agents[agentId] = { port: existing, updatedAt };
+    writeTuiPortRegistry(registryPath, registry);
+    return existing;
+  }
+
+  const preferred = deriveAgentTuiPort(agentId);
+  const span = TUI_AGENT_PORT_END - TUI_AGENT_PORT_START + 1;
+  for (let offset = 0; offset < span; offset += 1) {
+    const candidate = TUI_AGENT_PORT_START + ((preferred - TUI_AGENT_PORT_START + offset) % span);
+    if (!findAgentAssignedToPort(registry, candidate, agentId)) {
+      registry.agents[agentId] = { port: candidate, updatedAt };
+      writeTuiPortRegistry(registryPath, registry);
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `No free Gemmaclaw TUI ports in ${String(TUI_AGENT_PORT_START)}-${String(TUI_AGENT_PORT_END)}. ` +
+      "Use --port <free-port> or clean up ~/.gemmaclaw/state/tui-ports.json.",
+  );
+}
+
+async function probeGatewayHealth(port: number): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    try {
+      const res = await fetch(`http://127.0.0.1:${String(port)}/healthz`, {
+        signal: controller.signal,
+      });
+      return res.ok;
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return false;
+  }
+}
+
+async function isLoopbackPortOccupied(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(true));
+    server.once("listening", () => {
+      server.close(() => resolve(false));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+/**
+ * Check whether `port` is already occupied by any process. Returns PIDs when
+ * lsof is available, otherwise an empty array. The launcher also probes
+ * bindability so collision detection does not depend on lsof.
+ */
+export function findProcessesOnPort(port: number): string[] {
+  try {
+    const pids = execSync(`lsof -ti :${port}`, {
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 5_000,
+    }).trim();
+    return pids ? pids.split("\n").filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+const HEALTH_POLL_INTERVAL_MS = 500;
+const HEALTH_POLL_MAX_ATTEMPTS = 60;
+
+async function waitForGatewayReady(port: number): Promise<boolean> {
+  for (let i = 0; i < HEALTH_POLL_MAX_ATTEMPTS; i += 1) {
+    if (await probeGatewayHealth(port)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+function resolveCliEntryPath(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(here, "../../dist/entry.js"),
+    path.resolve(here, "../../gemmaclaw.mjs"),
+    path.resolve(here, "../../openclaw.mjs"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return process.argv[1] ?? candidates[0];
+}
+
+function spawnGatewayDetached(
+  port: number,
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const entryPath = resolveCliEntryPath();
+  const child = spawn(
+    process.execPath,
+    [
+      entryPath,
+      "gateway",
+      "run",
+      "--allow-unconfigured",
+      "--auth",
+      "none",
+      "--bind",
+      "loopback",
+      "--port",
+      String(port),
+    ],
+    { stdio: "ignore", detached: true, env },
+  );
+  child.unref();
+  return child.pid;
+}
+
+/**
+ * Build the TUI launch parameters for a resolved agent.
+ *
+ * - Host-local: launch terminal TUI with `--local` and the agent session key.
+ * - Container-backed: open browser chat on a localhost per-agent port.
+ */
+export function buildTuiAgentLaunchResult(
+  cfg: OpenClawConfig | undefined,
+  agentId: string,
+  overridePort?: number,
+): TuiAgentLaunchResult {
+  const normalized = normalizeAgentId(agentId);
+  const sessionKey = buildAgentMainSessionKey({ agentId: normalized });
+
+  if (isContainerBackedAgent(cfg, normalized)) {
+    const port = overridePort ?? deriveAgentTuiPort(normalized);
+    const url = `http://127.0.0.1:${String(port)}/?agent=${encodeURIComponent(normalized)}`;
+    return { mode: "browser", url, port };
+  }
+
+  const opts: TuiOptions = {
+    local: true,
+    session: sessionKey,
+  };
+  return { mode: "terminal", opts };
+}
+
+async function defaultPickAgent(agents: string[]): Promise<string | undefined> {
+  const prompter = createClackPrompter();
+  const choice = await prompter.select({
+    message: "Pick a Gemmaclaw instance to open",
+    options: agents.map((id) => ({ value: id, label: id })),
+  });
+  return typeof choice === "string" ? choice : undefined;
+}
+
+export type LaunchTuiAgentOpts = {
+  /** Positional agent name/id (or undefined = picker in TTY, error in non-TTY). */
+  agentArg?: string;
+  /** Port override for container agents. */
+  port?: number;
+  /** Whether to open browser automatically for container agents. */
+  openBrowser?: boolean;
+  /** Injected deps for testing. */
+  deps?: TuiAgentLaunchDeps;
+};
+
+/**
+ * High-level entry point: resolve agent, determine launch mode, and execute.
+ * Throws on error; callers should call `process.exit(1)` after catching.
+ */
+export async function launchTuiAgent(opts: LaunchTuiAgentOpts): Promise<void> {
+  const deps: TuiAgentLaunchDeps = opts.deps ?? {};
+  const cfg = await (deps.readConfig ?? (() => readBestEffortConfig().catch(() => undefined)))();
+
+  const agentId = await resolveTuiAgent(cfg, opts.agentArg, {
+    isTty: deps.isTty,
+    pickAgent: deps.pickAgent ?? defaultPickAgent,
+  });
+  const allocatedPort = isContainerBackedAgent(cfg, agentId)
+    ? resolveAgentTuiPort({
+        agentId,
+        overridePort: opts.port,
+        env: deps.env,
+        now: deps.now,
+      })
+    : opts.port;
+  const result = buildTuiAgentLaunchResult(cfg, agentId, allocatedPort);
+
+  if (result.mode === "terminal") {
+    await (deps.runTui ?? runTui)(result.opts);
+    return;
+  }
+
+  const { url, port } = result;
+  const healthProbe = deps.probeGatewayHealth ?? probeGatewayHealth;
+  const healthy = await healthProbe(port);
+  if (healthy) {
+    defaultRuntime.log(`Reusing existing Gemmaclaw gateway for agent "${agentId}".`);
+  } else {
+    const occupants = await (deps.findPortOccupants ?? findProcessesOnPort)(port);
+    const occupied =
+      occupants.length > 0 || (await (deps.isPortOccupied ?? isLoopbackPortOccupied)(port));
+    if (occupied) {
+      const pidText = occupants.length > 0 ? ` (PID ${occupants.join(", ")})` : "";
+      defaultRuntime.error(
+        `Port ${String(port)} is occupied${pidText} and is not a healthy Gemmaclaw gateway. ` +
+          "Stop the other process or retry with --port <free-port>.",
+      );
+      throw new Error(`port ${String(port)} occupied by non-gateway process`);
+    }
+
+    defaultRuntime.log(`Starting Gemmaclaw gateway on 127.0.0.1:${String(port)}...`);
+    const pid = (deps.spawnGateway ?? ((p) => spawnGatewayDetached(p, deps.env)))(port, agentId);
+    const ready = await (deps.waitForGatewayReady ?? waitForGatewayReady)(port);
+    if (!ready) {
+      defaultRuntime.error(
+        `Gateway did not become ready on 127.0.0.1:${String(port)} within 30 seconds. ` +
+          "Check logs with: gemmaclaw logs",
+      );
+      throw new Error(`gateway not reachable on port ${String(port)}`);
+    }
+    defaultRuntime.log(`Gateway is ready${pid ? ` (PID ${String(pid)})` : ""}.`);
+  }
+
+  defaultRuntime.log(`Agent:  ${agentId}`);
+  defaultRuntime.log(`Port:   ${String(port)} (localhost only)`);
+  defaultRuntime.log(`URL:    ${url}`);
+
+  if (opts.openBrowser !== false) {
+    const browserCmd = await (deps.resolveBrowserOpenCommand ?? resolveBrowserOpenCommand)();
+    if (browserCmd.argv) {
+      defaultRuntime.log(`Opening ${url} in your browser...`);
+      const opened = await (deps.openUrl ?? openUrl)(url);
+      if (!opened) {
+        defaultRuntime.log(
+          `Could not open browser automatically. Open this URL manually:\n  ${url}`,
+        );
+      }
+    } else {
+      defaultRuntime.log(
+        `No browser detected (${browserCmd.reason ?? "unknown"}). Open this URL manually:\n  ${url}`,
+      );
+    }
+  }
+}

--- a/src/gemmaclaw/provision/onboarding-wizard.test.ts
+++ b/src/gemmaclaw/provision/onboarding-wizard.test.ts
@@ -334,6 +334,9 @@ describe("formatNextSteps", () => {
     const text = lines.join("\n");
     expect(text).toContain("http://127.0.0.1:8765/");
     expect(text).toContain("--agent tester");
+    expect(text).toContain("gemmaclaw tui tester");
+    expect(text).toContain("Host-local agents open the terminal TUI directly.");
+    expect(text).toContain("~/.gemmaclaw/workspaces/tester/AGENTS.md");
     expect(text).toContain("setup --advanced");
   });
 
@@ -349,6 +352,8 @@ describe("formatNextSteps", () => {
     const text = lines.join("\n");
     expect(text).not.toContain("Open the chat UI");
     expect(text).toContain("--agent x");
+    expect(text).toContain("gemmaclaw tui x");
+    expect(text).toContain("persistent per-agent 127.0.0.1 port");
   });
 });
 

--- a/src/gemmaclaw/provision/onboarding-wizard.ts
+++ b/src/gemmaclaw/provision/onboarding-wizard.ts
@@ -519,11 +519,19 @@ export function formatNextSteps(choices: OnboardingChoices, gatewayUrl?: string)
     `  - Send a one-shot message:  gemmaclaw message --agent ${choices.agentName} "Hello"`,
   );
   lines.push(`  - Open an interactive chat: gemmaclaw chat --agent ${choices.agentName}`);
+  lines.push(`  - Open local TUI/chat:      gemmaclaw tui ${choices.agentName}`);
+  lines.push(
+    choices.useContainer
+      ? "    (Docker-backed agents use a persistent per-agent 127.0.0.1 port.)"
+      : "    (Host-local agents open the terminal TUI directly.)",
+  );
   lines.push("  - Re-run setup any time:    gemmaclaw setup");
   lines.push("");
   lines.push("Change later:");
   lines.push("  - Switch backend / model:   gemmaclaw setup --advanced");
-  lines.push("  - Edit persona files:       see ~/.gemmaclaw/workspace/AGENTS.md");
+  lines.push(
+    `  - Edit persona files:       see ~/.gemmaclaw/workspaces/${choices.agentName}/AGENTS.md`,
+  );
   lines.push(`  - Tweak thinking level:     edit agents.defaults.thinkingDefault in config`);
   return lines;
 }


### PR DESCRIPTION
## Summary

- New core CLI command: `gemmaclaw tui [agent]`
  - Accepts positional agent name or `--agent <id>` flag
  - Interactive agent picker when no agent is specified and TTY is available
  - Non-TTY with no agent → exits with hint to run `gemmaclaw list`
  - Host-local agents → terminal TUI via `runTui({local: true, session: "agent:<id>:main"})`
  - Container-backed agents (`agents.defaults.sandbox.backend=docker`) → browser chat UI at a deterministic per-agent port in `[9100, 9199]` (djb2 hash of normalised agent id)
  - `--port` to override the container port; `--no-open` to print URL without launching browser
  - Port collision detection with friendly error messages
- Remove `tui`/`terminal` from `subcli-descriptors.ts` to prevent Commander duplicate registration
- `gemmaclaw setup` completion text now mentions `gemmaclaw tui <agent>`
- `program.smoke.test.ts` updated to test new tui command (replaces removed `--timeout-ms` tests)
- README quick-start and site generator updated with per-agent tui examples; site regenerated

## Test plan

- [x] `src/commands/agents.commands.tui.test.ts` — 15 unit tests (port derivation, container detection, launch result builder, port probe helper)
- [x] `src/cli/program/register.tui.test.ts` — 9 unit tests (command parsing, flag handling, error hints)
- [x] `src/cli/program.smoke.test.ts` — 4 smoke tests (registers message/status, named agent, picker, setup wizard)
- [x] Full CLI test suite: 107 files / 1015 tests pass