### PR TITLE
fix: workspace fallback path and ssh shell exit propagation

### DIFF
--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -141,7 +141,7 @@ describe("deliverMattermostReplyPayload", () => {
       const core = createReplyDeliveryCore();
 
       const agentId = "agent-1";
-      const mediaUrl = `file://${path.join(stateDir, `workspace-${agentId}`, "photo.png")}`;
+      const mediaUrl = `file://${path.join(stateDir, "workspaces", agentId, "photo.png")}`;
       const cfg = {} satisfies OpenClawConfig;
 
       await deliverMattermostReplyPayload({
@@ -166,7 +166,7 @@ describe("deliverMattermostReplyPayload", () => {
           accountId: "default",
           mediaUrl,
           replyToId: "root-post",
-          mediaLocalRoots: expect.arrayContaining([path.join(stateDir, `workspace-${agentId}`)]),
+          mediaLocalRoots: expect.arrayContaining([path.join(stateDir, "workspaces", agentId)]),
         }),
       );
     } finally {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -399,7 +399,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
         mediaLocalRoots: expect.arrayContaining([
-          expect.stringMatching(/[\\/]\.openclaw[\\/]workspace-work$/u),
+          expect.stringMatching(/[\\/]\.openclaw[\\/]workspaces[\\/]work$/u),
         ]),
       }),
     );

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -287,7 +287,7 @@ describe("registerTelegramNativeCommands", () => {
     expect(firstDeliverRepliesCall?.[0]).toEqual(
       expect.objectContaining({
         mediaLocalRoots: expect.arrayContaining([
-          expect.stringMatching(/[\\/]\.openclaw[\\/]workspace-work$/),
+          expect.stringMatching(/[\\/]\.openclaw[\\/]workspaces[\\/]work$/),
         ]),
       }),
     );

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -168,7 +168,7 @@ export function resolveAgentWorkspaceDir(
     return stripNullBytes(path.join(resolveUserPath(fallback, env), id));
   }
   const stateDir = resolveStateDir(env);
-  return stripNullBytes(path.join(stateDir, `workspace-${id}`));
+  return stripNullBytes(path.join(stateDir, "workspaces", id));
 }
 
 export function resolveAgentDir(

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -503,7 +503,7 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.resolve("/shared-ws"));
   });
 
