### PR TITLE
fix(setup): use ~/.gemmaclaw in --workspace help and resolveStateDir for vertex auth path

### DIFF
--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -18,7 +18,7 @@ export function registerSetupCommand(program: Command) {
     )
     .option(
       "--workspace <dir>",
-      "Agent workspace directory (default: ~/.openclaw/workspace; stored as agents.defaults.workspace)",
+      "Agent workspace directory (default: ~/.gemmaclaw; stored as agents.defaults.workspace)",
     )
     .option(
       "--advanced",
@@ -120,8 +120,9 @@ export function registerSetupCommand(program: Command) {
 
           // Write auth profile with gcloud access token
           if (result.config.accessToken) {
-            const homeDir = process.env.OPENCLAW_HOME ?? process.env.HOME ?? "/root";
-            const authPath = path.join(homeDir, ".openclaw/agents/main/agent/auth-profiles.json");
+            const { resolveStateDir } = await import("../../config/paths.js");
+            const stateDir = resolveStateDir(process.env);
+            const authPath = path.join(stateDir, "agents/main/agent/auth-profiles.json");
             let existing: Record<string, unknown> = { version: 1, profiles: {} };
             try {
               existing = JSON.parse(fs.readFileSync(authPath, "utf-8"));


### PR DESCRIPTION
## Summary

- Fix `--workspace` option help text in `gemmaclaw setup --help`: was showing `~/.openclaw/workspace`, now shows `~/.gemmaclaw`
- Fix Vertex AI `--vertex` inline auth profile write: was using `OPENCLAW_HOME + hardcoded .openclaw path`, now uses `resolveStateDir(process.env)` from `config/paths.js` (same pattern as `setup-gemma.ts`)

These were two missed `.openclaw` references found by QA review of PR #91 (the main `~/.gemmaclaw` home migration).

## Test plan
- [x] Pre-commit hooks: typecheck, lint (0 errors), import-cycle check, 198 CLI tests all passed
- [x] `gemmaclaw setup --help` now shows `~/.gemmaclaw` for `--workspace` default description
- [x] Vertex auth path resolves via `resolveStateDir(process.env)` which respects `GEMMACLAW_HOME`/`OPENCLAW_STATE_DIR` overrides