### PR TITLE
fix(benchmark): preserve per-task container runs

### DIFF
--- a/scripts/benchmark-docker-entrypoint.sh
+++ b/scripts/benchmark-docker-entrypoint.sh
@@ -7,30 +7,9 @@ echo "========================================"
 echo ""
 
 export GEMMACLAW_BENCHMARK_CONTAINER=1
+OLLAMA_PID=""
 
-# ---------------------------------------------------------------------------
-# 1. Start Ollama
-# ---------------------------------------------------------------------------
-echo "[1/3] Starting Ollama server..."
-ollama serve &
-OLLAMA_PID=$!
-
-echo "[2/3] Waiting for Ollama..."
-for i in $(seq 1 60); do
-  if curl -s http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
-    echo "  Ollama ready after ${i}s"
-    break
-  fi
-  if [ "$i" -eq 60 ]; then
-    echo "ERROR: Ollama failed to start after 60s"
-    exit 1
-  fi
-  sleep 1
-done
-
-# ---------------------------------------------------------------------------
-# 2. Pull model (extract --model from args, default gemma3:1b)
-# ---------------------------------------------------------------------------
+# Extract --model from args, default gemma3:1b.
 MODEL="${BENCHMARK_MODEL:-gemma3:1b}"
 prev_was_model=0
 for arg in "$@"; do
@@ -44,8 +23,63 @@ for arg in "$@"; do
   fi
 done
 
-echo "[3/3] Pulling model: $MODEL"
-ollama pull "$MODEL"
+IS_AGENT=0
+for arg in "$@"; do
+  if [ "$arg" = "agent" ]; then
+    IS_AGENT=1
+    break
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 1. Start Ollama
+# ---------------------------------------------------------------------------
+if [ "$IS_AGENT" != "1" ]; then
+  echo "[1/3] Starting Ollama server..."
+  ollama serve &
+  OLLAMA_PID=$!
+
+  echo "[2/3] Waiting for Ollama..."
+  for i in $(seq 1 60); do
+    if curl -s http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+      echo "  Ollama ready after ${i}s"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: Ollama failed to start after 60s"
+      exit 1
+    fi
+    sleep 1
+  done
+else
+  echo "[1/3] Agent mode: using host Ollama, not container-local Ollama"
+  echo "[2/3] Skipping container-local Ollama startup"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Pull model for local benchmark modes only. Agent mode must use the host
+# model cache so one-container-per-task runs do not redownload large models.
+# ---------------------------------------------------------------------------
+if [ "$IS_AGENT" != "1" ]; then
+  echo "[3/3] Pulling model: $MODEL"
+  ollama pull "$MODEL"
+else
+  echo "[3/3] Agent mode: skipping container-local model pull for $MODEL"
+fi
+
+cleanup_ollama() {
+  if [ -n "${OLLAMA_PID:-}" ]; then
+    kill "$OLLAMA_PID" 2>/dev/null || true
+  fi
+}
+
+fix_results_owner() {
+  if [ -n "${GEMMACLAW_BENCHMARK_HOST_UID:-}" ] && [ -n "${GEMMACLAW_BENCHMARK_HOST_GID:-}" ]; then
+    chown -R "$GEMMACLAW_BENCHMARK_HOST_UID:$GEMMACLAW_BENCHMARK_HOST_GID" /results 2>/dev/null || true
+  fi
+}
+
+trap fix_results_owner EXIT
 
 # ---------------------------------------------------------------------------
 # 3. Sandbox mode: read the user-supplied file
@@ -110,21 +144,13 @@ if [ "${BENCHMARK_SANDBOX:-0}" = "1" ]; then
     sleep infinity
   fi
 
-  kill $OLLAMA_PID 2>/dev/null || true
+  cleanup_ollama
   exit ${EXIT_CODE:-0}
 fi
 
 # ---------------------------------------------------------------------------
 # 4. Agent mode: start gateway + mock gog, run E2E agentic benchmarks
 # ---------------------------------------------------------------------------
