### PR TITLE
maintenance: upstream sync 2026-05-09

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -321,8 +321,12 @@ describe("CLI attempt execution", () => {
     });
 
     const sessionFile = updatedEntry?.sessionFile;
-    expect(sessionFile).toBeTruthy();
-    const messages = await readSessionMessages(sessionFile!);
+    expect(typeof sessionFile).toBe("string");
+    expect(sessionFile?.length ?? 0).toBeGreaterThan(0);
+    if (typeof sessionFile !== "string" || sessionFile.length === 0) {
+      throw new Error("Expected CLI transcript session file.");
+    }
+    const messages = await readSessionMessages(sessionFile);
     expect(messages).toHaveLength(2);
     expect(messages[0]).toMatchObject({
       role: "user",

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -247,7 +247,7 @@ describe("plugins cli install", () => {
       runPluginsCommand(["plugins", "install", "alpha", "--marketplace", "local/repo", "--link"]),
     ).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors.at(-1)).toContain("`--link` is not supported with `--marketplace`.");
+    expect(runtimeErrors.at(-1)).toContain("--link is not supported with --marketplace.");
     expect(installPluginFromMarketplace).not.toHaveBeenCalled();
   });
 
@@ -256,7 +256,7 @@ describe("plugins cli install", () => {
       runPluginsCommand(["plugins", "install", "./plugin", "--link", "--force"]),
     ).rejects.toThrow("__exit__:1");
 
-    expect(runtimeErrors.at(-1)).toContain("`--force` is not supported with `--link`.");
+    expect(runtimeErrors.at(-1)).toContain("--force is not supported with --link.");
     expect(installPluginFromMarketplace).not.toHaveBeenCalled();
     expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
   });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -28,6 +28,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
