### PR TITLE
feat(google): enhance Vertex AI support and fix model path resolution

### DIFF
--- a/extensions/google/gemini-auth.ts
+++ b/extensions/google/gemini-auth.ts
@@ -1,6 +1,28 @@
+import { execSync } from "node:child_process";
 import { parseGoogleOauthApiKey } from "./oauth-token-shared.js";
 
+/** Marker for Vertex AI credentials that should be resolved via gcloud. */
+const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
+
 export function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
+  if (apiKey === GCP_VERTEX_CREDENTIALS_MARKER) {
+    try {
+      const token = execSync("gcloud auth print-access-token", {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      return {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      };
+    } catch (e) {
+      // In case gcloud fails, we log it and return empty headers (which will likely result in a 401).
+      console.error("Failed to resolve Vertex AI credentials via gcloud:", e);
+    }
+  }
+
   const parsed = apiKey.startsWith("{") ? parseGoogleOauthApiKey(apiKey) : null;
   if (parsed?.token) {
     return {

--- a/extensions/google/gemini-auth.ts
+++ b/extensions/google/gemini-auth.ts
@@ -7,7 +7,7 @@ const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 export function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
   if (apiKey === GCP_VERTEX_CREDENTIALS_MARKER) {
     try {
-      const token = execSync("gcloud auth print-access-token", {
+      const token = execSync("gcloud auth application-default print-access-token", {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
       }).trim();
@@ -19,7 +19,7 @@ export function parseGeminiAuth(apiKey: string): { headers: Record<string, strin
       };
     } catch (e) {
       // In case gcloud fails, we log it and return empty headers (which will likely result in a 401).
-      console.error("Failed to resolve Vertex AI credentials via gcloud:", e);
+      console.error("Failed to resolve Vertex AI credentials via gcloud application-default:", e);
     }
   }
 

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "google",
   "enabledByDefault": true,
-  "providers": ["google", "google-gemini-cli", "google-vertex", "google-antigravity"],
+  "providers": ["google", "google-gemini-cli", "google-vertex"],
   "autoEnableWhenConfiguredProviders": ["google-gemini-cli"],
   "cliBackends": ["google-gemini-cli"],
   "providerAuthEnvVars": {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "google",
   "enabledByDefault": true,
-  "providers": ["google", "google-gemini-cli"],
+  "providers": ["google", "google-gemini-cli", "google-vertex", "google-antigravity"],
   "autoEnableWhenConfiguredProviders": ["google-gemini-cli"],
   "cliBackends": ["google-gemini-cli"],
   "providerAuthEnvVars": {

--- a/extensions/google/provider-contract-api.ts
+++ b/extensions/google/provider-contract-api.ts
@@ -7,7 +7,7 @@ export function createGoogleProvider(): ProviderPlugin {
     id: "google",
     label: "Google AI Studio",
     docsPath: "/providers/models",
-    hookAliases: ["google-antigravity", "google-vertex"],
+    hookAliases: [],
     envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
     auth: [
       {
@@ -22,6 +22,31 @@ export function createGoogleProvider(): ProviderPlugin {
           groupId: "google",
           groupLabel: "Google",
           groupHint: "Gemini API key + OAuth",
+        },
+      },
+    ],
+  };
+}
+
+export function createGoogleVertexProvider(): ProviderPlugin {
+  return {
+    id: "google-vertex",
+    label: "Google Cloud Vertex AI",
+    docsPath: "/providers/models",
+    envVars: ["GOOGLE_APPLICATION_CREDENTIALS"],
+    auth: [
+      {
+        id: "gcloud-adc",
+        kind: "api_key",
+        label: "gcloud Application Default Credentials",
+        hint: "Vertex AI via gcloud auth",
+        run: noopAuth,
+        wizard: {
+          choiceId: "vertex-adc",
+          choiceLabel: "Google Cloud Vertex AI (gcloud)",
+          groupId: "google",
+          groupLabel: "Google",
+          groupHint: "Vertex AI via gcloud ADC or service account",
         },
       },
     ],

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -16,7 +16,7 @@ export function buildGoogleProvider(): ProviderPlugin {
     id: "google",
     label: "Google AI Studio",
     docsPath: "/providers/models",
-    hookAliases: ["google-antigravity", "google-vertex"],
+    hookAliases: [],
     envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
     auth: [
       createProviderApiKeyAuthMethod({
@@ -58,6 +58,53 @@ export function buildGoogleProvider(): ProviderPlugin {
   };
 }
 
+export function buildGoogleVertexProvider(): ProviderPlugin {
+  return {
+    id: "google-vertex",
+    label: "Google Cloud Vertex AI",
+    docsPath: "/providers/models",
+    envVars: ["GOOGLE_APPLICATION_CREDENTIALS"],
+    auth: [
+      createProviderApiKeyAuthMethod({
+        providerId: "google-vertex",
+        methodId: "gcloud-adc",
+        label: "gcloud Application Default Credentials",
+        hint: "Vertex AI via gcloud auth",
+        optionKey: "vertexCredentials",
+        flagName: "--vertex-credentials",
+        envVar: "GOOGLE_APPLICATION_CREDENTIALS",
+        promptMessage: "Enter path to service account key (or leave blank for gcloud ADC)",
+        defaultModel: "gemma-4-31b-it",
+        expectedProviders: ["google-vertex"],
+        applyConfig: (cfg) => applyGoogleGeminiModelDefault(cfg).next,
+        wizard: {
+          choiceId: "vertex-adc",
+          choiceLabel: "Google Cloud Vertex AI (gcloud)",
+          groupId: "google",
+          groupLabel: "Google",
+          groupHint: "Vertex AI via gcloud ADC or service account",
+        },
+      }),
+    ],
+    normalizeTransport: ({ api, baseUrl }) => resolveGoogleGenerativeAiTransport({ api, baseUrl }),
+    normalizeConfig: ({ provider, providerConfig }) =>
+      normalizeGoogleProviderConfig(provider, providerConfig),
+    normalizeModelId: ({ modelId }) => normalizeGoogleModelId(modelId),
+    resolveDynamicModel: (ctx) =>
+      resolveGoogleGeminiForwardCompatModel({
+        providerId: ctx.provider,
+        ctx,
+      }),
+    createStreamFn: ({ model }) =>
+      model.api === "google-generative-ai"
+        ? createGoogleGenerativeAiTransportStreamFn()
+        : undefined,
+    ...GOOGLE_GEMINI_PROVIDER_HOOKS,
+    isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
+  };
+}
+
 export function registerGoogleProvider(api: OpenClawPluginApi) {
   api.registerProvider(buildGoogleProvider());
+  api.registerProvider(buildGoogleVertexProvider());
 }

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -180,7 +180,12 @@ function normalizeToolCallId(id: string): string {
 }
 
 function resolveGoogleModelPath(modelId: string): string {
-  if (modelId.startsWith("models/") || modelId.startsWith("tunedModels/")) {
+  if (
+    modelId.startsWith("models/") ||
+    modelId.startsWith("tunedModels/") ||
+    modelId.startsWith("publishers/") ||
+    modelId.startsWith("projects/")
+  ) {
     return modelId;
   }
   return `models/${modelId}`;

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -1449,27 +1449,31 @@ gemmaclaw setup
 # Or run setup interactively (prompts for provider and key)
 gemmaclaw setup</code></pre></div>
 
-      <p>Available models: gemma-3-1b-it, gemma-3-4b-it, gemma-3-12b-it, gemma-3-27b-it.</p>
+      <p>Available models: gemma-4-31b-it, gemma-3-27b-it, gemma-3-12b-it, gemma-3-4b-it, gemma-3-1b-it.</p>
 
       <h3 id="path-vertex">Path 3: Vertex AI (Cloud, enterprise)</h3>
-      <p>For GCP-integrated deployments. Uses gcloud credentials or a service account. Requires a GCP project with the Vertex AI API enabled.</p>
+      <p>For GCP-integrated deployments. Uses gcloud credentials or a service account. Requires a GCP project with the Vertex AI API enabled. Auth tokens are resolved at runtime via <code>gcloud</code>, so they never go stale in your config.</p>
 
       <div class="code-block"><pre><code># Authenticate with gcloud
 gcloud auth application-default login
 gcloud config set project YOUR_PROJECT_ID
 
-# Interactive setup (prompts for project, region, model)
+# Interactive setup (prompts for project, region, API protocol, model)
 gemmaclaw setup --vertex
 
 # Non-interactive with flags
 gemmaclaw setup --vertex \\
   --vertex-project my-gcp-project \\
-  --vertex-region us-central1 \\
-  --vertex-model gemma-3-27b-it
+  --vertex-region us-west1 \\
+  --vertex-model gemma-4-31b-it
 
 # With a service account key
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
 gemmaclaw setup --vertex --vertex-project my-project</code></pre></div>
+
+      <p><strong>API protocol:</strong> The wizard asks you to choose between the native Gemini API and the OpenAI-compatible API. Native is the default and recommended for most setups. OpenAI-compatible is available if your tooling requires that format.</p>
+
+      <p><strong>Available models:</strong> gemma-4-31b-it, gemma-3-27b-it, gemma-3-12b-it, gemma-3-4b-it, gemma-3-1b-it.</p>
 
       <p>For Docker, mount your gcloud credentials:</p>
       <div class="code-block"><pre><code>docker run -v ~/.config/gcloud:/root/.config/gcloud gemmaclaw setup --vertex</code></pre></div>
@@ -1479,8 +1483,8 @@ gemmaclaw setup --vertex --vertex-project my-project</code></pre></div>
         <tbody>
           <tr><td><code>--vertex</code></td><td>Enable Vertex AI setup (required)</td></tr>
           <tr><td><code>--vertex-project &lt;id&gt;</code></td><td>GCP project ID (auto-detected from gcloud if not set)</td></tr>
-          <tr><td><code>--vertex-region &lt;region&gt;</code></td><td>GCP region (default: us-central1)</td></tr>
-          <tr><td><code>--vertex-model &lt;model&gt;</code></td><td>Gemma model (e.g. gemma-3-27b-it)</td></tr>
+          <tr><td><code>--vertex-region &lt;region&gt;</code></td><td>GCP region (default: us-west1)</td></tr>
+          <tr><td><code>--vertex-model &lt;model&gt;</code></td><td>Gemma model (e.g. gemma-4-31b-it)</td></tr>
         </tbody>
       </table></div>
 

--- a/site/setup.html
+++ b/site/setup.html
@@ -849,27 +849,31 @@ gemmaclaw setup
 # Or run setup interactively (prompts for provider and key)
 gemmaclaw setup</code></pre></div>
 
-      <p>Available models: gemma-3-1b-it, gemma-3-4b-it, gemma-3-12b-it, gemma-3-27b-it.</p>
+      <p>Available models: gemma-4-31b-it, gemma-3-27b-it, gemma-3-12b-it, gemma-3-4b-it, gemma-3-1b-it.</p>
 
       <h3 id="path-vertex">Path 3: Vertex AI (Cloud, enterprise)</h3>
-      <p>For GCP-integrated deployments. Uses gcloud credentials or a service account. Requires a GCP project with the Vertex AI API enabled.</p>
+      <p>For GCP-integrated deployments. Uses gcloud credentials or a service account. Requires a GCP project with the Vertex AI API enabled. Auth tokens are resolved at runtime via <code>gcloud</code>, so they never go stale in your config.</p>
 
       <div class="code-block"><pre><code># Authenticate with gcloud
 gcloud auth application-default login
 gcloud config set project YOUR_PROJECT_ID
 
-# Interactive setup (prompts for project, region, model)
+# Interactive setup (prompts for project, region, API protocol, model)
 gemmaclaw setup --vertex
 
 # Non-interactive with flags
 gemmaclaw setup --vertex \
   --vertex-project my-gcp-project \
-  --vertex-region us-central1 \
-  --vertex-model gemma-3-27b-it
+  --vertex-region us-west1 \
+  --vertex-model gemma-4-31b-it
 
 # With a service account key
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
 gemmaclaw setup --vertex --vertex-project my-project</code></pre></div>
+
+      <p><strong>API protocol:</strong> The wizard asks you to choose between the native Gemini API and the OpenAI-compatible API. Native is the default and recommended for most setups. OpenAI-compatible is available if your tooling requires that format.</p>
+
+      <p><strong>Available models:</strong> gemma-4-31b-it, gemma-3-27b-it, gemma-3-12b-it, gemma-3-4b-it, gemma-3-1b-it.</p>
 
       <p>For Docker, mount your gcloud credentials:</p>
       <div class="code-block"><pre><code>docker run -v ~/.config/gcloud:/root/.config/gcloud gemmaclaw setup --vertex</code></pre></div>
@@ -879,8 +883,8 @@ gemmaclaw setup --vertex --vertex-project my-project</code></pre></div>
         <tbody>
           <tr><td><code>--vertex</code></td><td>Enable Vertex AI setup (required)</td></tr>
           <tr><td><code>--vertex-project &lt;id&gt;</code></td><td>GCP project ID (auto-detected from gcloud if not set)</td></tr>
-          <tr><td><code>--vertex-region &lt;region&gt;</code></td><td>GCP region (default: us-central1)</td></tr>
-          <tr><td><code>--vertex-model &lt;model&gt;</code></td><td>Gemma model (e.g. gemma-3-27b-it)</td></tr>
+          <tr><td><code>--vertex-region &lt;region&gt;</code></td><td>GCP region (default: us-west1)</td></tr>
+          <tr><td><code>--vertex-model &lt;model&gt;</code></td><td>Gemma model (e.g. gemma-4-31b-it)</td></tr>
         </tbody>
       </table></div>
 

--- a/src/gemmaclaw/provision/vertex-setup.ts
+++ b/src/gemmaclaw/provision/vertex-setup.ts
@@ -23,6 +23,8 @@ export type VertexConfig = {
   project: string;
   region: string;
   model: string;
+  /** API format: "native" for Gemini API, "openai" for OpenAI-compatible. */
+  apiFormat?: "native" | "openai";
   /** Access token from gcloud (short-lived, refreshed per session). */
   accessToken?: string;
   /** Path to ADC credentials file. */
@@ -39,6 +41,7 @@ export type VertexSetupResult = {
 
 // Default Gemma models available on Vertex AI
 export const VERTEX_GEMMA_MODELS = [
+  { id: "gemma-4-31b-it", display: "Gemma 4 31B IT", params: "31B" },
   { id: "gemma-3-1b-it", display: "Gemma 3 1B IT", params: "1B" },
   { id: "gemma-3-4b-it", display: "Gemma 3 4B IT", params: "4B" },
   { id: "gemma-3-12b-it", display: "Gemma 3 12B IT", params: "12B" },
@@ -129,7 +132,13 @@ export async function testVertexConnection(
  * Returns the config object to merge into openclaw.json.
  */
 export function buildVertexConfig(vertex: VertexConfig): Record<string, unknown> {
-  const baseUrl = `https://${vertex.region}-aiplatform.googleapis.com/v1beta1/projects/${vertex.project}/locations/${vertex.region}/endpoints/openapi`;
+  const isNative = vertex.apiFormat === "native";
+
+  const baseUrl = isNative
+    ? `https://${vertex.region}-aiplatform.googleapis.com/v1/projects/${vertex.project}/locations/${vertex.region}/publishers/google`
+    : `https://${vertex.region}-aiplatform.googleapis.com/v1beta1/projects/${vertex.project}/locations/${vertex.region}/endpoints/openapi`;
+
+  const api = isNative ? "google-generative-ai" : "openai-responses";
 
   return {
     agents: {
@@ -147,7 +156,7 @@ export function buildVertexConfig(vertex: VertexConfig): Record<string, unknown>
             {
               id: vertex.model,
               name: vertex.model,
-              api: "google-generative-ai",
+              api,
             },
           ],
         },
@@ -164,6 +173,7 @@ export async function interactiveVertexSetup(opts?: {
   project?: string;
   region?: string;
   model?: string;
+  apiFormat?: "native" | "openai";
   nonInteractive?: boolean;
 }): Promise<VertexSetupResult> {
   const log = console.log;
@@ -204,10 +214,25 @@ export async function interactiveVertexSetup(opts?: {
   log(`  Project: ${project}`);
 
   // 3. Region
-  const region = opts?.region ?? "us-central1";
+  const region = opts?.region ?? "us-west1";
   log(`  Region: ${region}`);
 
-  // 4. Get access token
+  // 4. API Format
+  let apiFormat = opts?.apiFormat ?? "native";
+  if (!opts?.apiFormat && !opts?.nonInteractive) {
+    log("\nSelect API Protocol:");
+    log("  1) Native Gemini API (google-generative-ai)");
+    log("  2) OpenAI Compatible API (openai-responses)");
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const choice = await rl.question("Choice [1-2] (default: 1): ");
+    rl.close();
+    if (choice.trim() === "2") {
+      apiFormat = "openai";
+    }
+  }
+  log(`  Protocol: ${apiFormat}`);
+
+  // 5. Get access token
   log("Getting access token...");
   let accessToken: string | null = null;
 
@@ -291,6 +316,7 @@ export async function interactiveVertexSetup(opts?: {
       project,
       region,
       model,
+      apiFormat,
       accessToken: accessToken ?? undefined,
       adcPath: adcPath ?? undefined,
     },
@@ -304,6 +330,7 @@ export async function setupVertex(opts: {
   project?: string;
   region?: string;
   model?: string;
+  apiFormat?: "native" | "openai";
 }): Promise<VertexSetupResult> {
   return interactiveVertexSetup({ ...opts, nonInteractive: !process.stdin.isTTY });
 }

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -53,7 +53,7 @@ export const pluginRegistrationContractCases = {
   },
   google: {
     pluginId: "google",
-    providerIds: ["google", "google-gemini-cli"],
+    providerIds: ["google", "google-gemini-cli", "google-vertex"],
     webSearchProviderIds: ["gemini"],
     speechProviderIds: ["google"],
     mediaUnderstandingProviderIds: ["google"],


### PR DESCRIPTION
This PR enhances Vertex AI support in the Google extension by adding a marker for on-demand token resolution via gcloud and extending model path resolution to support publisher models.

Key changes:
- Added GCP_VERTEX_CREDENTIALS_MARKER to parseGeminiAuth to allow using 'application-default' tokens on demand.
- Extended resolveGoogleModelPath to support 'publishers/' and 'projects/' prefixed model IDs.
- Updated vertex-setup to include gemma-4-31b-it and select between native and openai API formats.
- Fixed default region to us-west1 for Vertex AI setup.
- Updated plugin manifest to include google-vertex and google-antigravity providers.