### PR TITLE
Add setup memory and knowledge defaults

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -35,8 +35,18 @@ You wake up fresh each session. These files are your continuity:
 
 - **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened
 - **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory
+- **Knowledge base:** `knowledge/` — durable project notes, procedures, research, decisions, and lessons that should survive beyond a single day
 
 Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.
+
+### Knowledge Maintenance
+
+- Use `memory/` for chronological daily logs and `knowledge/` for durable, organized context.
+- Before saying you do not know something, search `knowledge/`, `MEMORY.md`, and recent daily memory files.
+- When you learn a stable fact, procedure, project decision, debugging lesson, or user preference, write it into the most relevant existing `knowledge/` file. Create a new file only when no good home exists.
+- Keep knowledge files useful for future agents: include dates, source context, commands that worked, commands that failed, and observable verification steps.
+- Never store secrets, tokens, private keys, OAuth redirects, or raw credentials in memory or knowledge files.
+- A daily 3:00 AM knowledge maintenance job may review recent `memory/` and update `knowledge/`. Keep these files clear enough that job can maintain them safely.
 
 ### 🧠 MEMORY.md - Your Long-Term Memory
 

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -1020,6 +1020,15 @@ describe("setupChannels", () => {
     expect(select).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Select channel (QuickStart)" }),
     );
+    const quickstartSelectCall = (
+      select.mock.calls as unknown as Array<
+        [{ message?: string; options: Array<{ label: string; value: string }> }]
+      >
+    ).find(([params]) => params.message === "Select channel (QuickStart)");
+    expect(quickstartSelectCall?.[0].options[0]).toMatchObject({
+      value: "__skip__",
+      label: "Skip for now (use web interface)",
+    });
     expect(select).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("already configured") }),
     );

--- a/src/commands/onboard-hooks.test.ts
+++ b/src/commands/onboard-hooks.test.ts
@@ -159,6 +159,7 @@ describe("onboard-hooks", () => {
             hint: "Log all command events to a centralized audit file",
           },
         ],
+        initialValues: ["session-memory", "command-logger"],
       });
     });
 