-IS_AGENT=0
-for arg in "$@"; do
-  if [ "$arg" = "agent" ]; then
-    IS_AGENT=1
-    break
-  fi
-done
-
 if [ "$IS_AGENT" = "1" ]; then
   echo ""
   echo "========================================"
@@ -141,20 +167,19 @@ if [ "$IS_AGENT" = "1" ]; then
   export OPENCLAW_HOME="/root/.openclaw"
   mkdir -p "$OPENCLAW_HOME"
 
-  # Determine Ollama URL: prefer env, then check host.docker.internal (host Ollama),
-  # then fall back to local container Ollama
+  # Determine Ollama URL. Real agent benchmarks must use host Ollama so each
+  # per-task container starts clean without downloading or serving models.
   OLLAMA_TARGET="${OLLAMA_URL:-}"
   if [ -z "$OLLAMA_TARGET" ]; then
-    # Try host Ollama first (avoids GPU passthrough and model re-download)
-    if curl -sf http://host.docker.internal:11434/api/tags >/dev/null 2>&1; then
-      OLLAMA_TARGET="http://host.docker.internal:11434"
-      echo "[agent] Using host Ollama at $OLLAMA_TARGET"
-    else
-      OLLAMA_TARGET="http://127.0.0.1:11434"
-      echo "[agent] Using container-local Ollama"
-    fi
+    OLLAMA_TARGET="http://host.docker.internal:11434"
+  fi
+
+  if curl -sf "$OLLAMA_TARGET/api/tags" >/dev/null 2>&1; then
+    echo "[agent] Using host/configured Ollama at $OLLAMA_TARGET"
   else
-    echo "[agent] Using configured Ollama at $OLLAMA_TARGET"
+    echo "ERROR: Agent benchmarks require a reachable host/configured Ollama at $OLLAMA_TARGET"
+    echo "       Start host Ollama or pass OLLAMA_URL. Container-local Ollama is disabled for agent benchmarks."
+    exit 1
   fi
 
   # Create minimal gemmaclaw config
@@ -178,8 +203,10 @@ GCEOF
 
   export GEMMACLAW_BIN="$GEMMACLAW_CMD"
 
-  # Start gateway
-  $GEMMACLAW_CMD gateway start &
+  # Start gateway in the foreground inside the container. "gateway start" is
+  # the service-manager command and is intentionally unavailable in benchmark
+  # containers.
+  $GEMMACLAW_CMD gateway run --port 3001 --bind loopback --auth none --allow-unconfigured &
   GATEWAY_PID=$!
 
   echo "[agent] Waiting for gateway..."
@@ -190,7 +217,7 @@ GCEOF
     fi
     if [ "$i" -eq 30 ]; then
       echo "ERROR: Gateway failed to start after 30s"
-      kill $OLLAMA_PID 2>/dev/null || true
+      cleanup_ollama
       exit 1
     fi
     sleep 1
@@ -210,17 +237,13 @@ GCEOF
     EXTRA_ARGS+=(--output-dir /results)
   fi
 
-  if [ -f /app/dist/entry.js ]; then
-    node /app/gemmaclaw.mjs benchmark "$@" "${EXTRA_ARGS[@]}"
-  else
-    npx tsx /app/src/gemmaclaw/benchmark/cli-standalone.ts "$@" "${EXTRA_ARGS[@]}"
-  fi
+  node --import tsx /app/src/gemmaclaw/benchmark/cli-standalone.ts "$@" "${EXTRA_ARGS[@]}"
 
   EXIT_CODE=$?
 
   # Cleanup
   kill $GATEWAY_PID 2>/dev/null || true
-  kill $OLLAMA_PID 2>/dev/null || true
+  cleanup_ollama
 
   exit ${EXIT_CODE:-0}
 fi
