### PR TITLE
fix: comprehensive exclusion of test/harness/fixture files from bundle surface

### DIFF
--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -72,12 +72,7 @@ function collectTopLevelPublicSurfaceEntries(pluginDir) {
       if (
         normalizedName.endsWith(".d.ts") ||
         /^config-api\.(?:[cm]?[jt]s)$/u.test(normalizedName) ||
-        normalizedName.includes(".test.") ||
-        normalizedName.includes(".test-") ||
-        normalizedName.includes(".spec.") ||
-        normalizedName.includes(".spec-") ||
-        normalizedName.includes(".fixture.") ||
-        normalizedName.includes(".fixture-") ||
+        /(?:^|[.-])(?:test|spec|harness|fixture|mock|stub)(?:[.-]|$)/u.test(normalizedName) ||
         normalizedName.includes(".snap")
       ) {
         return [];


### PR DESCRIPTION
Replace per-pattern includes() checks with a single regex covering all test-related naming conventions: test-api.ts, harness.ts, test-helpers.ts etc. Fixes slack/test-api.ts and codex/harness.ts being included as bundle entries.