@@ -169,6 +170,14 @@ describe("onboard-hooks", () => {
 
       expect(result.hooks?.internal).toBeUndefined();
       expect(prompter.note).toHaveBeenCalledTimes(1);
+    });
+
+    it("should treat skip as exclusive even when default hooks are selected", async () => {
+      const { result } = await runSetupInternalHooks({
+        selected: ["__skip__", "session-memory", "command-logger"],
+      });
+
+      expect(result.hooks?.internal).toBeUndefined();
     });
 
     it("should handle no eligible hooks", async () => {

--- a/src/commands/onboard-hooks.ts
+++ b/src/commands/onboard-hooks.ts
@@ -5,6 +5,13 @@ import { buildWorkspaceHookStatus } from "../hooks/hooks-status.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
+const DEFAULT_INTERNAL_HOOK_NAMES = new Set([
+  "boot-md",
+  "bootstrap-extra-files",
+  "command-logger",
+  "session-memory",
+]);
+
 export async function setupInternalHooks(
   cfg: OpenClawConfig,
   runtime: RuntimeEnv,
@@ -35,6 +42,10 @@ export async function setupInternalHooks(
     return cfg;
   }
 
+  const defaultEnabledHooks = eligibleHooks
+    .filter((hook) => DEFAULT_INTERNAL_HOOK_NAMES.has(hook.name))
+    .map((hook) => hook.name);
+
   const toEnable = await prompter.multiselect({
     message: "Enable hooks?",
     options: [
@@ -45,9 +56,12 @@ export async function setupInternalHooks(
         hint: hook.description,
       })),
     ],
+    initialValues: defaultEnabledHooks,
   });
 
-  const selected = toEnable.filter((name) => name !== "__skip__");
+  const selected = toEnable.includes("__skip__")
+    ? []
+    : toEnable.filter((name) => name !== "__skip__");
   if (selected.length === 0) {
     return cfg;
   }

--- a/src/commands/onboard-knowledge-agent.test.ts
+++ b/src/commands/onboard-knowledge-agent.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { loadCronStore } from "../cron/store.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  DEFAULT_KNOWLEDGE_AGENT_CRON_ID,
+  DEFAULT_KNOWLEDGE_AGENT_PROMPT,
+  ensureDefaultKnowledgeAgentCron,
+} from "./onboard-knowledge-agent.js";
+
+function runtime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("onboard-knowledge-agent", () => {
+  it("adds the default 3 AM isolated knowledge maintenance cron job", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-knowledge-agent-"));
+    const storePath = path.join(dir, "cron", "jobs.json");
+    const prompter = { note: vi.fn(async () => undefined) };
+
+    await ensureDefaultKnowledgeAgentCron({
+      cfg: { cron: { store: storePath } },
+      runtime: runtime(),
+      prompter: prompter as never,
+      nowMs: 123,
+    });
+
+    const store = await loadCronStore(storePath);
+    expect(store.jobs).toHaveLength(1);
+    expect(store.jobs[0]).toMatchObject({
+      id: DEFAULT_KNOWLEDGE_AGENT_CRON_ID,
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 3 * * *", staggerMs: 0 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      delivery: { mode: "none" },
+      failureAlert: false,
+      createdAtMs: 123,
+      updatedAtMs: 123,
+    });
+    expect(store.jobs[0]?.payload).toMatchObject({
+      kind: "agentTurn",
+      message: DEFAULT_KNOWLEDGE_AGENT_PROMPT,
+      thinking: "medium",
+      timeoutSeconds: 3600,
+    });
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("Scheduled daily knowledge maintenance at 3:00 AM"),
+      "Knowledge maintenance",
+    );
+  });
+
+  it("does not duplicate an existing default job", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-knowledge-agent-"));
+    const storePath = path.join(dir, "cron", "jobs.json");
+
+    await ensureDefaultKnowledgeAgentCron({
+      cfg: { cron: { store: storePath } },
+      runtime: runtime(),
+      nowMs: 123,
+    });
+    await ensureDefaultKnowledgeAgentCron({
+      cfg: { cron: { store: storePath } },
+      runtime: runtime(),
+      nowMs: 456,
+    });
+
+    const store = await loadCronStore(storePath);
+    expect(store.jobs).toHaveLength(1);
+    expect(store.jobs[0]?.createdAtMs).toBe(123);
+  });
+
+  it("respects explicit cron disabled config", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-knowledge-agent-"));
+    const storePath = path.join(dir, "cron", "jobs.json");
+
+    await ensureDefaultKnowledgeAgentCron({
+      cfg: { cron: { enabled: false, store: storePath } },
+      runtime: runtime(),
+      nowMs: 123,
+    });
+
+    await expect(loadCronStore(storePath)).resolves.toEqual({ version: 1, jobs: [] });
+  });
+});