+import { formatCliCommand } from "./command-format.js";
 import {
   applySlotSelectionForPlugin,
   createPluginInstallLogger,
@@ -171,7 +172,11 @@ export function registerPluginsCli(program: Command) {
       }
 
       if (list.length === 0) {
-        defaultRuntime.log(theme.muted("No plugins found."));
+        defaultRuntime.log(
+          theme.muted(
+            `No plugins found. Run ${formatCliCommand("openclaw plugins install <plugin>")} to add one, or ${formatCliCommand("openclaw plugins list --json")} to inspect raw discovery state.`,
+          ),
+        );
         return;
       }
 

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -22,6 +22,7 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
+import { formatCliCommand } from "./command-format.js";
 import { looksLikeLocalInstallSpec } from "./install-spec.js";
 import { resolvePinnedNpmInstallRecordForCli } from "./npm-resolution.js";
 import {
@@ -301,16 +302,22 @@ export async function runPluginInstallCommand(params: {
   };
   if (opts.marketplace) {
     if (opts.link) {
-      defaultRuntime.error("`--link` is not supported with `--marketplace`.");
+      defaultRuntime.error(
+        `--link is not supported with --marketplace. Remove --link, or install a local path with ${formatCliCommand("openclaw plugins install --link <path>")}.`,
+      );
       return defaultRuntime.exit(1);
     }
     if (opts.pin) {
-      defaultRuntime.error("`--pin` is not supported with `--marketplace`.");
+      defaultRuntime.error(
+        `--pin is not supported with --marketplace. Use ${formatCliCommand("openclaw plugins install <plugin> --marketplace <name>")} without --pin.`,
+      );
       return defaultRuntime.exit(1);
     }
   }
   if (opts.link && opts.force) {
-    defaultRuntime.error("`--force` is not supported with `--link`.");
+    defaultRuntime.error(
+      `--force is not supported with --link. Linked plugins point at the source path directly; remove --force and re-run ${formatCliCommand("openclaw plugins install --link <path>")}.`,
+    );
     return defaultRuntime.exit(1);
   }
   const requestResolution = resolvePluginInstallRequestContext({
@@ -461,7 +468,9 @@ export async function runPluginInstallCommand(params: {
   }
 
   if (opts.link) {
-    defaultRuntime.error("`--link` requires a local path.");
+    defaultRuntime.error(
+      `--link requires a local path. Run ${formatCliCommand("openclaw plugins install --link <path>")}.`,
+    );
     return defaultRuntime.exit(1);
   }
 

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { confirm } from "@clack/prompts";
 import type { Command } from "commander";
 import { danger } from "../globals.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
 import { runSecretsApply } from "../secrets/apply.js";
 import { resolveSecretsAuditExitCode, runSecretsAudit } from "../secrets/audit.js";
@@ -9,6 +10,7 @@ import { runSecretsConfigureInteractive } from "../secrets/configure.js";
 import { isSecretsApplyPlan, type SecretsApplyPlan } from "../secrets/plan.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
+import { formatCliCommand } from "./command-format.js";
 import { addGatewayClientOptions, callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
 
 type SecretsReloadOptions = GatewayRpcOpts & { json?: boolean };
@@ -38,7 +40,9 @@ function readPlanFile(pathname: string): SecretsApplyPlan {
   const raw = fs.readFileSync(pathname, "utf8");
   const parsed = JSON.parse(raw) as unknown;
   if (!isSecretsApplyPlan(parsed)) {
-    throw new Error(`Invalid secrets plan file: ${pathname}`);
+    throw new Error(
+      `Invalid secrets plan file: ${pathname}. Generate a fresh plan with ${formatCliCommand("openclaw secrets configure --plan-out <path>")}.`,
+    );
   }
   return parsed;
 }
@@ -76,7 +80,11 @@ export function registerSecretsCli(program: Command) {
       }
       defaultRuntime.log("Secrets reloaded.");
     } catch (err) {
-      defaultRuntime.error(danger(String(err)));
+      defaultRuntime.error(
+        danger(
+          `Secrets reload failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} to inspect the active gateway.`,
+        ),
+      );
       defaultRuntime.exit(1);
     }
   });
@@ -123,7 +131,11 @@ export function registerSecretsCli(program: Command) {
           defaultRuntime.exit(exitCode);
         }
       } catch (err) {
-        defaultRuntime.error(danger(String(err)));
+        defaultRuntime.error(
+          danger(
+            `Secrets audit failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw doctor")} to inspect config and credential state.`,
+          ),
+        );
         defaultRuntime.exit(2);
       }
     });

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -10,6 +10,7 @@ import type {
   ChannelCapabilitiesDisplayLine,
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import {
   readConfigFileSnapshot,
   replaceConfigFile,
@@ -227,12 +228,20 @@ export async function channelsCapabilitiesCommand(
   const rawTarget = normalizeOptionalString(opts.target) ?? "";
 
   if (opts.account && (!rawChannel || rawChannel === "all")) {
-    runtime.error(danger("--account requires a specific --channel."));
+    runtime.error(
+      danger(
+        `--account requires a specific --channel. Run ${formatCliCommand("openclaw channels list")} to choose one.`,
+      ),
+    );
     runtime.exit(1);
     return;
   }
   if (rawTarget && (!rawChannel || rawChannel === "all")) {
-    runtime.error(danger("--target requires a specific --channel."));
+    runtime.error(
+      danger(
+        `--target requires a specific --channel. Run ${formatCliCommand("openclaw channels list")} to choose one.`,
+      ),
+    );
     runtime.exit(1);
     return;
   }
@@ -259,7 +268,11 @@ export async function channelsCapabilitiesCommand(
         })();
 
   if (!selected || selected.length === 0) {
-    runtime.error(danger(`Unknown channel "${rawChannel}".`));
+    runtime.error(
+      danger(
+        `Unknown channel "${rawChannel}". Run ${formatCliCommand("openclaw channels list")} to see installed channels.`,
+      ),
+    );
     runtime.exit(1);
     return;
   }

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../cli/command-format.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import type { WizardSection } from "./configure.shared.js";
@@ -27,7 +28,7 @@ export async function configureCommandFromSectionsArg(
 
   if (invalid.length > 0) {
     runtime.error(
-      `Invalid --section: ${invalid.join(", ")}. Expected one of: ${CONFIGURE_WIZARD_SECTIONS.join(", ")}.`,
+      `Invalid --section: ${invalid.join(", ")}. Expected one of: ${CONFIGURE_WIZARD_SECTIONS.join(", ")}. Run ${formatCliCommand("openclaw configure")} without --section to use the full wizard.`,
     );
     runtime.exit(1);
     return;

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -52,7 +52,7 @@ describe("setupWizardCommand", () => {
     );
 
     expect(runtime.error).toHaveBeenCalledWith(
-      'Invalid --secret-input-mode. Use "plaintext" or "ref".',
+      expect.stringContaining('Invalid --secret-input-mode. Use "plaintext" or "ref"'),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
@@ -150,7 +150,9 @@ describe("setupWizardCommand", () => {
     );
 
     expect(runtime.error).toHaveBeenCalledWith(
-      'Invalid --reset-scope. Use "config", "config+creds+sessions", or "full".',
+      expect.stringContaining(
+        'Invalid --reset-scope. Use "config", "config+creds+sessions", or "full"',
+      ),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.handleReset).not.toHaveBeenCalled();

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -50,13 +50,17 @@ export async function setupWizardCommand(
     normalizedOpts.secretInputMode !== "plaintext" && // pragma: allowlist secret
     normalizedOpts.secretInputMode !== "ref" // pragma: allowlist secret
   ) {
-    runtime.error('Invalid --secret-input-mode. Use "plaintext" or "ref".');
+    runtime.error(
+      `Invalid --secret-input-mode. Use "plaintext" or "ref", or run ${formatCliCommand("openclaw onboard")} for the interactive setup.`,
+    );
     runtime.exit(1);
     return;
   }
 
   if (normalizedOpts.resetScope && !VALID_RESET_SCOPES.has(normalizedOpts.resetScope)) {
-    runtime.error('Invalid --reset-scope. Use "config", "config+creds+sessions", or "full".');
+    runtime.error(
+      `Invalid --reset-scope. Use "config", "config+creds+sessions", or "full". Run ${formatCliCommand("openclaw onboard --reset --reset-scope config")} for a config-only reset.`,
+    );
     runtime.exit(1);
     return;
   }

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -183,7 +183,10 @@ describe("sandboxRecreateCommand", () => {
     it("should error if no filter is specified", async () => {
       await sandboxRecreateCommand({ all: false, browser: false, force: false }, runtime as never);
 
-      expectErrorContains(runtime, "Please specify --all, --session <key>, or --agent <id>");
+      expectErrorContains(
+        runtime,
+        "Choose the sandbox scope: --all, --session <key>, or --agent <id>",
+      );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(mocks.listSandboxContainers).not.toHaveBeenCalled();
       expect(mocks.listSandboxBrowsers).not.toHaveBeenCalled();
@@ -195,7 +198,7 @@ describe("sandboxRecreateCommand", () => {
         runtime as never,
       );
 
-      expectErrorContains(runtime, "Please specify only one of: --all, --session, --agent");
+      expectErrorContains(runtime, "Choose only one sandbox scope: --all, --session, or --agent.");
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(mocks.listSandboxContainers).not.toHaveBeenCalled();
       expect(mocks.listSandboxBrowsers).not.toHaveBeenCalled();
@@ -299,7 +302,9 @@ describe("sandboxRecreateCommand", () => {
     it("should show message when no containers match", async () => {
       await sandboxRecreateCommand({ all: true, browser: false, force: true }, runtime as never);
 
-      expect(runtime.log).toHaveBeenCalledWith("No sandbox runtimes found matching the criteria.");
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining("No sandbox runtimes found matching the criteria."),
+      );
       expect(mocks.removeSandboxContainer).not.toHaveBeenCalled();
     });
 

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -7,6 +7,8 @@ import {
   type SandboxBrowserInfo,
   type SandboxContainerInfo,
 } from "../agents/sandbox.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
   displayBrowsers,
@@ -74,7 +76,9 @@ export async function sandboxRecreateCommand(
   const filtered = await fetchAndFilterContainers(opts);
 
   if (filtered.containers.length + filtered.browsers.length === 0) {
-    runtime.log("No sandbox runtimes found matching the criteria.");
+    runtime.log(
+      `No sandbox runtimes found matching the criteria. Run ${formatCliCommand("openclaw sandbox list")} to inspect active runtimes.`,
+    );
     return;
   }
 
@@ -97,14 +101,16 @@ export async function sandboxRecreateCommand(
 
 function validateRecreateOptions(opts: SandboxRecreateOptions, runtime: RuntimeEnv): boolean {
   if (!opts.all && !opts.session && !opts.agent) {
-    runtime.error("Please specify --all, --session <key>, or --agent <id>");
+    runtime.error(
+      `Choose the sandbox scope: --all, --session <key>, or --agent <id>. Run ${formatCliCommand("openclaw sandbox list")} to inspect active runtimes first.`,
+    );
     runtime.exit(1);
     return false;
   }
 
   const exclusiveCount = [opts.all, opts.session, opts.agent].filter(Boolean).length;
   if (exclusiveCount > 1) {
-    runtime.error("Please specify only one of: --all, --session, --agent");
+    runtime.error("Choose only one sandbox scope: --all, --session, or --agent.");
     runtime.exit(1);
     return false;
   }
@@ -194,7 +200,9 @@ async function removeContainer(
     runtime.log(`✓ Removed ${containerName}`);
     return { success: true };
   } catch (err) {
-    runtime.error(`✗ Failed to remove ${containerName}: ${String(err)}`);
+    runtime.error(
+      `Failed to remove ${containerName}: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw sandbox list")} to inspect what remains.`,
+    );
     return { success: false };
   }
 }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -3,6 +3,7 @@ import { cancel, confirm, isCancel, multiselect } from "@clack/prompts";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isNixMode } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
 import { resolveHomeDir } from "../utils.js";
@@ -54,7 +55,9 @@ function buildScopeSelection(opts: UninstallOptions): {
 
 async function stopAndUninstallService(runtime: RuntimeEnv): Promise<boolean> {
   if (isNixMode) {
-    runtime.error("Nix mode detected; service uninstall is disabled.");
+    runtime.error(
+      `Nix mode detected; service uninstall is disabled. Manage the service through your Nix profile instead, then run ${formatCliCommand("openclaw status")} to verify.`,
+    );
     return false;
   }
   const service = resolveGatewayService();
@@ -62,7 +65,9 @@ async function stopAndUninstallService(runtime: RuntimeEnv): Promise<boolean> {
   try {
     loaded = await service.isLoaded({ env: process.env });
   } catch (err) {
-    runtime.error(`Gateway service check failed: ${String(err)}`);
+    runtime.error(
+      `Gateway service check failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} for service diagnostics.`,
+    );
     return false;
   }
   if (!loaded) {
@@ -72,13 +77,17 @@ async function stopAndUninstallService(runtime: RuntimeEnv): Promise<boolean> {
   try {
     await service.stop({ env: process.env, stdout: process.stdout });
   } catch (err) {
-    runtime.error(`Gateway stop failed: ${String(err)}`);
+    runtime.error(
+      `Gateway stop failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} before retrying uninstall.`,
+    );
   }
   try {
     await service.uninstall({ env: process.env, stdout: process.stdout });
     return true;
   } catch (err) {
-    runtime.error(`Gateway uninstall failed: ${String(err)}`);
+    runtime.error(
+      `Gateway uninstall failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep")} for the service state.`,
+    );
     return false;
   }
 }
@@ -101,14 +110,18 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
   const { scopes, hadExplicit } = buildScopeSelection(opts);
   const interactive = !opts.nonInteractive;
   if (!interactive && !opts.yes) {
-    runtime.error("Non-interactive mode requires --yes.");
+    runtime.error(
+      `Non-interactive uninstall requires --yes. Preview first with ${formatCliCommand("openclaw uninstall --dry-run --all")}.`,
+    );
     runtime.exit(1);
     return;
   }
 
   if (!hadExplicit) {
     if (!interactive) {
-      runtime.error("Non-interactive mode requires explicit scopes (use --all).");
+      runtime.error(
+        `Non-interactive uninstall requires explicit scopes. Use --all, or choose scopes such as --service --state.`,
+      );
       runtime.exit(1);
       return;
     }


### PR DESCRIPTION
## Summary

Port upstream openclaw/openclaw improvements through commit f5200eb466 (14 new upstream commits since last sync at c008c54f9e):

- cli/channels capabilities: Add actionable run-hint to --account/--target/unknown-channel error messages
- cli/configure: Add wizard fallback hint to --section validation error
- cli/onboard: Add interactive fallback hints to --secret-input-mode and --reset-scope errors
- cli/sandbox: Add sandbox list hint to no-match and missing-scope errors; use formatErrorMessage
- cli/uninstall: Improve Nix mode, gateway service, and non-interactive error messages; use formatErrorMessage
- cli/plugins: Add install hint to "No plugins found" message
- cli/plugins-install: Improve --link/--pin/--marketplace/--force error messages with actionable examples
- cli/secrets: Improve plan file, reload, and audit error messages with formatErrorMessage and next-step guidance
- test/cli: Tighten sessionFile assertion to check string type and length

All changed messages use formatCliCommand() which automatically substitutes gemmaclaw for openclaw in displayed output.

## Regression gate

- Build clean
- gemmaclaw --version, setup --help, backup --help, backup restore --help all pass
- 2077 tests pass across CLI, commands, and agents test suites
- Live Docker smoke deferred: active gemma4:31b benchmark on Ollama triggered safety guard. No code changes affect setup/Docker/sandbox smoke paths.