-  it("non-default agent without defaults.workspace falls back to stateDir", () => {
+  it("non-default agent without defaults.workspace falls back to stateDir workspaces/<id>", () => {
     const stateDir = path.join(path.sep, "tmp", "test-state");
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     const cfg: OpenClawConfig = {
@@ -512,7 +512,7 @@ describe("resolveAgentConfig", () => {
       },
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
-    expect(workspace).toBe(path.join(stateDir, "workspace-main"));
+    expect(workspace).toBe(path.join(stateDir, "workspaces", "main"));
   });
 });
 

--- a/src/agents/workspace-run.test.ts
+++ b/src/agents/workspace-run.test.ts
@@ -99,7 +99,7 @@ describe("resolveRunWorkspaceDir", () => {
 
     expect(result.agentId).toBe("research");
     expect(result.agentIdSource).toBe("explicit");
-    expect(result.workspaceDir).toBe(path.resolve("/tmp/openclaw-state", "workspace-research"));
+    expect(result.workspaceDir).toBe(path.resolve("/tmp/openclaw-state", "workspaces", "research"));
   });
 
   it("throws for malformed agent session keys even when config has a default agent", () => {

--- a/src/commands/agents.commands.ssh.test.ts
+++ b/src/commands/agents.commands.ssh.test.ts
@@ -184,6 +184,85 @@ describe("agentsSshCommand", () => {
     expect(mocks.runtime.error).not.toHaveBeenCalled();
   });
 
+  it("preserves bash exit code without sh fallback when bash exits nonzero", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "docker" && args.includes("--version")) {
+        return { status: 0, stdout: "docker version 24.0", stderr: "" };
+      }
+      if (cmd === "docker" && args.includes("inspect")) {
+        return { status: 0, stdout: "true\n", stderr: "" };
+      }
+      if (cmd === "docker" && args[0] === "exec" && args.includes("/bin/bash")) {
+        return { status: 2, stdout: "", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+
+    // Should NOT fall back to /bin/sh for a plain nonzero exit
+    const execCalls = mocks.spawnSyncMock.mock.calls.filter(
+      (call) => call[0] === "docker" && call[1][0] === "exec",
+    );
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0][1]).toContain("/bin/bash");
+    expect(process.exitCode).toBe(2);
+  });
+
+  it("falls back to /bin/sh when bash exits with code 127 (not found in container)", async () => {
+    mocks.resolveSandboxConfigForAgentMock.mockReturnValue({ mode: "all", backend: "docker" });
+    mocks.readRegistryMock.mockResolvedValue({
+      entries: [
+        {
+          containerName: "openclaw-sbx-main-abc",
+          sessionKey: "agent:main",
+          backendId: "docker",
+          createdAtMs: 0,
+          lastUsedAtMs: 0,
+          image: "test",
+        },
+      ],
+    });
+    mocks.spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "docker" && args.includes("--version")) {
+        return { status: 0, stdout: "docker version 24.0", stderr: "" };
+      }
+      if (cmd === "docker" && args.includes("inspect")) {
+        return { status: 0, stdout: "true\n", stderr: "" };
+      }
+      if (cmd === "docker" && args[0] === "exec" && args.includes("/bin/bash")) {
+        return { status: 127, stdout: "", stderr: "bash: not found" };
+      }
+      if (cmd === "docker" && args[0] === "exec" && args.includes("/bin/sh")) {
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    });
+
+    await agentsSshCommand({ agent: "main" }, mocks.runtime);
+
+    const execCalls = mocks.spawnSyncMock.mock.calls.filter(
+      (call) => call[0] === "docker" && call[1][0] === "exec",
+    );
+    expect(execCalls).toHaveLength(2);
+    expect(execCalls[0][1]).toContain("/bin/bash");
+    expect(execCalls[1][1]).toContain("/bin/sh");
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+  });
+
   it("fails with usage text and eligible agents in non-interactive mode with no agent", async () => {
     mocks.buildAgentSummariesMock.mockReturnValue([
       { id: "main", isDefault: true, workspace: "/w", agentDir: "/a", bindings: 0 },

--- a/src/commands/agents.commands.ssh.ts
+++ b/src/commands/agents.commands.ssh.ts
@@ -167,11 +167,16 @@ function openShell(containerName: string, backendId: string): void {
     stdio: "inherit",
   });
 
-  if (result.status !== 0) {
+  // Fall back to /bin/sh only when bash is unavailable in the container.
+  // Exit codes 126 (not executable) and 127 (not found) are standard POSIX signals for an
+  // unavailable command; a spawn error (e.g. ENOENT) means the runtime itself couldn't find
+  // bash. Any other exit code is the user's interactive bash exit and must be preserved as-is.
+  const bashUnavailable = result.error != null || result.status === 126 || result.status === 127;
+  if (bashUnavailable) {
     const fallback = spawnSync(runtime, ["exec", "-it", containerName, "/bin/sh"], {
       stdio: "inherit",
     });
-    if (fallback.status !== 0 && fallback.status !== null) {
+    if (fallback.status !== null && fallback.status !== 0) {
       process.exitCode = fallback.status;
     }
     return;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -530,7 +530,7 @@ describe("deliverOutboundPayloads", () => {
       | undefined;
     expect(
       sendFormattedMediaCall?.mediaLocalRoots?.some((root) =>
-        root.endsWith(path.join(".openclaw", "workspace-work")),
+        root.endsWith(path.join(".openclaw", "workspaces", "work")),
       ),
     ).toBe(true);
     expect(sendMedia).not.toHaveBeenCalled();

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -262,7 +262,7 @@ describe("runMessageAction plugin dispatch", () => {
 
     it("routes execution context ids into plugin handleAction", async () => {
       const stateDir = path.join("/tmp", "openclaw-plugin-dispatch-media-roots");
-      const expectedWorkspaceRoot = path.resolve(stateDir, "workspace-alpha");
+      const expectedWorkspaceRoot = path.resolve(stateDir, "workspaces", "alpha");
       vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
 
       await runMessageAction({

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -89,7 +89,7 @@ describe("local media roots", () => {
       name: "adds the active agent workspace without re-opening broad agent state roots",
       stateDir: path.join("/tmp", "openclaw-agent-media-roots-state"),
       getRoots: () => getAgentScopedMediaLocalRoots({}, "ops"),
-      expectedContained: ["workspace-ops", "sandboxes"],
+      expectedContained: [path.join("workspaces", "ops"), "sandboxes"],
       expectedExcluded: ["agents"],
     },
   ] as const)("$name", ({ stateDir, getRoots, expectedContained, expectedExcluded, minLength }) => {


### PR DESCRIPTION
## Summary

Two regressions introduced by PR #89 (feat/cli-ssh):

- **Workspace fallback path bug**: `resolveAgentWorkspaceDir` fell back to `stateDir/workspace-<id>` for unconfigured named agents. The Onboard Gemma E2E test and bootstrap infrastructure expected `stateDir/workspaces/<id>`. Fixed to `path.join(stateDir, "workspaces", id)`.

- **SSH shell exit propagation bug**: `openShell` was falling back to `/bin/sh` on any nonzero bash exit code. Fixed to only fall back when bash is genuinely unavailable (exit 126/127 or spawn error).

## Changes

- `src/agents/agent-scope-config.ts`: fix fallback path for unconfigured named agents
- `src/commands/agents.commands.ssh.ts`: guard bash→sh fallback to unavailability signals only
- `src/agents/agent-scope.test.ts`: update assertion for new path
- `src/commands/agents.commands.ssh.test.ts`: add 2 new tests (exit code preservation + bash-unavailable fallback)

## Test plan

- [x] agent-scope.test.ts: 27/27 pass
- [x] agents.commands.ssh.test.ts: 20/20 pass
- [x] setup-gemma.test.ts: 16/16 pass
- [x] Full pre-commit: 5116 tests across 554 files, 0 failures
- [x] TypeScript clean, lint clean, no import cycles