--- a/src/commands/onboard-knowledge-agent.ts
+++ b/src/commands/onboard-knowledge-agent.ts
@@ -1,0 +1,81 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronStorePath, loadCronStore, saveCronStore } from "../cron/store.js";
+import type { CronJob, CronStoreFile } from "../cron/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+export const DEFAULT_KNOWLEDGE_AGENT_CRON_ID = "knowledge-maintenance";
+export const DEFAULT_KNOWLEDGE_AGENT_CRON_NAME = "Knowledge maintenance";
+
+export const DEFAULT_KNOWLEDGE_AGENT_PROMPT = [
+  "Run workspace knowledge maintenance.",
+  "",
+  "Use the workspace as the source of truth. Read AGENTS.md first, then inspect recent files under memory/ and durable files under knowledge/.",
+  "",
+  "Maintain continuity without leaking private data:",
+  "- Promote durable facts, decisions, procedures, project context, and lessons from recent daily memory into appropriate knowledge/ files.",
+  "- Keep MEMORY.md concise when it exists and only update it with stable, high-value long-term context.",
+  "- Keep daily memory as a chronological log. Do not erase raw history unless the user explicitly asked you to remove something.",
+  "- Never write secrets, tokens, private keys, or credentials into memory or knowledge files.",
+  "- Prefer updating an existing relevant knowledge file over creating duplicates. Create knowledge/ only when it is missing.",
+  "- If a lesson should guide future behavior, update AGENTS.md or the relevant SKILL.md only when that is the right durable home.",
+  "",
+  "Write a short maintenance note in memory/YYYY-MM-DD.md summarizing what changed. If there is nothing useful to promote, write no file changes and reply HEARTBEAT_OK.",
+].join("\n");
+
+export function createDefaultKnowledgeAgentCronJob(nowMs = Date.now()): CronJob {
+  return {
+    id: DEFAULT_KNOWLEDGE_AGENT_CRON_ID,
+    name: DEFAULT_KNOWLEDGE_AGENT_CRON_NAME,
+    description: "Daily generic workspace knowledge and memory maintenance.",
+    enabled: true,
+    createdAtMs: nowMs,
+    updatedAtMs: nowMs,
+    schedule: { kind: "cron", expr: "0 3 * * *", staggerMs: 0 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: {
+      kind: "agentTurn",
+      message: DEFAULT_KNOWLEDGE_AGENT_PROMPT,
+      thinking: "medium",
+      timeoutSeconds: 3600,
+      lightContext: false,
+    },
+    delivery: { mode: "none" },
+    failureAlert: false,
+    state: {},
+  };
+}
+
+function hasKnowledgeAgentJob(store: CronStoreFile): boolean {
+  return store.jobs.some(
+    (job) =>
+      job.id === DEFAULT_KNOWLEDGE_AGENT_CRON_ID || job.name === DEFAULT_KNOWLEDGE_AGENT_CRON_NAME,
+  );
+}
+
+export async function ensureDefaultKnowledgeAgentCron(params: {
+  cfg: OpenClawConfig;
+  runtime: RuntimeEnv;
+  prompter?: WizardPrompter;
+  nowMs?: number;
+}): Promise<void> {
+  if (params.cfg.cron?.enabled === false) {
+    params.runtime.log?.("Skipping default knowledge maintenance cron because cron is disabled.");
+    return;
+  }
+
+  const storePath = resolveCronStorePath(params.cfg.cron?.store);
+  const store = await loadCronStore(storePath);
+  if (hasKnowledgeAgentJob(store)) {
+    params.runtime.log?.("Default knowledge maintenance cron already configured.");
+    return;
+  }
+
+  store.jobs.push(createDefaultKnowledgeAgentCronJob(params.nowMs));
+  await saveCronStore(storePath, store);
+  await params.prompter?.note(
+    "Scheduled daily knowledge maintenance at 3:00 AM. It runs as an isolated agent job and maintains memory/ plus knowledge/ files.",
+    "Knowledge maintenance",
+  );
+}

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -13,8 +13,10 @@ import { createTestRuntime } from "./test-runtime-config-helpers.js";
 const hoisted = vi.hoisted(() => {
   let capturedMutatedConfig: OpenClawConfig = {};
   const execFileSync = vi.fn();
+  const ensureDefaultKnowledgeAgentCron = vi.fn(async () => {});
   return {
     execFileSync,
+    ensureDefaultKnowledgeAgentCron,
     get capturedMutatedConfig() {
       return capturedMutatedConfig;
     },
@@ -56,6 +58,10 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("../gemmaclaw/provision/bootstrap-profiles.js", () => ({
   applyBootstrapProfile: vi.fn(),
+}));
+
+vi.mock("./onboard-knowledge-agent.js", () => ({
+  ensureDefaultKnowledgeAgentCron: hoisted.ensureDefaultKnowledgeAgentCron,
 }));
 
 // Stub out filesystem writes so tests don't touch disk.
@@ -417,6 +423,19 @@ describe("setupGemmaCommand — agent creation", () => {
     expect(hoisted.capturedMutatedConfig.tools?.exec).toMatchObject({
       security: "full",
       ask: "off",
+    });
+    expect(hoisted.capturedMutatedConfig.hooks?.internal).toMatchObject({
+      enabled: true,
+      entries: {
+        "boot-md": { enabled: true },
+        "bootstrap-extra-files": { enabled: true },
+        "command-logger": { enabled: true },
+        "session-memory": { enabled: true },
+      },
+    });
+    expect(hoisted.ensureDefaultKnowledgeAgentCron).toHaveBeenCalledWith({
+      cfg: hoisted.capturedMutatedConfig,
+      runtime,
     });
     expect(fsMock.mkdirSync).toHaveBeenCalledWith(
       `${process.env.HOME ?? "/root"}/.gemmaclaw/shared`,

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -43,6 +43,12 @@ export type SetupGemmaCommandOpts = {
 
 const HEALTH_POLL_INTERVAL_MS = 500;
 const HEALTH_POLL_MAX_ATTEMPTS = 60;
+const GEMMACLAW_DEFAULT_INTERNAL_HOOK_NAMES = [
+  "boot-md",
+  "bootstrap-extra-files",
+  "command-logger",
+  "session-memory",
+] as const;
 
 function ensureDockerWritableHostDir(
   fsModule: Pick<typeof import("node:fs"), "chmodSync" | "mkdirSync">,
@@ -87,6 +93,35 @@ function buildGemmaclawDockerSandboxConfig(): NonNullable<
       user: "0:0",
     },
   };
+}
+
+function applyGemmaclawHookDefaults(draft: OpenClawConfig): void {
+  draft.hooks ??= {};
+  const hooks = draft.hooks as Record<string, unknown>;
+  const internal =
+    typeof hooks.internal === "object" && hooks.internal !== null
+      ? ({ ...(hooks.internal as Record<string, unknown>) } as Record<string, unknown>)
+      : {};
+  const entries =
+    typeof internal.entries === "object" && internal.entries !== null
+      ? { ...(internal.entries as Record<string, unknown>) }
+      : {};
+  if (internal.enabled !== false) {
+    internal.enabled = true;
+  }
+  for (const name of GEMMACLAW_DEFAULT_INTERNAL_HOOK_NAMES) {
+    if (entries[name] === undefined) {
+      entries[name] = { enabled: true };
+    }
+  }
+  internal.entries = entries;
+  hooks.internal = internal;
+}
+
+async function ensureGemmaclawKnowledgeAgentCron(runtime: RuntimeEnv): Promise<void> {
+  const { loadConfig } = await import("../config/config.js");
+  const { ensureDefaultKnowledgeAgentCron } = await import("./onboard-knowledge-agent.js");
+  await ensureDefaultKnowledgeAgentCron({ cfg: loadConfig(), runtime });
 }
 
 async function ensureGemmaclawSharedDir(): Promise<void> {
@@ -390,14 +425,14 @@ export async function setupGemmaCommand(
 
   if (choices.backend === "gemini") {
     await setupGeminiBackend(runtime, choices, { dryRun });
-    await applySharedAgentDefaults(choices, useDocker);
+    await applySharedAgentDefaults(choices, useDocker, runtime);
     await printPostSetupSummary(runtime, choices, undefined);
     return;
   }
 
   if (choices.backend === "vertex") {
     await setupVertexBackend(runtime, choices, { dryRun });
-    await applySharedAgentDefaults(choices, useDocker);
+    await applySharedAgentDefaults(choices, useDocker, runtime);
     await printPostSetupSummary(runtime, choices, undefined);
     return;
   }
@@ -440,7 +475,7 @@ export async function setupGemmaCommand(
     runtime.log(
       `[dry-run] Would provision ${profile.backend} with model ${profile.model ?? "(auto)"} on port ${String(profile.port)}.`,
     );
-    await applySharedAgentDefaults(choices, useDocker);
+    await applySharedAgentDefaults(choices, useDocker, runtime);
     await printPostSetupSummary(runtime, choices, undefined);
     return;
   }
@@ -695,6 +730,7 @@ async function writeVertexAuthProfile(agentName: string, accessToken: string): P
 async function applySharedAgentDefaults(
   choices: OnboardingChoices,
   useContainer: boolean,
+  runtime: RuntimeEnv,
 ): Promise<void> {
   const { mutateConfigFile } = await import("../config/mutate.js");
   await mutateConfigFile({
@@ -720,6 +756,7 @@ async function applySharedAgentDefaults(
       draft.tools.exec ??= {};
       (draft.tools.exec as Record<string, unknown>).security = "full";
       (draft.tools.exec as Record<string, unknown>).ask = "off";
+      applyGemmaclawHookDefaults(draft);
       applySetupAgentConfig(draft, choices);
     },
   });
@@ -727,6 +764,7 @@ async function applySharedAgentDefaults(
     await ensureGemmaclawSharedDir();
   }
   await applyAgentNameAndBootstrap(choices);
+  await ensureGemmaclawKnowledgeAgentCron(runtime);
 }
 
 export async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Promise<void> {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -27728,6 +27728,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["advanced", "url-secret"],
     },
   },
-  version: "2026.4.22",
+  version: "2026.4.23",
   generatedAt: "2026-03-22T21:17:33.302Z",
 };

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -289,6 +289,15 @@ describe("setupChannels workspace shadow exclusion", () => {
     );
 
     expect(select).toHaveBeenCalledWith(expect.objectContaining({ message: "Select a channel" }));
+    const channelSelectCall = (
+      select.mock.calls as unknown as Array<
+        [{ message?: string; options: Array<{ label: string; value: string }> }]
+      >
+    ).find(([params]) => params.message === "Select a channel");
+    expect(channelSelectCall?.[0].options[0]).toMatchObject({
+      value: "__done__",
+      label: "Skip for now (use web interface)",
+    });
     expect(collectChannelStatus).not.toHaveBeenCalled();
     expect(listTrustedChannelPluginCatalogEntries).not.toHaveBeenCalled();
     expect(listChannelSetupPlugins).not.toHaveBeenCalled();

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -50,6 +50,14 @@ import {
 } from "./channel-setup.status.js";
 export { noteChannelStatus } from "./channel-setup.status.js";
 
+const SKIP_CHANNEL_SETUP_OPTION = {
+  value: "__skip__",
+  label: "Skip for now (use web interface)",
+  hint: `You can add channels later from the web interface or via \`${formatCliCommand(
+    "openclaw channels add",
+  )}\``,
+} as const;
+
 export function createChannelOnboardingPostWriteHookCollector() {
   const hooks = new Map<string, ChannelOnboardingPostWriteHook>();
   return {
@@ -590,16 +598,12 @@ export async function setupChannels(
       const choice = await prompter.select({
         message: "Select channel (QuickStart)",
         options: [
+          SKIP_CHANNEL_SETUP_OPTION,
           ...resolveChannelSetupSelectionContributions({
             entries,
             statusByChannel,
             resolveDisabledHint,
           }).map((contribution) => contribution.option),
-          {
-            value: "__skip__",
-            label: "Skip for now",
-            hint: `You can add channels later via \`${formatCliCommand("openclaw channels add")}\``,
-          },
         ],
         initialValue: quickstartDefault,
         searchable: true,
@@ -619,16 +623,21 @@ export async function setupChannels(
       const choice = await prompter.select({
         message: "Select a channel",
         options: [
+          {
+            ...SKIP_CHANNEL_SETUP_OPTION,
+            value: doneValue,
+            hint:
+              selection.length > 0
+                ? "Done"
+                : `You can add channels later from the web interface or via \`${formatCliCommand(
+                    "openclaw channels add",
+                  )}\``,
+          },
           ...resolveChannelSetupSelectionContributions({
             entries,
             statusByChannel,
             resolveDisabledHint,
           }).map((contribution) => contribution.option),
-          {
-            value: doneValue,
-            label: "Finished",
-            hint: selection.length > 0 ? "Done" : "Skip for now",
-          },
         ],
         initialValue,
       });

--- a/src/gemmaclaw/provision/bootstrap-profiles.test.ts
+++ b/src/gemmaclaw/provision/bootstrap-profiles.test.ts
@@ -54,6 +54,8 @@ describe("bootstrap-profiles", () => {
       expect(result.written).toContain("AGENTS.md");
       const written = fs.readFileSync(path.join(tmpDir, "AGENTS.md"), "utf-8");
       expect(written).toContain("AGENTS.md");
+      expect(written).toContain("Use `knowledge/` for durable project notes");
+      expect(written).toContain("daily 3:00 AM knowledge maintenance job");
     });
 
     it("writes both AGENTS.md and TOOLS.md for the coding profile", () => {
@@ -61,6 +63,9 @@ describe("bootstrap-profiles", () => {
       expect(result.written.toSorted()).toEqual(["AGENTS.md", "TOOLS.md"]);
       expect(fs.existsSync(path.join(tmpDir, "AGENTS.md"))).toBe(true);
       expect(fs.existsSync(path.join(tmpDir, "TOOLS.md"))).toBe(true);
+      const written = fs.readFileSync(path.join(tmpDir, "AGENTS.md"), "utf-8");
+      expect(written).toContain("Use `knowledge/` for durable project notes");
+      expect(written).toContain("observable verification steps");
     });
 
     it("writes nothing for the minimal profile", () => {

--- a/src/gemmaclaw/provision/bootstrap-profiles.ts
+++ b/src/gemmaclaw/provision/bootstrap-profiles.ts
@@ -28,6 +28,11 @@ You are a helpful Gemma-powered assistant. Be concise, accurate, and direct.
 ## Memory
 - This file is your durable instructions. Update it as the user gives you ongoing
   preferences (tone, language, formatting).
+- Use \`memory/YYYY-MM-DD.md\` for chronological daily notes. Create \`memory/\` when needed.
+- Use \`knowledge/\` for durable project notes, procedures, decisions, and lessons.
+- Before saying you do not know something, search \`knowledge/\`, \`MEMORY.md\`, and recent daily memory files.
+- Never store secrets, tokens, private keys, OAuth redirects, or raw credentials in memory or knowledge files.
+- A daily 3:00 AM knowledge maintenance job may review recent \`memory/\` and update \`knowledge/\`.
 
 ## Self-Awareness
 - You are running as a Gemmaclaw agent.
@@ -54,6 +59,12 @@ workspace.
 ## Memory
 - Add durable conventions (lint rules, framework choices, build commands) here
   as you learn them.
+- Use \`memory/YYYY-MM-DD.md\` for chronological daily notes. Create \`memory/\` when needed.
+- Use \`knowledge/\` for durable project notes, procedures, decisions, debugging lessons, and verification playbooks.
+- Before saying you do not know something, search \`knowledge/\`, \`MEMORY.md\`, and recent daily memory files.
+- Keep knowledge files useful for future agents: include dates, commands that worked, commands that failed, and observable verification steps.
+- Never store secrets, tokens, private keys, OAuth redirects, or raw credentials in memory or knowledge files.
+- A daily 3:00 AM knowledge maintenance job may review recent \`memory/\` and update \`knowledge/\`.
 
 ## Self-Awareness
 - You are running as a Gemmaclaw agent.
@@ -134,7 +145,7 @@ export function applyBootstrapProfile(
       continue;
     }
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    
+
     let contentToOutput = spec.content;
     if (opts.useContainer && spec.relativePath === "AGENTS.md") {
       contentToOutput += `

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -79,6 +79,7 @@ const finalizeSetupWizard = vi.hoisted(() =>
 const listChannelPlugins = vi.hoisted(() => vi.fn(() => []));
 const logConfigUpdated = vi.hoisted(() => vi.fn(() => {}));
 const setupInternalHooks = vi.hoisted(() => vi.fn(async (cfg) => cfg));
+const ensureDefaultKnowledgeAgentCron = vi.hoisted(() => vi.fn(async () => {}));
 
 const setupChannels = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
@@ -181,6 +182,10 @@ vi.mock("../commands/health.js", () => ({
 
 vi.mock("../commands/onboard-hooks.js", () => ({
   setupInternalHooks,
+}));
+
+vi.mock("../commands/onboard-knowledge-agent.js", () => ({
+  ensureDefaultKnowledgeAgentCron,
 }));
 
 vi.mock("../config/config.js", () => ({

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -685,6 +685,10 @@ export async function runSetupWizard(
   const { setupInternalHooks } = await import("../commands/onboard-hooks.js");
   nextConfig = await setupInternalHooks(nextConfig, runtime, prompter);
 
+  const { ensureDefaultKnowledgeAgentCron } =
+    await import("../commands/onboard-knowledge-agent.js");
+  await ensureDefaultKnowledgeAgentCron({ cfg: nextConfig, runtime, prompter });
+
   nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
   await writeConfigFile(nextConfig);
 


### PR DESCRIPTION
## Summary
- Put the setup channel skip option first and label it as the web-interface path
- Default-enable core internal hooks during setup
- Add a daily isolated knowledge maintenance cron job and starter memory/knowledge instructions
- Apply the same hook, cron, and AGENTS defaults to Gemmaclaw container setup

## Verification
- pnpm check:changed
- pnpm build
- pnpm test:e2e:onboard-gemma
- Gemmaclaw container setup dry-run with Gemini backend, verified Docker sandbox, hooks, cron job, and generated AGENTS.md
- gemini -p "Reply exactly GEMINI_SMOKE_OK"

Note: live container-agent smoke script skipped locally because GEMINI_API_KEY is not set in this environment.