### PR TITLE
test: clean outer smoke build artifact ownership

### DIFF
--- a/scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh
+++ b/scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh
@@ -55,6 +55,14 @@ printf 'HOST_SENTINEL_ORIGINAL\n' > "$HOST_SENTINEL"
 
 cleanup() {
   local status=$?
+  if command -v docker >/dev/null 2>&1; then
+    local uid gid
+    uid="$(id -u)"
+    gid="$(id -g)"
+    docker run --rm -v "$ROOT_DIR:/repo" debian:bookworm-slim \
+      sh -lc "chown -R $uid:$gid /repo/dist /repo/dist-runtime /repo/.artifacts 2>/dev/null || true" \
+      >/dev/null 2>&1 || true
+  fi
   if [ "$status" -eq 0 ]; then
     rm -rf "$HOST_ROOT"
   else


### PR DESCRIPTION
## Summary
- repair ownership of generated build artifacts after the outer-Docker non-container smoke exits
- prevents root-owned `dist-runtime` plugin dependency trees from breaking the next local `pnpm build`

## Verification
- `pnpm build`
- `GEMMACLAW_LOCAL_AGENT_SMOKE_REQUIRED=1 pnpm test:docker:gemmaclaw-setup-live-smoke`
- repeated `pnpm build` immediately after the smoke
- `pnpm check:changed`
