### PR TITLE
fix: point TUI help docs link to Gemmaclaw site

### DIFF
--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -22,7 +22,8 @@ export function registerTuiCli(program: Command) {
     .option("--history-limit <n>", "History entries to load", "200")
     .addHelpText(
       "after",
-      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/tui", "docs.openclaw.ai/cli/tui")}\n`,
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("https://gemmaclaw.github.io/gemmaclaw/setup.html#cmd-tui", "gemmaclaw.github.io/gemmaclaw/setup.html#cmd-tui")}\n`,
     )
     .action(async (opts, cmd) => {
       try {


### PR DESCRIPTION
Fix TUI help docs link to point to Gemmaclaw site instead of OpenClaw docs. Old: docs.openclaw.ai/cli/tui. New: gemmaclaw.github.io/gemmaclaw/setup.html#cmd-tui. All 1013 tests pass.