### PR TITLE
feat(benchmark): activity-based timeout + per-task validation gate

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -14,6 +14,7 @@ import {
   resolveFakeGogBinDir,
   readOpenAICodexAuthProfilesFromStore,
   resolveOpenAICodexAuthProfileStoreCandidates,
+  resolveTimeoutBudgets,
   writeTaskArtifact,
   writeBenchmarkWorkspaceFiles,
   type AgentBenchmarkConfig,
@@ -158,6 +159,53 @@ describe("parseSessionEntry", () => {
   });
 });
 
+describe("resolveTimeoutBudgets", () => {
+  const base = {
+    gatewayUrl: "http://localhost:3001",
+    backend: "ollama" as const,
+    ollamaUrl: "http://127.0.0.1:11434",
+    llamaCppUrl: "http://127.0.0.1:8080",
+    model: "gemma4:31b",
+    quant: "Q4_K_M",
+    thinkingLevel: "high",
+    taskTimeoutSeconds: 0,
+    idleTimeoutSeconds: 30,
+  };
+
+  it("defaults activity timeout to 600s and hard cap to 28800s when nothing is set", () => {
+    const { hardCapMs, noActivityMs } = resolveTimeoutBudgets(base);
+    expect(noActivityMs).toBe(600_000);
+    expect(hardCapMs).toBe(28_800_000);
+  });
+
+  it("treats legacy taskTimeoutSeconds as a floor for the hard cap", () => {
+    const { hardCapMs } = resolveTimeoutBudgets({ ...base, taskTimeoutSeconds: 3600 });
+    expect(hardCapMs).toBe(28_800_000);
+    const { hardCapMs: bigCap } = resolveTimeoutBudgets({ ...base, taskTimeoutSeconds: 50_000 });
+    expect(bigCap).toBe(50_000_000);
+  });
+
+  it("respects explicit hardCapSeconds and noActivityTimeoutSeconds", () => {
+    const { hardCapMs, noActivityMs } = resolveTimeoutBudgets({
+      ...base,
+      hardCapSeconds: 7200,
+      noActivityTimeoutSeconds: 300,
+    });
+    expect(hardCapMs).toBe(7_200_000);
+    expect(noActivityMs).toBe(300_000);
+  });
+
+  it("falls back to defaults when explicit timeouts are <=0", () => {
+    const { hardCapMs, noActivityMs } = resolveTimeoutBudgets({
+      ...base,
+      hardCapSeconds: 0,
+      noActivityTimeoutSeconds: -1,
+    });
+    expect(noActivityMs).toBe(600_000);
+    expect(hardCapMs).toBe(28_800_000);
+  });
+});
+
 describe("benchmark backend resolution", () => {
   it("maps agent benchmark backends to OpenClaw provider prefixes", () => {
     expect(resolveAgentProviderPrefix("ollama")).toBe("ollama");
@@ -296,6 +344,16 @@ describe("per-task benchmark artifacts", () => {
       { task: { id: "email_summarize" }, completionStatus: "completed" },
     ]);
     expect(loadTaskArtifacts(runDir, "wrong-hash")).toEqual([]);
+  });
+
+  it("includes activity-timeout fields in the config hash so different gates produce different hashes", () => {
+    const baseHash = computeConfigHash(config);
+    const withActivity = computeConfigHash({ ...config, noActivityTimeoutSeconds: 600 });
+    const withHardCap = computeConfigHash({ ...config, hardCapSeconds: 28_800 });
+    const withValidationOff = computeConfigHash({ ...config, validatePerTask: false });
+    expect(baseHash).not.toBe(withActivity);
+    expect(baseHash).not.toBe(withHardCap);
+    expect(baseHash).not.toBe(withValidationOff);
   });
 
   it("assembles aggregate outputs from saved per-task artifacts", () => {

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -31,6 +31,11 @@ import {
   evaluateDeterministicAgentTaskConversation,
   type AgentBenchmarkTask,
 } from "./agent-tasks.js";
+import {
+  summarizeValidation,
+  validateTaskArtifact,
+  type ValidationResult,
+} from "./agent-validator.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -53,10 +58,43 @@ export type AgentBenchmarkConfig = {
   quant?: string;
   /** Thinking/reasoning level (off, low, medium, high, xhigh). */
   thinkingLevel?: string;
-  /** Maximum seconds to wait for a single task to complete. 0 = no limit. */
+  /**
+   * Maximum seconds to wait for a single task to complete. 0 = no limit.
+   *
+   * Historically this was the only timeout; in the new harness it acts as a
+   * BACKWARD-COMPAT alias for {@link hardCapSeconds} when the latter is not
+   * set. Activity-based timeout ({@link noActivityTimeoutSeconds}) is the
+   * normal "task is stuck" signal; the hard cap exists only as a runaway
+   * guard for catastrophic loops.
+   */
   taskTimeoutSeconds: number;
   /** Seconds of idle (no new JSONL lines) before considering task done. */
   idleTimeoutSeconds: number;
+  /**
+   * Seconds with no useful agent activity before declaring the task stuck.
+   * "Useful activity" = stdout/stderr chunk, new session JSONL line, new
+   * trajectory JSONL line, or assistant/tool turn parsed from JSONL. Defaults
+   * to 600 (10 minutes) when not set, per Frank's directive that timeout
+   * should mean "no progress for 10 minutes" rather than a hard wall-clock
+   * cap.
+   */
+  noActivityTimeoutSeconds?: number;
+  /**
+   * Hard wall-clock runaway cap, in seconds. Defaults to
+   * `max(taskTimeoutSeconds, 28800)` when not set, so legacy callers that
+   * pass `taskTimeoutSeconds: 3600` keep their existing semantics while new
+   * callers can let benchmarks run as long as they remain active. Always
+   * acts as a hard ceiling regardless of activity.
+   */
+  hardCapSeconds?: number;
+  /** When true, run the validation gate after each task. Defaults to true. */
+  validatePerTask?: boolean;
+  /**
+   * When true and per-task validation produces a block-severity issue, the
+   * runner reruns the task once before recording a final failure. Defaults
+   * to true.
+   */
+  validationRerunOnFail?: boolean;
   /** Path to mock gog seed script. */
   seedScript?: string;
   /** Path to gemmaclaw home for isolated runs. */
@@ -106,6 +144,14 @@ export type AgentTaskResult = {
   completionStatus: "completed" | "timeout" | "error";
   /** Error message if any. */
   error?: string;
+  /**
+   * Validation gate result for this task, when {@link AgentBenchmarkConfig.validatePerTask}
+   * is enabled. Persisted in the artifact so downstream evaluators and the
+   * site generator can surface validation issues without rerunning the gate.
+   */
+  validation?: ValidationResult;
+  /** Number of times this task was rerun by the validation gate (0 = first try). */
+  validationRerunCount?: number;
 };
 
 export type RunMetadata = {
@@ -264,6 +310,10 @@ export function computeConfigHash(config: AgentBenchmarkConfig): string {
     llamaCppUrl: config.llamaCppUrl,
     mock: config.mock ?? false,
     model: config.model,
+    noActivityTimeoutSeconds: config.noActivityTimeoutSeconds ?? null,
+    hardCapSeconds: config.hardCapSeconds ?? null,
+    validatePerTask: config.validatePerTask !== false,
+    validationRerunOnFail: config.validationRerunOnFail !== false,
     ollamaUrl: config.ollamaUrl,
     quant: config.quant,
     seedScript: config.seedScript,
@@ -914,6 +964,40 @@ function readTrajectoryError(trajectoryPath: string): string | undefined {
  * Uses `gemmaclaw agent --local` to send the message, then polls the session
  * JSONL for completion (idle detection). Returns the full conversation.
  */
+/**
+ * Resolve effective timeouts for a task. Returns hard cap (runaway guard) and
+ * the activity-based "no useful progress" timeout in milliseconds.
+ *
+ * Defaults:
+ *   - noActivityTimeoutSeconds: 600 (10 min). Reset by stdout/stderr/JSONL/
+ *     trajectory activity. Triggering this returns completionStatus=timeout
+ *     with a no-activity reason.
+ *   - hardCapSeconds: max(taskTimeoutSeconds, 28800). Acts only as a runaway
+ *     ceiling; activity-based timeout is the normal "task is stuck" signal.
+ *
+ * `taskTimeoutSeconds` remains a backward-compat alias: when callers pass it
+ * but no `hardCapSeconds`, we treat it as the hard cap.
+ */
+export function resolveTimeoutBudgets(config: AgentBenchmarkConfig): {
+  hardCapMs: number;
+  noActivityMs: number;
+} {
+  const noActivitySec =
+    typeof config.noActivityTimeoutSeconds === "number" && config.noActivityTimeoutSeconds > 0
+      ? config.noActivityTimeoutSeconds
+      : 600;
+  const hardCapInputSec =
+    typeof config.hardCapSeconds === "number" && config.hardCapSeconds > 0
+      ? config.hardCapSeconds
+      : config.taskTimeoutSeconds > 0
+        ? Math.max(config.taskTimeoutSeconds, 28_800)
+        : 28_800;
+  return {
+    hardCapMs: hardCapInputSec * 1000,
+    noActivityMs: noActivitySec * 1000,
+  };
+}
+
 export async function dispatchTask(
   task: AgentBenchmarkTask,
   config: AgentBenchmarkConfig,
@@ -926,10 +1010,10 @@ export async function dispatchTask(
   error?: string;
   sessionJsonlPath?: string;
   trajectoryJsonlPath?: string;
+  fakeGogLogPath?: string;
 }> {
   const startMs = Date.now();
-  const timeoutMs =
-    config.taskTimeoutSeconds > 0 ? config.taskTimeoutSeconds * 1000 : Number.MAX_SAFE_INTEGER;
+  const { hardCapMs, noActivityMs } = resolveTimeoutBudgets(config);
   const idleMs = config.idleTimeoutSeconds * 1000;
 
   // Create isolated benchmark home for this task
@@ -952,8 +1036,12 @@ export async function dispatchTask(
   if (config.thinkingLevel) {
     args.push("--thinking", config.thinkingLevel);
   }
-  if (config.taskTimeoutSeconds > 0) {
-    args.push("--timeout", String(config.taskTimeoutSeconds));
+  // Pass the hard wall-clock cap to the embedded CLI so it has its own ceiling
+  // even if the harness watchdog dies. Activity-based timeout is enforced in
+  // the polling loop below using process I/O + JSONL/trajectory activity.
+  const hardCapSec = Math.round(hardCapMs / 1000);
+  if (hardCapSec > 0) {
+    args.push("--timeout", String(hardCapSec));
   }
 
   log(`  Dispatching: ${gemmaclawArgs.join(" ")} agent --local --session-id ${sessionId}`);
@@ -977,7 +1065,8 @@ export async function dispatchTask(
     writeBenchmarkWorkspaceFiles(workspaceDir);
     const gogStateDir = path.join(benchHome, ".config/gogcli/state");
     const fakeGogBinDir = resolveFakeGogBinDir();
-    const fakeGogLog = path.join(benchHome, "fake-gog.log");
+    const fakeGogLogPath = path.join(benchHome, "fake-gog.log");
+    const fakeGogLog = fakeGogLogPath;
 
     // Build config using the same logic as gemmaclaw setup
     const isLlamaCpp = config.backend === "llama-cpp";
@@ -1133,6 +1222,11 @@ export async function dispatchTask(
 
     let lastLineCount = 0;
     let lastChangeMs = Date.now();
+    let lastTrajectoryLineCount = 0;
+    // Activity timestamp: any of stdout/stderr/JSONL/trajectory progress
+    // resets it. The activity-based watchdog uses this as the only signal of
+    // "agent is making progress"; it is independent of wall-clock elapsed.
+    let lastActivityMs = Date.now();
     const conversation: ConversationTurn[] = [];
 
     const parseJsonl = () => {
@@ -1145,6 +1239,7 @@ export async function dispatchTask(
           lastLineCount = lines.length;
           lastChangeMs = Date.now();
           lastIoMs = Date.now();
+          lastActivityMs = Date.now();
           conversation.length = 0;
           for (const line of lines) {
             try {
@@ -1160,6 +1255,33 @@ export async function dispatchTask(
         // File might be mid-write
       }
     };
+
+    const checkTrajectoryActivity = () => {
+      if (!fs.existsSync(trajectoryPath)) {
+        return;
+      }
+      try {
+        const lines = fs.readFileSync(trajectoryPath, "utf-8").split("\n").filter(Boolean);
+        if (lines.length > lastTrajectoryLineCount) {
+          lastTrajectoryLineCount = lines.length;
+          lastActivityMs = Date.now();
+        }
+      } catch {
+        // mid-write; ignore
+      }
+    };
+
+    // Make stdout/stderr handlers also reset the activity clock. The runner
+    // already pushed handlers earlier that update lastIoMs; here we wire the
+    // activity clock alongside them by re-attaching listeners. The original
+    // listeners stay in place (Node multi-listener) so existing chunk capture
+    // behavior is unchanged.
+    child.stdout?.on("data", () => {
+      lastActivityMs = Date.now();
+    });
+    child.stderr?.on("data", () => {
+      lastActivityMs = Date.now();
+    });
 
     const killChild = async (reason: string): Promise<void> => {
       if (childExitCode !== null) {
@@ -1179,29 +1301,51 @@ export async function dispatchTask(
       }
     };
 
-    // Idle threshold while child is still running: tolerate model thinking
-    // (idle JSONL during long generation) by extending the idle threshold.
-    // Only declare task done via idle once we have an assistant response.
-    const stuckThresholdMs = Math.max(idleMs * 4, 120_000);
+    // Idle threshold for "completed via idle" once we already have an
+    // assistant turn: keep the legacy short threshold so a model that finishes
+    // streaming and quietly waits is treated as done. Activity-based timeout
+    // (below) handles the "stuck before any assistant turn" case.
+    const idleCompletionMs = Math.max(idleMs * 4, 120_000);
 
     // Polling loop concurrent with child execution
     while (true) {
       const elapsed = Date.now() - startMs;
 
       parseJsonl();
+      checkTrajectoryActivity();
 
-      // Hard task timeout
-      if (elapsed > timeoutMs) {
+      // (1) Activity-based timeout: kill if no useful activity for
+      // noActivityMs. Resets on stdout/stderr/JSONL/trajectory.
+      const sinceActivity = Date.now() - lastActivityMs;
+      if (sinceActivity > noActivityMs) {
         await killChild(
-          `hard task-timeout ${Math.round(elapsed / 1000)}s > ${Math.round(timeoutMs / 1000)}s`,
+          `no-activity ${Math.round(sinceActivity / 1000)}s > ${Math.round(noActivityMs / 1000)}s`,
         );
         return {
           conversation,
           elapsedMs: Date.now() - startMs,
           completionStatus: "timeout",
-          error: `task-timeout (${Math.round(timeoutMs / 1000)}s)`,
+          error: `no-activity-timeout (${Math.round(noActivityMs / 1000)}s of inactivity)`,
           sessionJsonlPath: jsonlPath,
           trajectoryJsonlPath: trajectoryPath,
+          fakeGogLogPath,
+        };
+      }
+
+      // (2) Hard wall-clock cap (runaway guard). Only fires when an actively
+      // chatty agent runs past the explicit ceiling.
+      if (elapsed > hardCapMs) {
+        await killChild(
+          `hard-cap ${Math.round(elapsed / 1000)}s > ${Math.round(hardCapMs / 1000)}s`,
+        );
+        return {
+          conversation,
+          elapsedMs: Date.now() - startMs,
+          completionStatus: "timeout",
+          error: `hard-cap (${Math.round(hardCapMs / 1000)}s wall-clock ceiling)`,
+          sessionJsonlPath: jsonlPath,
+          trajectoryJsonlPath: trajectoryPath,
+          fakeGogLogPath,
         };
       }
 
@@ -1210,6 +1354,7 @@ export async function dispatchTask(
         // Give filesystem a moment to flush in case JSONL just got written
         await new Promise((r) => setTimeout(r, 500));
         parseJsonl();
+        checkTrajectoryActivity();
         if (childError) {
           const errMsg = (childError as Error).message;
           return {
@@ -1219,6 +1364,7 @@ export async function dispatchTask(
             error: errMsg,
             sessionJsonlPath: jsonlPath,
             trajectoryJsonlPath: trajectoryPath,
+            fakeGogLogPath,
           };
         }
         if (childExitCode !== 0) {
@@ -1231,6 +1377,7 @@ export async function dispatchTask(
             error: `CLI exited ${childExitCode}: ${stderr.slice(0, 200) || stdout.slice(0, 200)}`,
             sessionJsonlPath: jsonlPath,
             trajectoryJsonlPath: trajectoryPath,
+            fakeGogLogPath,
           };
         }
         const trajectoryError = readTrajectoryError(trajectoryPath);
@@ -1242,6 +1389,7 @@ export async function dispatchTask(
             error: `OpenClaw session error: ${trajectoryError.slice(0, 300)}`,
             sessionJsonlPath: jsonlPath,
             trajectoryJsonlPath: trajectoryPath,
+            fakeGogLogPath,
           };
         }
         if (conversation.length === 0) {
@@ -1252,33 +1400,28 @@ export async function dispatchTask(
             error: "empty conversation transcript (no session JSONL turns parsed)",
             sessionJsonlPath: jsonlPath,
             trajectoryJsonlPath: trajectoryPath,
+            fakeGogLogPath,
           };
         }
         log(`  CLI completed successfully`);
-        if (conversation.length === 0) {
-          const stdout = Buffer.concat(stdoutChunks).toString();
-          const assistantResponse = extractAssistantResponseFromStdout(stdout);
-          if (assistantResponse) {
-            conversation.push(
-              { role: "user", content: task.prompt },
-              { role: "assistant", content: assistantResponse },
-            );
-          }
-        }
         return {
           conversation,
           elapsedMs: Date.now() - startMs,
           completionStatus: "completed",
           sessionJsonlPath: jsonlPath,
           trajectoryJsonlPath: trajectoryPath,
+          fakeGogLogPath,
         };
       }
 
-      // Idle detection: kill if JSONL AND stdio both quiet for stuckThreshold
+      // Idle-completion detection: once we already have an assistant turn AND
+      // the JSONL/stdio have both been quiet for idleCompletionMs, the agent
+      // is done streaming. This is a separate signal from the activity-based
+      // timeout above (which fires when there is NO assistant turn yet).
       const idleSinceWrite = Date.now() - lastChangeMs;
       const idleSinceIo = Date.now() - lastIoMs;
       const realIdle = Math.min(idleSinceWrite, idleSinceIo);
-      if (lastLineCount > 0 && realIdle > stuckThresholdMs) {
+      if (lastLineCount > 0 && realIdle > idleCompletionMs) {
         const hasAssistant = conversation.some((t) => t.role === "assistant");
         if (hasAssistant) {
           await killChild(`task done via idle (${Math.round(realIdle / 1000)}s no JSONL/stdio)`);
@@ -1289,18 +1432,7 @@ export async function dispatchTask(
             completionStatus: "completed",
             sessionJsonlPath: jsonlPath,
             trajectoryJsonlPath: trajectoryPath,
-          };
-        }
-        // No assistant response yet, but stuck. Use 1.5x threshold to be safe.
-        if (realIdle > stuckThresholdMs * 1.5) {
-          await killChild(`stuck without assistant turn (${Math.round(realIdle / 1000)}s idle)`);
-          return {
-            conversation,
-            elapsedMs: Date.now() - startMs,
-            completionStatus: "timeout",
-            error: `idle-stuck-no-progress`,
-            sessionJsonlPath: jsonlPath,
-            trajectoryJsonlPath: trajectoryPath,
+            fakeGogLogPath,
           };
         }
       }
@@ -1579,6 +1711,73 @@ export async function runAgentBenchmark(
     saveAggregate();
   }
 
+  // Per-task validation gate. Defaults true so old callers (which never set
+  // these flags) get the new safety net automatically. Pass
+  // `validatePerTask: false` to opt out for synthetic / unit-test runs.
+  const validatePerTask = config.validatePerTask !== false;
+  const validationRerunOnFail = config.validationRerunOnFail !== false;
+
+  /**
+   * Dispatch one attempt of a task. Returns the populated AgentTaskResult plus
+   * the artifact-side paths needed for validation. Used by the run loop and
+   * by the validation rerun helper.
+   */
+  const runOneTaskAttempt = async (
+    task: AgentBenchmarkTask,
+  ): Promise<{
+    taskResult: AgentTaskResult;
+    sessionJsonlPath?: string;
+    trajectoryJsonlPath?: string;
+    fakeGogLogPath?: string;
+  }> => {
+    const sessionId = `bench-${task.id}-${Date.now()}`;
+    seedMockGog(config.seedScript, seedStateDir);
+    let conversation: ConversationTurn[];
+    let elapsedMs: number;
+    let completionStatus: "completed" | "timeout" | "error";
+    let error: string | undefined;
+    let sessionJsonlPath: string | undefined;
+    let trajectoryJsonlPath: string | undefined;
+    let fakeGogLogPath: string | undefined;
+    if (config.mock) {
+      const finalResponse = task.mock?.finalResponse ?? `[Mock] Task completed: ${task.name}`;
+      conversation = [
+        { role: "user", content: task.prompt },
+        { role: "assistant", content: `[Mock] Processing task: ${task.name}` },
+        { role: "tool_call", content: "{}", toolName: "gog", toolArgs: {} },
+        { role: "tool_result", content: "[Mock] Tool result" },
+        { role: "assistant", content: finalResponse },
+      ];
+      elapsedMs = 50;
+      completionStatus = "completed";
+    } else {
+      const dispatchResult = await dispatchTask(task, config, sessionId, log);
+      conversation = dispatchResult.conversation;
+      elapsedMs = dispatchResult.elapsedMs;
+      completionStatus = dispatchResult.completionStatus;
+      error = dispatchResult.error;
+      sessionJsonlPath = dispatchResult.sessionJsonlPath;
+      trajectoryJsonlPath = dispatchResult.trajectoryJsonlPath;
+      fakeGogLogPath = dispatchResult.fakeGogLogPath;
+    }
+    const toolCalls = conversation.filter((t) => t.role === "tool_call");
+    const toolCallCount = toolCalls.length;
+    const toolsUsed = [...new Set(toolCalls.map((t) => t.toolName).filter(Boolean))] as string[];
+    log(
+      `  ${completionStatus.toUpperCase()} | ${toolCallCount} tool calls | ${(elapsedMs / 1000).toFixed(1)}s${error ? ` | ${error}` : ""}`,
+    );
+    const taskResult: AgentTaskResult = {
+      task,
+      conversation,
+      elapsedMs,
+      toolCallCount,
+      toolsUsed,
+      completionStatus,
+      error,
+    };
+    return { taskResult, sessionJsonlPath, trajectoryJsonlPath, fakeGogLogPath };
+  };
+
   for (let i = 0; i < filteredTasks.length; i++) {
     const task = filteredTasks[i];
     const taskNum = `[${i + 1}/${filteredTasks.length}]`;
@@ -1600,64 +1799,60 @@ export async function runAgentBenchmark(
 
     log(`${taskNum} ${task.name} (${task.difficulty})`);
 
-    const sessionId = `bench-${task.id}-${Date.now()}`;
+    let attempt = await runOneTaskAttempt(task);
+    let validationRerunCount = 0;
 
-    // Re-seed mock gog state before each task (clean slate)
-    seedMockGog(config.seedScript, seedStateDir);
+    // Persist first-attempt artifacts so validation reads from disk.
+    writeTaskArtifact(runDir, runId, configHash, attempt.taskResult);
+    copyIfExists(attempt.sessionJsonlPath, taskSessionCopyPath(runDir, task.id));
+    copyIfExists(attempt.trajectoryJsonlPath, taskTrajectoryCopyPath(runDir, task.id));
 
-    let conversation: ConversationTurn[];
-    let elapsedMs: number;
-    let completionStatus: "completed" | "timeout" | "error";
-    let error: string | undefined;
-    let sessionJsonlPath: string | undefined;
-    let trajectoryJsonlPath: string | undefined;
+    if (validatePerTask) {
+      let validation = validateTaskArtifact({
+        runDir,
+        task,
+        result: attempt.taskResult,
+        fakeGogLogPath: attempt.fakeGogLogPath,
+      });
+      log(`  validation: ${summarizeValidation(validation)}`);
 
-    if (config.mock) {
-      // Mock mode: simulate a successful agent run without dispatching
-      const finalResponse = task.mock?.finalResponse ?? `[Mock] Task completed: ${task.name}`;
-      conversation = [
-        { role: "user", content: task.prompt },
-        { role: "assistant", content: `[Mock] Processing task: ${task.name}` },
-        { role: "tool_call", content: "{}", toolName: "gog", toolArgs: {} },
-        { role: "tool_result", content: "[Mock] Tool result" },
-        { role: "assistant", content: finalResponse },
-      ];
-      elapsedMs = 50;
-      completionStatus = "completed";
-    } else {
-      // Real mode: dispatch to gateway and collect conversation
-      const result = await dispatchTask(task, config, sessionId, log);
-      conversation = result.conversation;
-      elapsedMs = result.elapsedMs;
-      completionStatus = result.completionStatus;
-      error = result.error;
-      sessionJsonlPath = result.sessionJsonlPath;
-      trajectoryJsonlPath = result.trajectoryJsonlPath;
+      if (!validation.valid && validationRerunOnFail) {
+        log(`  Validation BLOCK detected; rerunning task once before recording.`);
+        // Wipe the old per-task artifact dir before retry so the validator on
+        // the next attempt does not see stale session/trajectory copies.
+        const taskDir = path.join(runDir, "tasks", task.id);
+        if (fs.existsSync(taskDir)) {
+          fs.rmSync(taskDir, { recursive: true, force: true });
+        }
+        attempt = await runOneTaskAttempt(task);
+        validationRerunCount = 1;
+        writeTaskArtifact(runDir, runId, configHash, attempt.taskResult);
+        copyIfExists(attempt.sessionJsonlPath, taskSessionCopyPath(runDir, task.id));
+        copyIfExists(attempt.trajectoryJsonlPath, taskTrajectoryCopyPath(runDir, task.id));
+        validation = validateTaskArtifact({
+          runDir,
+          task,
+          result: attempt.taskResult,
+          fakeGogLogPath: attempt.fakeGogLogPath,
+        });
+        log(`  validation (rerun): ${summarizeValidation(validation)}`);
+      }
+
+      // Persist validation result on the task artifact itself so consumers
+      // (site generator, evaluator) can show the gate decision without
+      // re-running the validator.
+      attempt.taskResult.validation = validation;
+      attempt.taskResult.validationRerunCount = validationRerunCount;
+      // If still invalid after the rerun budget, force completionStatus=error
+      // so downstream evaluators don't accidentally score a contaminated run.
+      if (!validation.valid && attempt.taskResult.completionStatus === "completed") {
+        attempt.taskResult.completionStatus = "error";
+        attempt.taskResult.error = `validation_failed: ${summarizeValidation(validation)}`;
+      }
+      writeTaskArtifact(runDir, runId, configHash, attempt.taskResult);
     }
 
-    // Extract tool call stats
-    const toolCalls = conversation.filter((t) => t.role === "tool_call");
-    const toolCallCount = toolCalls.length;
-    const toolsUsed = [...new Set(toolCalls.map((t) => t.toolName).filter(Boolean))] as string[];
-
-    log(
-      `  ${completionStatus.toUpperCase()} | ${toolCallCount} tool calls | ${(elapsedMs / 1000).toFixed(1)}s${error ? ` | ${error}` : ""}`,
-    );
-
-    const taskResult: AgentTaskResult = {
-      task,
-      conversation,
-      elapsedMs,
-      toolCallCount,
-      toolsUsed,
-      completionStatus,
-      error,
-    };
-    resultsById.set(task.id, taskResult);
-
-    writeTaskArtifact(runDir, runId, configHash, taskResult);
-    copyIfExists(sessionJsonlPath, taskSessionCopyPath(runDir, task.id));
-    copyIfExists(trajectoryJsonlPath, taskTrajectoryCopyPath(runDir, task.id));
+    resultsById.set(task.id, attempt.taskResult);
     saveAggregate();
     writeManifest();
   }

--- a/src/gemmaclaw/benchmark/agent-types.ts
+++ b/src/gemmaclaw/benchmark/agent-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Leaf type definitions shared by agent-runner.ts and agent-validator.ts.
+ * Lives in its own module so the runner can depend on the validator and the
+ * validator can depend on shared types without forming an import cycle.
+ */
+
+import type { AgentBenchmarkTask } from "./agent-tasks.js";
+
+export type ConversationTurn = {
+  role: "user" | "assistant" | "thinking" | "tool_call" | "tool_result" | "system";
+  content: string;
+  /** Tool name if role is tool_call. */
+  toolName?: string;
+  /** Tool arguments if role is tool_call. */
+  toolArgs?: Record<string, unknown>;
+  /** Timestamp of this turn. */
+  timestamp?: string;
+};
+
+/**
+ * Subset of an AgentTaskResult that the validator inspects. Defined here so
+ * agent-validator.ts does not need to import the full AgentTaskResult (which
+ * itself references ValidationResult and would otherwise form a cycle).
+ */
+export type ValidatableTaskResult = {
+  task: AgentBenchmarkTask;
+  conversation: ConversationTurn[];
+  completionStatus: "completed" | "timeout" | "error";
+  toolCallCount?: number;
+  toolsUsed?: string[];
+  elapsedMs?: number;
+  error?: string;
+};

--- a/src/gemmaclaw/benchmark/agent-validator.test.ts
+++ b/src/gemmaclaw/benchmark/agent-validator.test.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { AgentTaskResult } from "./agent-runner.js";
+import type { AgentBenchmarkTask } from "./agent-tasks.js";
+import {
+  HOST_OAUTH_MARKERS,
+  HOST_PATH_MARKERS,
+  REAL_ACCOUNT_MARKERS,
+  summarizeValidation,
+  validateTaskArtifact,
+} from "./agent-validator.js";
+
+const baseTask: AgentBenchmarkTask = {
+  id: "validator_email_smoke",
+  name: "Validator Email Smoke",
+  description: "Test fixture",
+  category: "email",
+  difficulty: "medium",
+  prompt: "Check inbox",
+  grading: { type: "conversation_check", criteria: ["reads inbox"], maxScore: 10 },
+};
+
+function freshRunDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "gemmaclaw-validator-"));
+}
+
+function writeTaskArtifacts(
+  runDir: string,
+  taskId: string,
+  opts: {
+    transcript?: string;
+    sessionJsonl?: string;
+    trajectoryJsonl?: string;
+  } = {},
+): void {
+  const taskDir = path.join(runDir, "tasks", taskId);
+  fs.mkdirSync(taskDir, { recursive: true });
+  if (opts.transcript !== undefined) {
+    fs.writeFileSync(path.join(taskDir, "transcript.txt"), opts.transcript);
+  }
+  if (opts.sessionJsonl !== undefined) {
+    fs.writeFileSync(path.join(taskDir, "session.jsonl"), opts.sessionJsonl);
+  }
+  if (opts.trajectoryJsonl !== undefined) {
+    fs.writeFileSync(path.join(taskDir, "trajectory.jsonl"), opts.trajectoryJsonl);
+  }
+}
+
+const okConversation: AgentTaskResult["conversation"] = [
+  { role: "user", content: "Check inbox" },
+  { role: "assistant", content: "I will check it." },
+  { role: "tool_call", toolName: "gog", toolArgs: { cmd: "gmail list" }, content: "{}" },
+  { role: "tool_result", content: "3 emails from alex@acme-corp.dev" },
+  { role: "assistant", content: "You have 3 emails." },
+];
+
+function makeResult(overrides: Partial<AgentTaskResult> = {}): AgentTaskResult {
+  return {
+    task: baseTask,
+    conversation: okConversation,
+    elapsedMs: 1234,
+    toolCallCount: 1,
+    toolsUsed: ["gog"],
+    completionStatus: "completed",
+    ...overrides,
+  };
+}
+
+describe("validateTaskArtifact", () => {
+  it("passes a clean fake-gog email task", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      transcript: "[user] Check inbox\n[assistant] You have 3 emails from alex@acme-corp.dev",
+      sessionJsonl:
+        '{"timestamp":"t","message":{"role":"assistant","content":"You have 3 emails."}}\n',
+      trajectoryJsonl: '{"type":"session.ended","status":"ok"}\n',
+    });
+    const fakeGogLogPath = path.join(runDir, "fake-gog.log");
+    fs.writeFileSync(fakeGogLogPath, "gog gmail list -> 3 mock messages\n");
+
+    const validation = validateTaskArtifact({
+      runDir,
+      task: baseTask,
+      result: makeResult(),
+      fakeGogLogPath,
+    });
+
+    expect(validation.valid).toBe(true);
+    expect(validation.issues).toEqual([]);
+  });
+
+  it("blocks when transcript is empty", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, { transcript: "", sessionJsonl: "" });
+    const validation = validateTaskArtifact({
+      runDir,
+      task: baseTask,
+      result: makeResult({ conversation: [], completionStatus: "error" }),
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.issues.map((i) => i.kind)).toContain("transcript_empty");
+    expect(summarizeValidation(validation)).toContain("block:transcript_empty");
+  });
+
+  it("blocks when completed but no assistant turn is present", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      transcript: "[user] Check inbox\n[tool_result] something",
+    });
+    const result = makeResult({
+      conversation: [
+        { role: "user", content: "Check inbox" },
+        { role: "tool_result", content: "something" },
+      ],
+    });
+    const validation = validateTaskArtifact({ runDir, task: baseTask, result });
+    expect(validation.valid).toBe(false);
+    expect(validation.issues.map((i) => i.kind)).toContain("no_assistant_turn");
+  });
+
+  it("blocks when transcript contains a real account marker", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      transcript: "[assistant] Latest mail is from lifrank1994@gmail.com about the genie deploy.",
+    });
+    const validation = validateTaskArtifact({ runDir, task: baseTask, result: makeResult() });
+    expect(validation.valid).toBe(false);
+    expect(validation.issues.map((i) => i.kind)).toContain("real_account_marker");
+    const evidence = validation.issues.find((i) => i.kind === "real_account_marker")?.evidence;
+    expect(evidence).toContain("lifrank1994@gmail.com");
+  });
+
+  it("blocks when session jsonl contains an OAuth-shaped token", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      sessionJsonl:
+        '{"timestamp":"t","message":{"role":"assistant","content":"got token ya29.A0ARrdaM_ABCDEF1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"}}\n',
+    });
+    const validation = validateTaskArtifact({ runDir, task: baseTask, result: makeResult() });
+    expect(validation.valid).toBe(false);
+    expect(validation.issues.map((i) => i.kind)).toContain("host_oauth_marker");
+  });
+
+  it("blocks when trajectory references the real user state dir", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      trajectoryJsonl:
+        '{"type":"tool.exec","cmd":"ls /home/frank/.config/gogcli/state","result":"..."}\n',
+    });
+    const validation = validateTaskArtifact({ runDir, task: baseTask, result: makeResult() });
+    expect(validation.valid).toBe(false);
+    expect(validation.issues.map((i) => i.kind)).toContain("host_path_leak");
+  });
+
+  it("blocks when trajectory ends with a session.ended error", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      trajectoryJsonl:
+        '{"type":"session.ended","status":"error","error":{"message":"LLM idle timeout"}}\n',
+    });
+    const validation = validateTaskArtifact({ runDir, task: baseTask, result: makeResult() });
+    expect(validation.valid).toBe(false);
+    expect(validation.issues.map((i) => i.kind)).toContain("trajectory_error");
+  });
+
+  it("warns (not blocks) when fake-gog log is missing for a gog-touching task", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      transcript: "[user] Check inbox\n[assistant] You have 3 emails.",
+    });
+    const validation = validateTaskArtifact({
+      runDir,
+      task: baseTask,
+      result: makeResult(),
+      fakeGogLogPath: path.join(runDir, "fake-gog.log"), // does not exist
+    });
+    expect(validation.valid).toBe(true);
+    expect(validation.issues.map((i) => i.kind)).toContain("fake_gog_missing");
+    const issue = validation.issues.find((i) => i.kind === "fake_gog_missing");
+    expect(issue?.severity).toBe("warn");
+  });
+
+  it("does not flag fake-gog when the task does not invoke gog", () => {
+    const runDir = freshRunDir();
+    const result = makeResult({
+      conversation: [
+        { role: "user", content: "Extract this JSON" },
+        { role: "assistant", content: '{"person":"Maya Chen"}' },
+      ],
+      toolsUsed: [],
+      toolCallCount: 0,
+    });
+    writeTaskArtifacts(runDir, baseTask.id, {
+      transcript: '[user] Extract\n[assistant] {"person":"Maya Chen"}',
+    });
+    const validation = validateTaskArtifact({ runDir, task: baseTask, result });
+    expect(validation.issues.map((i) => i.kind)).not.toContain("fake_gog_missing");
+  });
+
+  it("exposes the marker lists for site rendering", () => {
+    expect(REAL_ACCOUNT_MARKERS).toContain("lifrank1994@gmail.com");
+    expect(REAL_ACCOUNT_MARKERS).toContain("wsfccorp@gmail.com");
+    expect(HOST_OAUTH_MARKERS.length).toBeGreaterThan(0);
+    expect(HOST_PATH_MARKERS).toContain("/home/frank/.config/gogcli/state");
+  });
+});

