### PR TITLE
fix: exclude .test-helpers files from bundle surface entries

### DIFF
--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -73,8 +73,11 @@ function collectTopLevelPublicSurfaceEntries(pluginDir) {
         normalizedName.endsWith(".d.ts") ||
         /^config-api\.(?:[cm]?[jt]s)$/u.test(normalizedName) ||
         normalizedName.includes(".test.") ||
+        normalizedName.includes(".test-") ||
         normalizedName.includes(".spec.") ||
+        normalizedName.includes(".spec-") ||
         normalizedName.includes(".fixture.") ||
+        normalizedName.includes(".fixture-") ||
         normalizedName.includes(".snap")
       ) {
         return [];


### PR DESCRIPTION
The collectTopLevelPublicSurfaceEntries filter excluded .test. and .spec. but missed hyphenated variants like .test-helpers.ts. Files named google-shared.test-helpers.ts were included as bundle entries, pulling vitest/expect-type into the production build and causing UNRESOLVED_IMPORT errors (expect-type CJS dist lacks branding.js and overloads.js runtime files). Fix extends exclusions to cover .test-, .spec-, .fixture- hyphenated variants.