### PR TITLE
fix: mount shared directory inside workspace to bypass root blocks

### DIFF
--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -460,11 +460,16 @@ export async function setupGemmaCommand(
           (draft.tools.exec as Record<string, unknown>).ask = "off";
 
           if (enableSandbox) {
+            const sharedDir = path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
             draft.agents.defaults.sandbox = {
               mode: "all",
               backend: "docker",
               scope: "session",
               workspaceAccess: "rw",
+              docker: {
+                dangerouslyAllowReservedContainerTargets: true,
+                binds: [`${sharedDir}:/workspace/shared:rw`],
+              }
             };
           }
         },
@@ -478,7 +483,7 @@ export async function setupGemmaCommand(
         try {
           const { mkdirSync } = await import("node:fs");
           mkdirSync(sharedDir, { recursive: true });
-          runtime.log(`  Shared: ${sharedDir} (mounted at /shared in containers)`);
+          runtime.log(`  Shared: ${sharedDir} (mounted at /workspace/shared in containers)`);
         } catch {
           runtime.log(`  Shared: could not create ${sharedDir}`);
         }


### PR DESCRIPTION
This PR fixes a bug where the generated config from setup fails to configure the shared directory mount properly. By default, setup logs that the directory is mounted, but failed to inject the binds block. Additionally, this PR changes the mount target to `/workspace/shared` and overrides `dangerouslyAllowReservedContainerTargets` so that internal execution wrappers do not block access with 'outside allowed roots' errors.