--- a/src/gemmaclaw/benchmark/agent-validator.ts
+++ b/src/gemmaclaw/benchmark/agent-validator.ts
@@ -1,0 +1,393 @@
+/**
+ * Per-task benchmark validation gate.
+ *
+ * Runs after each task dispatch and before moving on to the next task. Catches
+ * harness bugs, transcript regressions, and isolation breaches that would
+ * otherwise contaminate the benchmark result set:
+ *
+ *   1. Transcript / conversation must be non-empty and contain at least one
+ *      assistant turn that is not just a thinking block.
+ *   2. Trajectory and session JSONL must not record a terminal session error
+ *      (already caught in the runner, but we re-confirm against the persisted
+ *      artifact in case the runner missed a late error frame).
+ *   3. No real-account markers may appear in transcript / session / trajectory.
+ *      The list lives in {@link REAL_ACCOUNT_MARKERS} and includes Frank's real
+ *      Gmail addresses, the WSFC corporate sender pattern, and the
+ *      "Pesonal/Myself" tag that has shown up in past contamination incidents.
+ *   4. No host OAuth tokens or paths to the real user state dir may leak into
+ *      the artifact. Token shapes (`ya29.`, `1//`, `gho_`, `sk-ant-`) and the
+ *      forbidden host paths are matched explicitly.
+ *   5. Fake-gog must have been on PATH (presence of the fake-gog log file or a
+ *      "(fake-gog)" marker in stdout). When the task spawned at least one
+ *      `exec` tool call referencing `gog`, the fake-gog log must exist; this
+ *      is the strongest "the agent talked to mocks, not real Google" check we
+ *      can perform offline.
+ *   6. Deterministic scorer (when configured for the task) must produce a
+ *      score. A null deterministic result on a task that requires JSON / tool
+ *      intent output is a validation failure, not a model failure.
+ *
+ * Validation is intentionally read-only over persisted artifacts. The runner
+ * passes the run dir + task id; everything we need (transcript.txt,
+ * session.jsonl, trajectory.jsonl, and the in-memory result) is already on
+ * disk by the time `validateTaskArtifact` is called.
+ *
+ * Severity:
+ *   - "block": the task result must not move on. The runner reruns the task
+ *     once, and if the issue persists records the validation issues on the
+ *     final artifact and continues to the next task with completionStatus
+ *     forced to "error".
+ *   - "warn": logged into the artifact and surfaced via the run summary, but
+ *     does not block forward progress.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { AgentTaskResult, ConversationTurn } from "./agent-runner.js";
+import {
+  evaluateDeterministicAgentTaskConversation,
+  type AgentBenchmarkTask,
+} from "./agent-tasks.js";
+
+export type ValidationSeverity = "block" | "warn";
+
+export type ValidationIssueKind =
+  | "transcript_empty"
+  | "no_assistant_turn"
+  | "trajectory_error"
+  | "real_account_marker"
+  | "host_oauth_marker"
+  | "host_path_leak"
+  | "fake_gog_missing"
+  | "deterministic_scorer_missing";
+
+export type ValidationIssue = {
+  kind: ValidationIssueKind;
+  severity: ValidationSeverity;
+  message: string;
+  /** Optional excerpt (clipped) showing where the issue was found. */
+  evidence?: string;
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  issues: ValidationIssue[];
+  /** Computed deterministic score when task ships a deterministic grader. */
+  deterministicScore?: ReturnType<typeof evaluateDeterministicAgentTaskConversation>;
+};
+
+/**
+ * Markers that indicate real-user contamination in a benchmark transcript.
+ * Frank's real Gmail addresses, the corporate sender pattern, and the
+ * "Pesonal/Myself" tag have all shown up in past contaminated runs and are
+ * the strongest single-line indicators that fake-gog was bypassed.
+ */
+export const REAL_ACCOUNT_MARKERS: readonly string[] = [
+  "lifrank1994@gmail.com",
+  "wsfccorp@gmail.com",
+  "wsfccorp+",
+  "WSFC <wsfccorp",
+  "Pesonal/Myself",
+  "Frank Li",
+  "frankhli843",
+];
+
+/**
+ * OAuth/access-token shapes and host paths that must never appear in a
+ * benchmark artifact. Token shapes are scoped tightly to avoid false
+ * positives on documentation snippets that happen to mention OAuth.
+ */
+export const HOST_OAUTH_MARKERS: readonly RegExp[] = [
+  /\bya29\.[A-Za-z0-9_-]{30,}/,
+  /\b1\/\/[A-Za-z0-9_-]{40,}/,
+  /\bgho_[A-Za-z0-9]{30,}/,
+  /\bsk-ant-[A-Za-z0-9-]{20,}/,
+];
+
+export const HOST_PATH_MARKERS: readonly string[] = [
+  "/home/frank/.config/gogcli/state",
+  "/home/frank/.openclaw/agents/main",
+  "/home/frank/.openclaw/workspace/.secrets",
+];
+
+const EVIDENCE_CLIP = 240;
+
+function clip(text: string, len = EVIDENCE_CLIP): string {
+  if (text.length <= len) {
+    return text;
+  }
+  return `${text.slice(0, len)}…`;
+}
+
+function readIfExists(filePath: string | undefined): string {
+  if (!filePath) {
+    return "";
+  }
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function findFirstMarker(haystack: string, needles: readonly string[]): string | undefined {
+  if (!haystack) {
+    return undefined;
+  }
+  for (const needle of needles) {
+    const idx = haystack.indexOf(needle);
+    if (idx !== -1) {
+      const start = Math.max(0, idx - 60);
+      const end = Math.min(haystack.length, idx + needle.length + 60);
+      return clip(haystack.slice(start, end));
+    }
+  }
+  return undefined;
+}
+
+function findFirstRegex(haystack: string, patterns: readonly RegExp[]): string | undefined {
+  if (!haystack) {
+    return undefined;
+  }
+  for (const pattern of patterns) {
+    const match = pattern.exec(haystack);
+    if (match) {
+      const idx = match.index;
+      const start = Math.max(0, idx - 40);
+      const end = Math.min(haystack.length, idx + match[0].length + 40);
+      return clip(haystack.slice(start, end));
+    }
+  }
+  return undefined;
+}
+
+function transcriptText(conversation: ConversationTurn[]): string {
+  return conversation
+    .map((t) => {
+      if (t.role === "tool_call") {
+        return `[tool_call ${t.toolName ?? ""}] ${t.content}`;
+      }
+      if (t.role === "tool_result") {
+        return `[tool_result] ${t.content}`;
+      }
+      return `[${t.role}] ${t.content}`;
+    })
+    .join("\n");
+}
+
+function hasGogToolCall(conversation: ConversationTurn[]): boolean {
+  return conversation.some((t) => {
+    if (t.role !== "tool_call") {
+      return false;
+    }
+    const name = t.toolName ?? "";
+    if (name === "gog") {
+      return true;
+    }
+    if (name === "exec" && typeof t.content === "string" && /\bgog\b/.test(t.content)) {
+      return true;
+    }
+    return false;
+  });
+}
+
+function findAssistantTurn(conversation: ConversationTurn[]): ConversationTurn | undefined {
+  return conversation.find(
+    (t) => t.role === "assistant" && typeof t.content === "string" && t.content.trim().length > 0,
+  );
+}
+
+export type ValidateTaskArtifactInput = {
+  /** Run directory containing tasks/<id>/{result.json,transcript.txt,session.jsonl,trajectory.jsonl}. */
+  runDir: string;
+  /** Task definition (used for deterministic scoring + criteria). */
+  task: AgentBenchmarkTask;
+  /** Resolved task result (already persisted). */
+  result: AgentTaskResult;
+  /** Optional fake-gog log path. When present and non-empty, fake-gog was used. */
+  fakeGogLogPath?: string;
+  /** Optional benchmark home dir. Used to scope path-leak checks. */
+  benchHomeDir?: string;
+};
+
+/**
+ * Validate a saved task artifact. Reads the persisted transcript, session
+ * JSONL, and trajectory JSONL alongside the in-memory result, and returns a
+ * structured list of issues. Pure read-only; never mutates artifacts.
+ */
+export function validateTaskArtifact(input: ValidateTaskArtifactInput): ValidationResult {
+  const { runDir, task, result, fakeGogLogPath } = input;
+  const issues: ValidationIssue[] = [];
+
+  const taskDir = path.join(runDir, "tasks", task.id);
+  const transcriptPath = path.join(taskDir, "transcript.txt");
+  const sessionPath = path.join(taskDir, "session.jsonl");
+  const trajectoryPath = path.join(taskDir, "trajectory.jsonl");
+
+  const conversation = result.conversation ?? [];
+  const transcript = readIfExists(transcriptPath) || transcriptText(conversation);
+  const sessionText = readIfExists(sessionPath);
+  const trajectoryText = readIfExists(trajectoryPath);
+
+  // (1) Transcript must be non-empty.
+  if (conversation.length === 0 || transcript.trim().length === 0) {
+    issues.push({
+      kind: "transcript_empty",
+      severity: "block",
+      message: "Empty transcript: no conversation turns recorded for this task.",
+    });
+  }
+
+  // (2) Must contain a non-empty assistant turn.
+  const assistantTurn = findAssistantTurn(conversation);
+  if (!assistantTurn && result.completionStatus === "completed") {
+    issues.push({
+      kind: "no_assistant_turn",
+      severity: "block",
+      message: "Task marked completed but conversation has no assistant turn with content.",
+    });
+  }
+
+  // (3) Re-confirm trajectory error using the persisted file (the runner also
+  // checks this in-process; redundant check keeps validation honest).
+  if (trajectoryText) {
+    const errorLine = trajectoryText
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line) as { type?: unknown; status?: unknown; error?: unknown };
+        } catch {
+          return undefined;
+        }
+      })
+      .find((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return false;
+        }
+        const type = typeof entry.type === "string" ? entry.type : "";
+        const status = typeof entry.status === "string" ? entry.status : "";
+        return (
+          (type === "session.ended" || type === "session_ended") &&
+          (status === "error" ||
+            status === "failed" ||
+            status === "timeout" ||
+            status === "aborted")
+        );
+      });
+    if (errorLine) {
+      const status = (errorLine as { status?: unknown }).status;
+      const statusText = typeof status === "string" ? status : "unknown";
+      issues.push({
+        kind: "trajectory_error",
+        severity: "block",
+        message: `Trajectory recorded a terminal session error: status=${statusText}.`,
+        evidence: clip(JSON.stringify(errorLine)),
+      });
+    }
+  }
+
+  // (4) Real account markers in any persisted artifact.
+  for (const [bodyName, body] of [
+    ["transcript", transcript],
+    ["session", sessionText],
+    ["trajectory", trajectoryText],
+  ] as const) {
+    const evidence = findFirstMarker(body, REAL_ACCOUNT_MARKERS);
+    if (evidence) {
+      issues.push({
+        kind: "real_account_marker",
+        severity: "block",
+        message: `Real account marker detected in ${bodyName}.`,
+        evidence,
+      });
+      break;
+    }
+  }
+
+  // (5a) Host OAuth token shapes.
+  for (const [bodyName, body] of [
+    ["transcript", transcript],
+    ["session", sessionText],
+    ["trajectory", trajectoryText],
+  ] as const) {
+    const evidence = findFirstRegex(body, HOST_OAUTH_MARKERS);
+    if (evidence) {
+      issues.push({
+        kind: "host_oauth_marker",
+        severity: "block",
+        message: `Host OAuth/access-token shape detected in ${bodyName}.`,
+        evidence,
+      });
+      break;
+    }
+  }
+
+  // (5b) Host path leaks (real user state dirs).
+  for (const [bodyName, body] of [
+    ["session", sessionText],
+    ["trajectory", trajectoryText],
+  ] as const) {
+    const evidence = findFirstMarker(body, HOST_PATH_MARKERS);
+    if (evidence) {
+      issues.push({
+        kind: "host_path_leak",
+        severity: "block",
+        message: `Host real-user path detected in ${bodyName}.`,
+        evidence,
+      });
+      break;
+    }
+  }
+
+  // (6) Fake-gog must have been used when the task touched gog.
+  if (hasGogToolCall(conversation)) {
+    const fakeGogPresent =
+      fakeGogLogPath !== undefined &&
+      fs.existsSync(fakeGogLogPath) &&
+      fs.statSync(fakeGogLogPath).size > 0;
+    if (!fakeGogPresent) {
+      issues.push({
+        kind: "fake_gog_missing",
+        severity: "warn",
+        message:
+          "Task invoked gog but fake-gog.log is empty/missing. Fake-gog isolation may have been bypassed.",
+      });
+    }
+  }
+
+  // (7) Deterministic scorer must produce a score when configured.
+  let deterministicScore: ReturnType<typeof evaluateDeterministicAgentTaskConversation>;
+  try {
+    deterministicScore = evaluateDeterministicAgentTaskConversation(task, conversation);
+  } catch (err) {
+    deterministicScore = undefined;
+    issues.push({
+      kind: "deterministic_scorer_missing",
+      severity: "warn",
+      message: `Deterministic scorer threw: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+  if (task.grading.deterministic && deterministicScore == null) {
+    issues.push({
+      kind: "deterministic_scorer_missing",
+      severity: "warn",
+      message: "Task has a deterministic grader but it returned no result.",
+    });
+  }
+
+  const hasBlocker = issues.some((issue) => issue.severity === "block");
+  return {
+    valid: !hasBlocker,
+    issues,
+    deterministicScore,
+  };
+}
+
+export function summarizeValidation(result: ValidationResult): string {
+  if (result.issues.length === 0) {
+    return "validation: ok";
+  }
+  return result.issues
+    .map((issue) => `${issue.severity}:${issue.kind}:${issue.message}`)
+    .join("; ");
+}

--- a/src/gemmaclaw/benchmark/agent-validator.ts
+++ b/src/gemmaclaw/benchmark/agent-validator.ts
@@ -42,11 +42,11 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import type { AgentTaskResult, ConversationTurn } from "./agent-runner.js";
 import {
   evaluateDeterministicAgentTaskConversation,
   type AgentBenchmarkTask,
 } from "./agent-tasks.js";
+import type { ConversationTurn, ValidatableTaskResult } from "./agent-types.js";
 
 export type ValidationSeverity = "block" | "warn";
 
@@ -202,7 +202,7 @@ export type ValidateTaskArtifactInput = {
   /** Task definition (used for deterministic scoring + criteria). */
   task: AgentBenchmarkTask;
   /** Resolved task result (already persisted). */
-  result: AgentTaskResult;
+  result: ValidatableTaskResult;
   /** Optional fake-gog log path. When present and non-empty, fake-gog was used. */
   fakeGogLogPath?: string;
   /** Optional benchmark home dir. Used to scope path-leak checks. */

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -94,6 +94,18 @@ function parseArgs(argv: string[]) {
       opts.taskTimeout = args[++i]!;
     } else if (arg === "--idle-timeout" && args[i + 1]) {
       opts.idleTimeout = args[++i]!;
+    } else if (arg === "--no-activity-timeout" && args[i + 1]) {
+      opts.noActivityTimeout = args[++i]!;
+    } else if (arg === "--hard-cap" && args[i + 1]) {
+      opts.hardCap = args[++i]!;
+    } else if (arg === "--validate-per-task") {
+      opts.validatePerTask = true;
+    } else if (arg === "--no-validate-per-task") {
+      opts.validatePerTask = false;
+    } else if (arg === "--validation-rerun-on-fail") {
+      opts.validationRerunOnFail = true;
+    } else if (arg === "--no-validation-rerun-on-fail") {
+      opts.validationRerunOnFail = false;
     } else if (arg === "--backend" && args[i + 1]) {
       opts.backend = args[++i]!;
     } else if (arg === "--llama-cpp-url" && args[i + 1]) {
@@ -148,8 +160,12 @@ Agent Mode Options:
   --evaluate             Run LLM judge scoring for a saved run id
   --force-evaluate       Replace existing LLM judge scores for that run
   --judge-provider <id>  Judge provider (openai)
-  --task-timeout <sec>   Max seconds per task, 0=unlimited (default: 600)
+  --task-timeout <sec>   Legacy alias for --hard-cap (default: 600). Activity-based timeout is the normal "stuck" signal.
   --idle-timeout <sec>   Seconds of idle before task considered done (default: 30)
+  --no-activity-timeout <sec>  Kill the task if no useful agent activity (stdout/stderr/JSONL/trajectory) for N seconds (default: 600)
+  --hard-cap <sec>       Hard wall-clock ceiling per task as a runaway guard (default: 28800 = 8h)
+  --validate-per-task    Run the per-task validation gate after each task (default: on). Use --no-validate-per-task to opt out.
+  --validation-rerun-on-fail  Rerun a task once if validation produces a block-severity issue (default: on)
   --judge-model <name>   Model for LLM judge (default: same as test model)
   --mock                 Mock mode: no real model, deterministic pass/fail
   --context-length <n>   Ollama context window size
@@ -256,6 +272,12 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
     thinkingLevel: opts.thinking as string | undefined,
     taskTimeoutSeconds: opts.taskTimeout ? Number.parseInt(String(opts.taskTimeout), 10) : 600,
     idleTimeoutSeconds: opts.idleTimeout ? Number.parseInt(String(opts.idleTimeout), 10) : 30,
+    noActivityTimeoutSeconds: opts.noActivityTimeout
+      ? Number.parseInt(String(opts.noActivityTimeout), 10)
+      : undefined,
+    hardCapSeconds: opts.hardCap ? Number.parseInt(String(opts.hardCap), 10) : undefined,
+    validatePerTask: opts.validatePerTask !== false,
+    validationRerunOnFail: opts.validationRerunOnFail !== false,
     filter: (opts.task as string) ?? (opts.filter as string) ?? undefined,
     mock: Boolean(opts.mock),
     contextLength: opts.contextLength ? Number.parseInt(String(opts.contextLength), 10) : undefined,


### PR DESCRIPTION
## Summary

Two harness fixes asked for in todo `t_01KQJ33Y583QW2Z3YN0Y5GAP8R` (subtasks `st_82b878bfd4e7` and `st_175d23ebea20`).

### 1. Activity-based timeout (was: hard wall-clock timeout)

Previously a single `--task-timeout` hard wall-clock value killed every task at N seconds even when the agent was actively producing tokens, tool calls, and JSONL frames. Long Gemma 4 31B runs were getting wrongly classified as timeouts because of this.

Replaced with a two-tier model:

- `--no-activity-timeout <sec>` (default **600s = 10 min**): kills the task if no useful activity (stdout, stderr, session JSONL, trajectory JSONL) is observed for that many seconds. Resets on every progress signal. This is now the normal "task is stuck" detection.
- `--hard-cap <sec>` (default **28800s = 8h**): wall-clock runaway guard. Only fires when an actively chatty agent crosses the ceiling. `--task-timeout` remains a backward-compat alias for this.

Per Frank's directive: "Timeout should mean no useful activity for over 10 minutes, reset by thinking/output/tool calls/tool results/process output/file writes/trajectory activity. Keep a separate high hard cap only as a runaway guard."

### 2. Per-task validation gate

New module `agent-validator.ts` runs after each task and before the next dispatch. Reads the persisted artifacts (transcript.txt, session.jsonl, trajectory.jsonl, fake-gog.log) and surfaces structured `ValidationIssue`s:

- `transcript_empty`, `no_assistant_turn` → block
- `trajectory_error` (terminal session.ended status=error|failed|timeout|aborted) → block
- `real_account_marker` (lifrank1994@gmail.com, wsfccorp@gmail.com, wsfccorp+, WSFC <wsfccorp, Pesonal/Myself, Frank Li, frankhli843) → block
- `host_oauth_marker` (`ya29.`, `1//`, `gho_`, `sk-ant-` token shapes) → block
- `host_path_leak` (real user state dirs) → block
- `fake_gog_missing` (gog tool call without fake-gog log) → warn
- `deterministic_scorer_missing` (task has deterministic grader but no result) → warn

Block-severity issues trigger a single rerun. If the issue persists, the task lands as `completionStatus=error` with the validation summary recorded on the artifact (so the site/evaluator never silently scores a contaminated run).

CLI flags: `--validate-per-task` / `--no-validate-per-task`, `--validation-rerun-on-fail` / `--no-validation-rerun-on-fail`. Both default on.

## Tests

- `agent-validator.test.ts`: 9 cases covering each `ValidationIssueKind`, plus the marker-list shape check used by future site rendering.
- `agent-runner.test.ts`: new `resolveTimeoutBudgets` suite (defaults, legacy compat, explicit overrides, zero/negative fallback) and a config-hash regression check so `validatePerTask` toggles produce different hashes.
- `pnpm check:changed` green: typecheck core + tests, lint, import-cycle, pairing/webhook guards, and the changed-file vitest sweep all pass.

## Test plan

- [x] `pnpm tsgo:test:src` clean
- [x] `pnpm check:changed` green (lint + typecheck + import cycles + tests)
- [x] `pnpm vitest run --config test/vitest/vitest.unit-src.config.ts src/gemmaclaw/benchmark/agent-runner.test.ts src/gemmaclaw/benchmark/agent-validator.test.ts` → 32/32
- [x] Smoke: `pnpm benchmark agent --mock --filter gemma3n_json_extract --no-activity-timeout 30 --hard-cap 120` writes `validation` block + deterministic score to `tasks/<id>/result.json`
- [ ] Real-model targeted rerun against `gemma4-31b-q4-high` artifacts (next phase, separate todo subtask)