### PR TITLE
fix: use release token for Gemmaclaw release PRs

### DIFF
--- a/.github/workflows/gemmaclaw-npm-release.yml
+++ b/.github/workflows/gemmaclaw-npm-release.yml
@@ -7,9 +7,9 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: gemmaclaw-npm-release-${{ github.ref }}
@@ -23,10 +23,20 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Validate release-please token
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "::error::Configure the RELEASE_PLEASE_TOKEN repository secret with contents:write and pull_requests:write. The gemmaclaw organization blocks GITHUB_TOKEN from creating release PRs."
+            exit 1
+          fi
+
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -1021,7 +1021,7 @@ npm install -g .  # or: npm link</code></pre></div>
 
       <h3 id="release-automation">Release Automation</h3>
       <p>Gemmaclaw releases use the <code>Gemmaclaw npm Release</code> GitHub Action. Trigger it manually to create or update the release PR. After that PR merges to <code>main</code>, the same workflow creates the GitHub release and publishes the tagged package to npm.</p>
-      <p>The workflow is powered by <code>release-please</code>. Version state lives in <code>.release-please-manifest.json</code> and release behavior lives in <code>release-please-config.json</code>. npm publishing expects GitHub Actions trusted publishing to be configured for the <code>gemmaclaw</code> package.</p>
+      <p>The workflow is powered by <code>release-please</code>. Version state lives in <code>.release-please-manifest.json</code> and release behavior lives in <code>release-please-config.json</code>. The workflow requires a <code>RELEASE_PLEASE_TOKEN</code> repository secret with contents and pull request write access because the organization blocks the default <code>GITHUB_TOKEN</code> from creating release PRs. npm publishing expects GitHub Actions trusted publishing to be configured for the <code>gemmaclaw</code> package.</p>
 
       <h3 id="wizard">The Onboarding Wizard</h3>
       <p>Running <code>gemmaclaw setup</code> kicks off a six-question wizard. Press Enter at any prompt to keep the bracketed default. Every question is also exposed as a CLI flag so you can script the whole flow.</p>

--- a/site/setup.html
+++ b/site/setup.html
@@ -660,7 +660,7 @@ npm install -g .  # or: npm link</code></pre></div>
 
       <h3 id="release-automation">Release Automation</h3>
       <p>Gemmaclaw releases use the <code>Gemmaclaw npm Release</code> GitHub Action. Trigger it manually to create or update the release PR. After that PR merges to <code>main</code>, the same workflow creates the GitHub release and publishes the tagged package to npm.</p>
-      <p>The workflow is powered by <code>release-please</code>. Version state lives in <code>.release-please-manifest.json</code> and release behavior lives in <code>release-please-config.json</code>. npm publishing expects GitHub Actions trusted publishing to be configured for the <code>gemmaclaw</code> package.</p>
+      <p>The workflow is powered by <code>release-please</code>. Version state lives in <code>.release-please-manifest.json</code> and release behavior lives in <code>release-please-config.json</code>. The workflow requires a <code>RELEASE_PLEASE_TOKEN</code> repository secret with contents and pull request write access because the organization blocks the default <code>GITHUB_TOKEN</code> from creating release PRs. npm publishing expects GitHub Actions trusted publishing to be configured for the <code>gemmaclaw</code> package.</p>
 
       <h3 id="wizard">The Onboarding Wizard</h3>
       <p>Running <code>gemmaclaw setup</code> kicks off a six-question wizard. Press Enter at any prompt to keep the bracketed default. Every question is also exposed as a CLI flag so you can script the whole flow.</p>

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearBundledProviderPolicySurfaceCache } from "../plugins/provider-public-artifacts.js";
+import { resetBundledPluginPublicArtifactLoaderForTest } from "../plugins/public-surface-loader.js";
 import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
 import {
   applyAgentDefaults,
@@ -10,10 +12,16 @@ describe("config defaults", () => {
   beforeEach(() => {
     vi.stubEnv("ANTHROPIC_API_KEY", "");
     vi.stubEnv("ANTHROPIC_OAUTH_TOKEN", "");
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", "");
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "");
+    clearBundledProviderPolicySurfaceCache();
+    resetBundledPluginPublicArtifactLoaderForTest();
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    clearBundledProviderPolicySurfaceCache();
+    resetBundledPluginPublicArtifactLoaderForTest();
   });
 
   it("skips provider defaults when agent defaults are absent", () => {


### PR DESCRIPTION
## Summary
- require RELEASE_PLEASE_TOKEN for release-please because the organization blocks GITHUB_TOKEN-created PRs
- document the release token prerequisite on the generated setup docs page
- regenerate site/setup.html

## Verification
- python3 scripts/site/generate-site.py
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
- actionlint .github/workflows/gemmaclaw-npm-release.yml