### PR TITLE
maintenance: upstream sync 2026-05-07 (CLI completion guard + gateway startup warnings)

### DIFF
--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -68,9 +68,9 @@ function formatCompletionSourceLine(
   cachePath: string,
 ): string {
   if (shell === "fish") {
-    return `source "${cachePath}"`;
+    return `test -f "${cachePath}"; and source "${cachePath}"`;
   }
-  return `source "${cachePath}"`;
+  return `[ -f "${cachePath}" ] && source "${cachePath}"`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -99,6 +99,11 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     }
     assertValidGatewayStartupConfigSnapshot(configSnapshot, { includeDoctorHint: true });
   }
+  if (configSnapshot.warnings.length > 0) {
+    params.log.warn(
+      `gateway: config warnings:\n${formatConfigIssueLines(configSnapshot.warnings, "-").join("\n")}`,
+    );
+  }
 
   const autoEnable = params.minimalTestGateway
     ? { config: configSnapshot.config, changes: [] as string[] }


### PR DESCRIPTION
## Summary

- **cli/completion**: Guard shell profile source lines with file-exists check (port of upstream #78659)
  - bash/zsh: `[ -f "${cachePath}" ] && source "${cachePath}"`
  - fish: `test -f "${cachePath}"; and source "${cachePath}"`
  - Prevents errors when the completion cache file doesn't exist yet
- **gateway**: Log config warnings at startup (port of upstream #78642)
  - Surfaces `configSnapshot.warnings` in the gateway startup log for visibility
  - No behavior change; purely diagnostic

## Changes from upstream/main (as of 2026-05-07)

Reviewed 20 upstream commits. Applied 2 directly applicable bug fixes. Remaining commits are CI infrastructure, telegram plugin, docs, or perf optimizations deferred for separate review.

## Regression gate

- `pnpm check:changed` passed (typecheck, lint, import cycles, tests)
- vitest.gateway.config.ts: 231 files, 2632 tests passed
- vitest.cli.config.ts: 108 files, 1024 tests passed