### PR TITLE
fix: set 4 GB heap limit in gemmaclaw launcher for large backup restores

### DIFF
--- a/gemmaclaw.mjs
+++ b/gemmaclaw.mjs
@@ -62,6 +62,14 @@ if (gemmaclawStateDir !== null) {
   childEnv.OPENCLAW_STATE_DIR = gemmaclawStateDir;
 }
 
+// Increase the Node.js heap limit for operations that process large archives
+// (e.g. backup restore on instances with large node_modules or model files).
+// Default ~2 GB is insufficient for 4+ GB backups. Only set if not already
+// configured by the caller via NODE_OPTIONS.
+if (!childEnv.NODE_OPTIONS?.includes("--max-old-space-size")) {
+  childEnv.NODE_OPTIONS = `${childEnv.NODE_OPTIONS ?? ""} --max-old-space-size=4096`.trimStart();
+}
+
 const child = spawn(process.execPath, [openclawEntrypoint, ...process.argv.slice(2)], {
   stdio: "inherit",
   env: childEnv,


### PR DESCRIPTION
## Summary
- Sets NODE_OPTIONS=--max-old-space-size=4096 in gemmaclaw.mjs launcher when not already configured
- Prevents Node.js heap OOM when running gemmaclaw backup restore on large instances (4+ GB archives)
- Respects existing NODE_OPTIONS; only appends if --max-old-space-size not already set

## Root cause
Default V8 heap (~2 GB) was insufficient for restoring 4.75 GB backup (538K entries). Restore exhausted heap after ~743s. Fix confirmed working with 4 GB heap.

## Test plan
- [x] Restore of 4.75 GB archive succeeded with the 4 GB heap setting
- [ ] CI: backup/restore tests pass with new launcher env