@@ -251,6 +274,6 @@ fi
 
 EXIT_CODE=$?
 
-kill $OLLAMA_PID 2>/dev/null || true
+cleanup_ollama
 
 exit ${EXIT_CODE:-0}

--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -15,6 +15,7 @@ import {
   readOpenAICodexAuthProfilesFromStore,
   resolveOpenAICodexAuthProfileStoreCandidates,
   resolveTimeoutBudgets,
+  runAgentBenchmark,
   writeTaskArtifact,
   writeBenchmarkWorkspaceFiles,
   type AgentBenchmarkConfig,
@@ -301,6 +302,14 @@ describe("per-task benchmark artifacts", () => {
     },
   };
 
+  const secondTask: AgentBenchmarkTask = {
+    ...task,
+    id: "calendar_summary",
+    name: "Calendar Summary",
+    category: "calendar",
+    prompt: "Summarize my calendar",
+  };
+
   const config: AgentBenchmarkConfig = {
     gatewayUrl: "http://localhost:3001",
     backend: "ollama",
@@ -313,6 +322,18 @@ describe("per-task benchmark artifacts", () => {
     idleTimeoutSeconds: 3600,
     mock: true,
     runId: "q4-smoke",
+  };
+
+  const hardware = {
+    cpu: { arch: "x64", cores: 16, model: "test cpu" },
+    ram: { totalBytes: 32 * 1024 ** 3, availableBytes: 16 * 1024 ** 3 },
+    gpu: {
+      detected: true,
+      nvidia: true,
+      apple: false,
+      name: "test gpu",
+      vramBytes: 24 * 1024 ** 3,
+    },
   };
 
   const result: AgentTaskResult = {
@@ -363,17 +384,7 @@ describe("per-task benchmark artifacts", () => {
       model: config.model,
       quant: config.quant,
       thinkingLevel: config.thinkingLevel,
-      hardware: {
-        cpu: { arch: "x64", cores: 16, model: "test cpu" },
-        ram: { totalBytes: 32 * 1024 ** 3, availableBytes: 16 * 1024 ** 3 },
-        gpu: {
-          detected: true,
-          nvidia: true,
-          apple: false,
-          name: "test gpu",
-          vramBytes: 24 * 1024 ** 3,
-        },
-      },
+      hardware,
       gatewayUrl: config.gatewayUrl,
       ollamaUrl: config.ollamaUrl,
       startedAt: "2026-05-07T10:00:00.000Z",
@@ -406,5 +417,46 @@ describe("per-task benchmark artifacts", () => {
     expect(fs.existsSync(path.join(outputDir, "evaluations/q4-smoke/email_summarize.json"))).toBe(
       true,
     );
+  });
+
+  it("lets per-task container slices share the parent artifact hash and manifest", async () => {
+    const outputDir = tempDir();
+    const runDir = path.join(outputDir, "runs", "q4-smoke");
+    const sharedHash = "legacy-clean-hash";
+    const parentConfig = { ...config, outputDir, runId: "q4-smoke", mock: true };
+    writeTaskArtifact(runDir, "q4-smoke", sharedHash, result);
+
+    await runAgentBenchmark(
+      [secondTask],
+      {
+        ...parentConfig,
+        filter: secondTask.id,
+        artifactConfigHash: sharedHash,
+        manifestConfig: parentConfig,
+        manifestTaskIds: [task.id, secondTask.id],
+      },
+      hardware,
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(runDir, "manifest.json"), "utf-8")) as {
+      configHash: string;
+      taskIds: string[];
+      config: AgentBenchmarkConfig;
+    };
+    expect(manifest.configHash).toBe(sharedHash);
+    expect(manifest.taskIds).toEqual([task.id, secondTask.id]);
+    expect(manifest.config.filter).toBeUndefined();
+    expect(
+      loadTaskArtifacts(runDir, sharedHash)
+        .map((entry) => entry.task.id)
+        .toSorted(),
+    ).toEqual([task.id, secondTask.id].toSorted());
+
+    const assembled = assembleAgentBenchmarkRun(
+      [task, secondTask],
+      { ...parentConfig, runId: "q4-smoke" },
+      outputDir,
+    );
+    expect(assembled.tasks.map((entry) => entry.task.id)).toEqual([task.id, secondTask.id]);
   });
 });

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -115,6 +115,12 @@ export type AgentBenchmarkConfig = {
   rerun?: boolean;
   /** Rerun only tasks whose existing result is timeout/error. */
   rerunFailed?: boolean;
+  /** Internal: force per-task artifacts to use the shared parent run hash. */
+  artifactConfigHash?: string;
+  /** Internal: manifest config to write when a per-task container runs a slice. */
+  manifestConfig?: AgentBenchmarkConfig;
+  /** Internal: full selected task set for the shared run manifest. */
+  manifestTaskIds?: string[];
 };
 
 export type ConversationTurn = {
@@ -1033,7 +1039,11 @@ export async function dispatchTask(
     "--message",
     task.prompt,
   ];
-  if (config.thinkingLevel) {
+  // Ollama/Gemma benchmark runs record the requested thinking level in the
+  // benchmark metadata, but the embedded agent CLI may reject reasoning flags
+  // for local provider paths. Only forward the flag to backends where the
+  // agent harness is expected to support it.
+  if (config.thinkingLevel && config.backend === "openai-codex") {
     args.push("--thinking", config.thinkingLevel);
   }
   // Pass the hard wall-clock cap to the embedded CLI so it has its own ceiling
@@ -1119,6 +1129,26 @@ export async function dispatchTask(
           },
         },
       };
+    } else if (!isOpenAICodex) {
+      benchConfigData.models = {
+        providers: {
+          ollama: {
+            baseUrl: config.ollamaUrl,
+            api: "ollama",
+            models: [
+              {
+                id: config.model,
+                name: config.model,
+                reasoning: false,
+                input: ["text"],
+                contextWindow: config.contextLength ?? 262_144,
+                maxTokens: 8_192,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      };
     }
     fs.writeFileSync(path.join(ocDir, "openclaw.json"), JSON.stringify(benchConfigData, null, 2));
 
@@ -1157,6 +1187,7 @@ export async function dispatchTask(
         GEMMACLAW_FAKE_GOG_STATE_DIR: gogStateDir,
         GEMMACLAW_FAKE_GOG_WRITES_DIR: path.join(gogStateDir, "_writes"),
         GEMMACLAW_FAKE_GOG_LOG: fakeGogLog,
+        OLLAMA_HOST: config.ollamaUrl,
         XDG_CONFIG_HOME: benchHome,
         HOME: benchHome,
         PATH: `${fakeGogBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
@@ -1664,8 +1695,10 @@ export async function runAgentBenchmark(
   config = { ...config, outputDir, runId: formatRunDirNameFromConfig(config, metadata) };
   const runId = config.runId!;
   const runDir = path.join(outputDir, "runs", runId);
-  const configHash = computeConfigHash(config);
+  const configHash = config.artifactConfigHash ?? computeConfigHash(config);
   fs.mkdirSync(runDir, { recursive: true });
+  const manifestConfig = config.manifestConfig ? { ...config.manifestConfig, runId } : config;
+  const manifestTaskIds = config.manifestTaskIds ?? filteredTasks.map((task) => task.id);
 
   const existingManifestPath = path.join(runDir, "manifest.json");
   let createdAt = metadata.startedAt;
@@ -1684,9 +1717,9 @@ export async function runAgentBenchmark(
       schemaVersion: 1,
       runId,
       configHash,
-      config,
+      config: manifestConfig,
       metadata,
-      taskIds: filteredTasks.map((task) => task.id),
+      taskIds: manifestTaskIds,
       createdAt,
       updatedAt: new Date().toISOString(),
     } satisfies AgentRunManifest);

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -23,7 +23,8 @@
  *   pnpm benchmark agent --quant Q4_K_M     # Record quantization level
  */
 
-import { execSync, spawn } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { benchmarkGemmaCommand, benchmarkSandboxCommand } from "../../commands/benchmark-gemma.js";
@@ -42,6 +43,7 @@ import { evaluateAgentBenchmarkRun, type AgentJudgeProvider } from "./agent-eval
 import {
   assembleAgentBenchmarkRun,
   autoSelectModel,
+  computeConfigHash,
   isAgentBackendType,
   runAgentBenchmark,
   type AgentBenchmarkConfig,
@@ -143,12 +145,122 @@ function parseArgs(argv: string[]) {
   return opts;
 }
 
+function buildAgentBenchmarkConfig(
+  opts: Record<string, string | boolean>,
+  outputDir: string,
+): AgentBenchmarkConfig {
+  const hardware = detectHardware();
+  const autoSelected = autoSelectModel(hardware);
+  const backendInput = (opts.backend as string | undefined) ?? autoSelected.backend;
+  if (!isAgentBackendType(backendInput)) {
+    throw new Error(`Unsupported agent benchmark backend: ${backendInput}`);
+  }
+  const backend = backendInput;
+  const model = (opts.model as string) ?? autoSelected.model;
+
+  return {
+    gatewayUrl: (opts.gatewayUrl as string) ?? "http://localhost:3001",
+    backend,
+    ollamaUrl: (opts.ollamaUrl as string) ?? "http://127.0.0.1:11434",
+    llamaCppUrl: (opts.llamaCppUrl as string) ?? "http://127.0.0.1:8080",
+    model,
+    quant: opts.quant as string | undefined,
+    thinkingLevel: opts.thinking as string | undefined,
+    taskTimeoutSeconds: opts.taskTimeout ? Number.parseInt(String(opts.taskTimeout), 10) : 600,
+    idleTimeoutSeconds: opts.idleTimeout ? Number.parseInt(String(opts.idleTimeout), 10) : 30,
+    noActivityTimeoutSeconds: opts.noActivityTimeout
+      ? Number.parseInt(String(opts.noActivityTimeout), 10)
+      : undefined,
+    hardCapSeconds: opts.hardCap ? Number.parseInt(String(opts.hardCap), 10) : undefined,
+    validatePerTask: opts.validatePerTask !== false,
+    validationRerunOnFail: opts.validationRerunOnFail !== false,
+    filter: (opts.task as string) ?? (opts.filter as string) ?? undefined,
+    mock: Boolean(opts.mock),
+    contextLength: opts.contextLength ? Number.parseInt(String(opts.contextLength), 10) : undefined,
+    gemmaclawHome: opts.gemmaclawHome as string | undefined,
+    outputDir,
+    runId: opts.runId as string | undefined,
+    rerun: Boolean(opts.rerun),
+    rerunFailed: Boolean(opts.rerunFailed),
+  };
+}
+
+function parseJsonEnv(name: string): unknown {
+  const raw = process.env[name];
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON in ${name}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function existingRunArtifactConfigHash(outputDir: string, runId: string): string | undefined {
+  const tasksDir = path.join(outputDir, "runs", runId, "tasks");
+  if (!fs.existsSync(tasksDir)) {
+    return undefined;
+  }
+  const counts = new Map<string, number>();
+  for (const taskId of fs.readdirSync(tasksDir)) {
+    const artifactPath = path.join(tasksDir, taskId, "result.json");
+    if (!fs.existsSync(artifactPath)) {
+      continue;
+    }
+    try {
+      const data = JSON.parse(fs.readFileSync(artifactPath, "utf-8")) as { configHash?: string };
+      if (data.configHash) {
+        counts.set(data.configHash, (counts.get(data.configHash) ?? 0) + 1);
+      }
+    } catch {
+      /* Ignore malformed partial artifacts. */
+    }
+  }
+  return [...counts.entries()].toSorted((a, b) => b[1] - a[1])[0]?.[0];
+}
+
+function restoreHostOutputOwnership(hostOutputDir: string): void {
+  const uid = process.getuid?.();
+  if (uid === undefined) {
+    return;
+  }
+  const gid = process.getgid?.() ?? uid;
+  const result = spawnSync(
+    "docker",
+    [
+      "run",
+      "--rm",
+      "-v",
+      `${hostOutputDir}:/results`,
+      "--entrypoint",
+      "chown",
+      AGENT_BENCHMARK_DOCKER_IMAGE,
+      "-R",
+      `${uid}:${gid}`,
+      "/results",
+    ],
+    { stdio: "inherit" },
+  );
+  if (result.status !== 0) {
+    console.warn(
+      `Warning: failed to restore host ownership for ${hostOutputDir}; host-side assembly may need manual chown.`,
+    );
+  }
+}
+
 async function runAgentModeInDocker(opts: Record<string, string | boolean>): Promise<void> {
   const repoRoot = findBenchmarkRepoRoot();
   const hostOutputDir = path.resolve((opts.outputDir as string | undefined) ?? "benchmark-results");
   const containerOutputDir = "/results";
   const selectedTaskIds = selectAgentBenchmarkTaskIds(AGENT_BENCHMARK_TASKS, opts);
   const runId = defaultAgentBenchmarkRunId(opts);
+  const manifestConfig = { ...buildAgentBenchmarkConfig(opts, hostOutputDir), runId };
+  const artifactConfigHash =
+    existingRunArtifactConfigHash(hostOutputDir, runId) ?? computeConfigHash(manifestConfig);
 
   console.log("========================================");
   console.log("  Gemmaclaw Agent Benchmark Containers");
@@ -159,6 +271,7 @@ async function runAgentModeInDocker(opts: Record<string, string | boolean>): Pro
   console.log(`Image:  ${AGENT_BENCHMARK_DOCKER_IMAGE}`);
   console.log(`Output: ${hostOutputDir}`);
   console.log(`Run id: ${runId}`);
+  console.log(`Artifact config hash: ${artifactConfigHash}`);
   console.log(`Tasks:  ${selectedTaskIds.length}`);
   console.log("");
 
@@ -181,6 +294,16 @@ async function runAgentModeInDocker(opts: Record<string, string | boolean>): Pro
       "--add-host=host.docker.internal:host-gateway",
       "-e",
       "GEMMACLAW_BENCHMARK_CONTAINER=1",
+      "-e",
+      `GEMMACLAW_BENCHMARK_ARTIFACT_CONFIG_HASH=${artifactConfigHash}`,
+      "-e",
+      `GEMMACLAW_BENCHMARK_MANIFEST_TASK_IDS=${JSON.stringify(selectedTaskIds)}`,
+      "-e",
+      `GEMMACLAW_BENCHMARK_MANIFEST_CONFIG=${JSON.stringify(manifestConfig)}`,
+      "-e",
+      `GEMMACLAW_BENCHMARK_HOST_UID=${process.getuid?.() ?? 0}`,
+      "-e",
+      `GEMMACLAW_BENCHMARK_HOST_GID=${process.getgid?.() ?? 0}`,
       "-v",
       `${hostOutputDir}:${containerOutputDir}`,
       AGENT_BENCHMARK_DOCKER_IMAGE,
@@ -192,6 +315,7 @@ async function runAgentModeInDocker(opts: Record<string, string | boolean>): Pro
       const child = spawn("docker", dockerArgs, { cwd: repoRoot, stdio: "inherit" });
       child.on("error", reject);
       child.on("close", (code) => {
+        restoreHostOutputOwnership(hostOutputDir);
         if (code === 0) {
           resolve();
         } else {
@@ -368,41 +492,14 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
   }
 
   const hardware = detectHardware();
-
-  // Auto-select model and backend if not specified
-  const autoSelected = autoSelectModel(hardware);
-  const backendInput = (opts.backend as string | undefined) ?? autoSelected.backend;
-  if (!isAgentBackendType(backendInput)) {
-    throw new Error(`Unsupported agent benchmark backend: ${backendInput}`);
-  }
-  const backend = backendInput;
-  const model = (opts.model as string) ?? autoSelected.model;
-
-  const config: AgentBenchmarkConfig = {
-    gatewayUrl: (opts.gatewayUrl as string) ?? "http://localhost:3001",
-    backend,
-    ollamaUrl: (opts.ollamaUrl as string) ?? "http://127.0.0.1:11434",
-    llamaCppUrl: (opts.llamaCppUrl as string) ?? "http://127.0.0.1:8080",
-    model,
-    quant: opts.quant as string | undefined,
-    thinkingLevel: opts.thinking as string | undefined,
-    taskTimeoutSeconds: opts.taskTimeout ? Number.parseInt(String(opts.taskTimeout), 10) : 600,
-    idleTimeoutSeconds: opts.idleTimeout ? Number.parseInt(String(opts.idleTimeout), 10) : 30,
-    noActivityTimeoutSeconds: opts.noActivityTimeout
-      ? Number.parseInt(String(opts.noActivityTimeout), 10)
-      : undefined,
-    hardCapSeconds: opts.hardCap ? Number.parseInt(String(opts.hardCap), 10) : undefined,
-    validatePerTask: opts.validatePerTask !== false,
-    validationRerunOnFail: opts.validationRerunOnFail !== false,
-    filter: (opts.task as string) ?? (opts.filter as string) ?? undefined,
-    mock: Boolean(opts.mock),
-    contextLength: opts.contextLength ? Number.parseInt(String(opts.contextLength), 10) : undefined,
-    gemmaclawHome: opts.gemmaclawHome as string | undefined,
-    outputDir: (opts.outputDir as string) ?? "benchmark-results",
-    runId: opts.runId as string | undefined,
-    rerun: Boolean(opts.rerun),
-    rerunFailed: Boolean(opts.rerunFailed),
-  };
+  const config = buildAgentBenchmarkConfig(opts, (opts.outputDir as string) ?? "benchmark-results");
+  config.artifactConfigHash = process.env.GEMMACLAW_BENCHMARK_ARTIFACT_CONFIG_HASH;
+  config.manifestTaskIds = parseJsonEnv("GEMMACLAW_BENCHMARK_MANIFEST_TASK_IDS") as
+    | string[]
+    | undefined;
+  config.manifestConfig = parseJsonEnv("GEMMACLAW_BENCHMARK_MANIFEST_CONFIG") as
+    | AgentBenchmarkConfig
+    | undefined;
 
   const outputDir = config.outputDir ?? "benchmark-results";
   config.logDir = path.join(outputDir, ".logs");


### PR DESCRIPTION
## Summary
- keep real agent benchmarks container-only while using host Ollama instead of container-local model pulls
- start the benchmark gateway with foreground gateway run inside containers
- preserve parent run manifest/config hash across one-container-per-task slices
- restore host ownership for mounted benchmark artifacts after each container

## Verification
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm exec vitest run --config test/vitest/vitest.unit.config.ts src/gemmaclaw/benchmark/agent-container-guard.test.ts src/gemmaclaw/benchmark/agent-runner.test.ts --reporter=verbose
- pnpm check:changed
- manual E2E: pnpm benchmark agent --model gemma4:e4b --thinking low --run-id per-task-container-manifest-smoke --task gemma3n_json_extract --output-dir /home/frank/gemmaclaw-benchmarks/e2e-smoke/per-task-container-manifest --no-activity-timeout 600 --hard-cap 1800 --rerun