### PR TITLE
fix(benchmark): enforce gateway model selection in agent-mode container

### DIFF
--- a/scripts/benchmark-docker-entrypoint.sh
+++ b/scripts/benchmark-docker-entrypoint.sh
@@ -235,18 +235,29 @@ if [ "$IS_AGENT" = "1" ]; then
     "defaults": {
       "model": {
         "primary": "${EXPECTED_AGENT_MODEL}"
-      }
+      },
+      "llm": { "idleTimeoutSeconds": 0 }
     }
   },
   "models": {
     "providers": {
       "ollama": {
         "baseUrl": "${OLLAMA_TARGET}",
-        "api": "ollama"
+        "api": "ollama",
+        "models": [
+          {
+            "id": "${MODEL}",
+            "name": "${MODEL}",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          }
+        ]
       }
     }
   },
-  "sandbox": { "mode": "off" },
   "tools": { "exec": { "host": "gateway", "security": "full", "ask": "off" } }
 }
 GCEOF

--- a/scripts/benchmark-docker-entrypoint.sh
+++ b/scripts/benchmark-docker-entrypoint.sh
@@ -158,14 +158,44 @@ if [ "$IS_AGENT" = "1" ]; then
   echo "========================================"
   echo ""
 
+  # Determine which provider/backend the host caller asked for. Default is
+  # ollama. llama-cpp uses an OpenAI-compatible base URL, so the provider
+  # prefix differs.
+  BENCHMARK_BACKEND="ollama"
+  prev_was_backend=0
+  for arg in "$@"; do
+    if [ "$prev_was_backend" = "1" ]; then
+      BENCHMARK_BACKEND="$arg"
+      prev_was_backend=0
+      continue
+    fi
+    if [ "$arg" = "--backend" ]; then
+      prev_was_backend=1
+    fi
+  done
+  case "$BENCHMARK_BACKEND" in
+    ollama)         PROVIDER_PREFIX="ollama" ;;
+    llama-cpp)      PROVIDER_PREFIX="openai" ;;
+    openai-codex)   PROVIDER_PREFIX="openai-codex" ;;
+    *)              PROVIDER_PREFIX="$BENCHMARK_BACKEND" ;;
+  esac
+  EXPECTED_AGENT_MODEL="${PROVIDER_PREFIX}/${MODEL}"
+
   # Seed mock gog state
   echo "[agent] Seeding mock gog state..."
   python3 /app/scripts/benchmark/seed-mock-gog.py
 
-  # Start gemmaclaw gateway in the background
+  # Start gemmaclaw gateway in the background. The gemmaclaw binary resolves
+  # its state directory via GEMMACLAW_HOME first, then OPENCLAW_STATE_DIR,
+  # then ~/.gemmaclaw (see src/gemmaclaw/home.ts). OPENCLAW_HOME is NOT a
+  # supported override and was the source of an earlier bug where the gateway
+  # silently fell back to /root/.gemmaclaw/openclaw.json (default
+  # openai/gpt-5.4) instead of the entrypoint-written config.
   echo "[agent] Starting gemmaclaw gateway..."
-  export OPENCLAW_HOME="/root/.openclaw"
-  mkdir -p "$OPENCLAW_HOME"
+  export GEMMACLAW_HOME="/root/.gemmaclaw"
+  export OPENCLAW_STATE_DIR="$GEMMACLAW_HOME"
+  unset OPENCLAW_HOME
+  mkdir -p "$GEMMACLAW_HOME"
 
   # Determine Ollama URL. Real agent benchmarks must use host Ollama so each
   # per-task container starts clean without downloading or serving models.
@@ -177,21 +207,60 @@ if [ "$IS_AGENT" = "1" ]; then
   if curl -sf "$OLLAMA_TARGET/api/tags" >/dev/null 2>&1; then
     echo "[agent] Using host/configured Ollama at $OLLAMA_TARGET"
   else
-    echo "ERROR: Agent benchmarks require a reachable host/configured Ollama at $OLLAMA_TARGET"
-    echo "       Start host Ollama or pass OLLAMA_URL. Container-local Ollama is disabled for agent benchmarks."
+    echo "FAIL: Agent benchmarks require a reachable host/configured Ollama at $OLLAMA_TARGET"
+    echo "      Start host Ollama or pass OLLAMA_URL. Container-local Ollama is disabled for agent benchmarks."
     exit 1
   fi
 
-  # Create minimal gemmaclaw config
-  cat > "$OPENCLAW_HOME/openclaw.json" << GCEOF
+  # Verify the requested model exists on host Ollama before starting the
+  # gateway. A missing model is a hard fail; we do not fall back to a
+  # different model silently.
+  if [ "$BENCHMARK_BACKEND" = "ollama" ]; then
+    if ! curl -sf "$OLLAMA_TARGET/api/tags" \
+        | python3 -c "import json,sys; tags=json.load(sys.stdin).get('models',[]); names=[m.get('name','') for m in tags]; sys.exit(0 if '$MODEL' in names else 1)"; then
+      echo "FAIL: model $MODEL is not present on host Ollama at $OLLAMA_TARGET. Run 'ollama pull $MODEL' on the host before running benchmarks."
+      exit 1
+    fi
+    echo "[agent] Confirmed host Ollama has model: $MODEL"
+  fi
+
+  # Write the gateway config in the canonical schema. The OUTER gateway is
+  # primarily used by per-task agents for tools.exec.host=gateway, but its
+  # configured agent model is also the diagnostic source of truth for
+  # "what is this benchmark actually running?". Use the same schema the
+  # benchmark agent-runner writes for its isolated per-task config.
+  cat > "$GEMMACLAW_HOME/openclaw.json" << GCEOF
 {
-  "provider": "ollama",
-  "model": "$MODEL",
-  "ollamaUrl": "$OLLAMA_TARGET",
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "${EXPECTED_AGENT_MODEL}"
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "baseUrl": "${OLLAMA_TARGET}",
+        "api": "ollama"
+      }
+    }
+  },
   "sandbox": { "mode": "off" },
-  "tools": { "exec": { "host": "gateway" } },
-  "security": "full",
-  "ask": "off"
+  "tools": { "exec": { "host": "gateway", "security": "full", "ask": "off" } }
+}
+GCEOF
+
+  # Provide a minimal auth profile so the gateway can boot without prompting
+  # (the inner per-task agent writes its own isolated profile).
+  mkdir -p "$GEMMACLAW_HOME/agents/main/agent"
+  cat > "$GEMMACLAW_HOME/agents/main/agent/auth-profiles.json" << GCEOF
+{
+  "ollama:default": {
+    "type": "token",
+    "provider": "ollama",
+    "token": "benchmark-dummy-key"
+  }
 }
 GCEOF
 
@@ -203,25 +272,88 @@ GCEOF
 
   export GEMMACLAW_BIN="$GEMMACLAW_CMD"
 
+  GATEWAY_LOG="/tmp/gemmaclaw-gateway-startup.log"
+  : > "$GATEWAY_LOG"
+
   # Start gateway in the foreground inside the container. "gateway start" is
   # the service-manager command and is intentionally unavailable in benchmark
-  # containers.
-  $GEMMACLAW_CMD gateway run --port 3001 --bind loopback --auth none --allow-unconfigured &
+  # containers. Redirect stdout+stderr to a grep-able log file so the
+  # entrypoint can verify the resolved agent model after startup. (The
+  # container's own stdout already reports the entrypoint's echoes; the
+  # gateway's verbose log is not needed on container stdout.)
+  $GEMMACLAW_CMD gateway run --port 3001 --bind loopback --auth none --allow-unconfigured \
+    >> "$GATEWAY_LOG" 2>&1 &
   GATEWAY_PID=$!
 
   echo "[agent] Waiting for gateway..."
-  for i in $(seq 1 30); do
+  for i in $(seq 1 60); do
     if curl -s http://127.0.0.1:3001/healthz >/dev/null 2>&1; then
       echo "  Gateway ready after ${i}s"
       break
     fi
-    if [ "$i" -eq 30 ]; then
-      echo "ERROR: Gateway failed to start after 30s"
+    if [ "$i" -eq 60 ]; then
+      echo "FAIL: Gateway failed to start after 60s"
       cleanup_ollama
       exit 1
     fi
     sleep 1
   done
+
+  # Verify gateway picked up our config: the most recent "agent model:" log
+  # line must match EXPECTED_AGENT_MODEL. The gateway sometimes emits this
+  # line twice (once on initial start, once after a restart triggered by a
+  # config-recovery write). We use the LAST occurrence.
+  echo "[agent] Verifying gateway resolved agent model = $EXPECTED_AGENT_MODEL"
+  for i in $(seq 1 30); do
+    if grep -E "\[gateway\] agent model: " "$GATEWAY_LOG" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  ACTUAL_AGENT_MODEL="$(grep -E "\[gateway\] agent model: " "$GATEWAY_LOG" | tail -1 | sed -E 's/.*\[gateway\] agent model: //' | tr -d '\r' | awk '{print $1}')"
+  if [ -z "$ACTUAL_AGENT_MODEL" ]; then
+    echo "FAIL: Gateway did not log an 'agent model:' line within 30s. Gateway log:"
+    tail -40 "$GATEWAY_LOG"
+    kill $GATEWAY_PID 2>/dev/null || true
+    cleanup_ollama
+    exit 1
+  fi
+  if [ "$ACTUAL_AGENT_MODEL" != "$EXPECTED_AGENT_MODEL" ]; then
+    echo "FAIL: gateway agent model is '$ACTUAL_AGENT_MODEL', expected '$EXPECTED_AGENT_MODEL'."
+    echo "      Last 60 gateway log lines:"
+    tail -60 "$GATEWAY_LOG"
+    kill $GATEWAY_PID 2>/dev/null || true
+    cleanup_ollama
+    exit 1
+  fi
+  echo "[agent] PREFLIGHT OK: gateway agent model = $ACTUAL_AGENT_MODEL"
+  echo "[agent] Gateway log captured at $GATEWAY_LOG"
+
+  # Warm host Ollama so the model is loaded into VRAM before the agent
+  # dispatch starts. Without this, the first task can spend several minutes
+  # waiting for the model to load while the activity-based watchdog ticks.
+  if [ "$BENCHMARK_BACKEND" = "ollama" ]; then
+    echo "[agent] Warming host Ollama with $MODEL (keep_alive=30m)"
+    if ! curl -sf -X POST "$OLLAMA_TARGET/api/generate" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\":\"$MODEL\",\"prompt\":\"hi\",\"stream\":false,\"keep_alive\":\"30m\",\"options\":{\"num_predict\":1}}" \
+        >/tmp/ollama-warmup.json 2>&1; then
+      echo "FAIL: host Ollama warmup for $MODEL failed."
+      cat /tmp/ollama-warmup.json 2>/dev/null | tail -20
+      kill $GATEWAY_PID 2>/dev/null || true
+      cleanup_ollama
+      exit 1
+    fi
+    LOADED_MODELS="$(curl -sf "$OLLAMA_TARGET/api/ps" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(','.join(m.get('name','') for m in d.get('models',[])))" 2>/dev/null)"
+    if ! echo "$LOADED_MODELS" | tr ',' '\n' | grep -Fxq "$MODEL"; then
+      echo "FAIL: after warmup, host Ollama /api/ps does not show $MODEL loaded. Loaded: $LOADED_MODELS"
+      kill $GATEWAY_PID 2>/dev/null || true
+      cleanup_ollama
+      exit 1
+    fi
+    echo "[agent] Host Ollama loaded models: $LOADED_MODELS"
+  fi
 
   # Run the benchmark
   HAS_OUTPUT_DIR=0
@@ -240,6 +372,20 @@ GCEOF
   node --import tsx /app/src/gemmaclaw/benchmark/cli-standalone.ts "$@" "${EXTRA_ARGS[@]}"
 
   EXIT_CODE=$?
+
+  # Post-task verification: the host Ollama process must show the requested
+  # model loaded after the benchmark dispatch. If the dispatch silently
+  # routed to a different model, /api/ps will say so.
+  if [ "$BENCHMARK_BACKEND" = "ollama" ]; then
+    POST_LOADED="$(curl -sf "$OLLAMA_TARGET/api/ps" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(','.join(m.get('name','') for m in d.get('models',[])))" 2>/dev/null)"
+    if echo "$POST_LOADED" | tr ',' '\n' | grep -Fxq "$MODEL"; then
+      echo "[agent] POST-TASK OK: host Ollama still has $MODEL loaded ($POST_LOADED)"
+    else
+      echo "WARN: after benchmark, host Ollama /api/ps does not show $MODEL. Loaded: $POST_LOADED"
+      echo "      This may be a timing race (model unloaded after task finished) or a model-selection bug."
+    fi
+  fi
 
   # Cleanup
   kill $GATEWAY_PID 2>/dev/null || true

--- a/scripts/benchmark-docker-entrypoint.sh
+++ b/scripts/benchmark-docker-entrypoint.sh
@@ -9,6 +9,24 @@ echo ""
 export GEMMACLAW_BENCHMARK_CONTAINER=1
 OLLAMA_PID=""
 
+# Bounded curl probes. Every health/readiness probe in this entrypoint must use
+# explicit --connect-timeout and --max-time so a stuck network syscall (peer up
+# but not responding, kernel TCP backlog wedge, etc.) cannot pin a probe loop
+# forever. Codex eval observed a stuck `curl -s /healthz` in smoke container
+# 8672a8bfe1e2 on PR #139 before these bounds were added.
+HEALTH_CONNECT_TIMEOUT=2
+HEALTH_MAX_TIME=5
+WARMUP_CONNECT_TIMEOUT=10
+WARMUP_MAX_TIME=600
+
+probe_curl() {
+  curl -s --connect-timeout "$HEALTH_CONNECT_TIMEOUT" --max-time "$HEALTH_MAX_TIME" "$@"
+}
+
+probe_curl_fail() {
+  curl -sf --connect-timeout "$HEALTH_CONNECT_TIMEOUT" --max-time "$HEALTH_MAX_TIME" "$@"
+}
+
 # Extract --model from args, default gemma3:1b.
 MODEL="${BENCHMARK_MODEL:-gemma3:1b}"
 prev_was_model=0
@@ -41,12 +59,12 @@ if [ "$IS_AGENT" != "1" ]; then
 
   echo "[2/3] Waiting for Ollama..."
   for i in $(seq 1 60); do
-    if curl -s http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
+    if probe_curl http://127.0.0.1:11434/api/tags >/dev/null 2>&1; then
       echo "  Ollama ready after ${i}s"
       break
     fi
     if [ "$i" -eq 60 ]; then
-      echo "ERROR: Ollama failed to start after 60s"
+      echo "ERROR: Ollama failed to start after 60s (each probe bounded to ${HEALTH_MAX_TIME}s)"
       exit 1
     fi
     sleep 1
@@ -204,11 +222,12 @@ if [ "$IS_AGENT" = "1" ]; then
     OLLAMA_TARGET="http://host.docker.internal:11434"
   fi
 
-  if curl -sf "$OLLAMA_TARGET/api/tags" >/dev/null 2>&1; then
+  if probe_curl_fail "$OLLAMA_TARGET/api/tags" >/dev/null 2>&1; then
     echo "[agent] Using host/configured Ollama at $OLLAMA_TARGET"
   else
     echo "FAIL: Agent benchmarks require a reachable host/configured Ollama at $OLLAMA_TARGET"
     echo "      Start host Ollama or pass OLLAMA_URL. Container-local Ollama is disabled for agent benchmarks."
+    echo "      (probe bounded to ${HEALTH_MAX_TIME}s per attempt)"
     exit 1
   fi
 
@@ -216,9 +235,10 @@ if [ "$IS_AGENT" = "1" ]; then
   # gateway. A missing model is a hard fail; we do not fall back to a
   # different model silently.
   if [ "$BENCHMARK_BACKEND" = "ollama" ]; then
-    if ! curl -sf "$OLLAMA_TARGET/api/tags" \
+    if ! probe_curl_fail "$OLLAMA_TARGET/api/tags" \
         | python3 -c "import json,sys; tags=json.load(sys.stdin).get('models',[]); names=[m.get('name','') for m in tags]; sys.exit(0 if '$MODEL' in names else 1)"; then
       echo "FAIL: model $MODEL is not present on host Ollama at $OLLAMA_TARGET. Run 'ollama pull $MODEL' on the host before running benchmarks."
+      echo "      (api/tags probe bounded to ${HEALTH_MAX_TIME}s)"
       exit 1
     fi
     echo "[agent] Confirmed host Ollama has model: $MODEL"
@@ -296,19 +316,46 @@ GCEOF
     >> "$GATEWAY_LOG" 2>&1 &
   GATEWAY_PID=$!
 
-  echo "[agent] Waiting for gateway..."
+  # Bounded gateway readiness probe. Each curl is capped at ${HEALTH_MAX_TIME}s
+  # so a stuck network syscall cannot pin this loop forever (Codex eval found a
+  # stuck unbounded `curl -s /healthz` in smoke container 8672a8bfe1e2). Worst-
+  # case wall-clock for 60 attempts is ~60 * (HEALTH_MAX_TIME + 1)s.
+  echo "[agent] Waiting for gateway (probe timeout: connect=${HEALTH_CONNECT_TIMEOUT}s max=${HEALTH_MAX_TIME}s, attempts=60)..."
+  GATEWAY_READY=0
+  HEALTH_FAILS=0
   for i in $(seq 1 60); do
-    if curl -s http://127.0.0.1:3001/healthz >/dev/null 2>&1; then
-      echo "  Gateway ready after ${i}s"
+    HEALTH_BODY=""
+    if HEALTH_BODY="$(probe_curl http://127.0.0.1:3001/healthz 2>&1)"; then
+      echo "  Gateway ready after ${i}s (healthz: ${HEALTH_BODY:-<empty>})"
+      GATEWAY_READY=1
       break
     fi
-    if [ "$i" -eq 60 ]; then
-      echo "FAIL: Gateway failed to start after 60s"
-      cleanup_ollama
-      exit 1
+    HEALTH_FAILS=$((HEALTH_FAILS + 1))
+    # Loud diagnostic every 10 failed probes so the log shows progress instead
+    # of going silent if the gateway boots slowly or hangs.
+    if [ "$((HEALTH_FAILS % 10))" = "0" ]; then
+      echo "  [healthz probe] still waiting after ${i}s (curl rc!=0; last 5 gateway log lines):"
+      tail -5 "$GATEWAY_LOG" 2>/dev/null | sed 's/^/    /'
+      if ! kill -0 "$GATEWAY_PID" 2>/dev/null; then
+        echo "FAIL: Gateway PID $GATEWAY_PID is no longer alive after ${i}s"
+        echo "      Last 80 gateway log lines:"
+        tail -80 "$GATEWAY_LOG" 2>/dev/null | sed 's/^/    /'
+        cleanup_ollama
+        exit 1
+      fi
     fi
     sleep 1
   done
+  if [ "$GATEWAY_READY" != "1" ]; then
+    echo "FAIL: Gateway healthz did not respond after 60 bounded probes"
+    echo "      curl: --connect-timeout=${HEALTH_CONNECT_TIMEOUT}s --max-time=${HEALTH_MAX_TIME}s"
+    echo "      Gateway PID: $GATEWAY_PID (alive=$(kill -0 "$GATEWAY_PID" 2>/dev/null && echo yes || echo no))"
+    echo "      Last 120 gateway log lines:"
+    tail -120 "$GATEWAY_LOG" 2>/dev/null | sed 's/^/    /'
+    kill "$GATEWAY_PID" 2>/dev/null || true
+    cleanup_ollama
+    exit 1
+  fi
 
   # Verify gateway picked up our config: the most recent "agent model:" log
   # line must match EXPECTED_AGENT_MODEL. The gateway sometimes emits this
@@ -345,17 +392,21 @@ GCEOF
   # waiting for the model to load while the activity-based watchdog ticks.
   if [ "$BENCHMARK_BACKEND" = "ollama" ]; then
     echo "[agent] Warming host Ollama with $MODEL (keep_alive=30m)"
-    if ! curl -sf -X POST "$OLLAMA_TARGET/api/generate" \
+    # Warmup is a real generate call that may take a while when the model
+    # is cold-loading from disk. Bound it generously (--max-time 600) so a
+    # truly stuck call still fails instead of pinning the entrypoint.
+    if ! curl -sf --connect-timeout "$WARMUP_CONNECT_TIMEOUT" --max-time "$WARMUP_MAX_TIME" \
+        -X POST "$OLLAMA_TARGET/api/generate" \
         -H "Content-Type: application/json" \
         -d "{\"model\":\"$MODEL\",\"prompt\":\"hi\",\"stream\":false,\"keep_alive\":\"30m\",\"options\":{\"num_predict\":1}}" \
         >/tmp/ollama-warmup.json 2>&1; then
-      echo "FAIL: host Ollama warmup for $MODEL failed."
+      echo "FAIL: host Ollama warmup for $MODEL failed (curl bounded to ${WARMUP_MAX_TIME}s)."
       cat /tmp/ollama-warmup.json 2>/dev/null | tail -20
       kill $GATEWAY_PID 2>/dev/null || true
       cleanup_ollama
       exit 1
     fi
-    LOADED_MODELS="$(curl -sf "$OLLAMA_TARGET/api/ps" 2>/dev/null \
+    LOADED_MODELS="$(probe_curl_fail "$OLLAMA_TARGET/api/ps" 2>/dev/null \
       | python3 -c "import json,sys; d=json.load(sys.stdin); print(','.join(m.get('name','') for m in d.get('models',[])))" 2>/dev/null)"
     if ! echo "$LOADED_MODELS" | tr ',' '\n' | grep -Fxq "$MODEL"; then
       echo "FAIL: after warmup, host Ollama /api/ps does not show $MODEL loaded. Loaded: $LOADED_MODELS"
@@ -388,7 +439,7 @@ GCEOF
   # model loaded after the benchmark dispatch. If the dispatch silently
   # routed to a different model, /api/ps will say so.
   if [ "$BENCHMARK_BACKEND" = "ollama" ]; then
-    POST_LOADED="$(curl -sf "$OLLAMA_TARGET/api/ps" 2>/dev/null \
+    POST_LOADED="$(probe_curl_fail "$OLLAMA_TARGET/api/ps" 2>/dev/null \
       | python3 -c "import json,sys; d=json.load(sys.stdin); print(','.join(m.get('name','') for m in d.get('models',[])))" 2>/dev/null)"
     if echo "$POST_LOADED" | tr ',' '\n' | grep -Fxq "$MODEL"; then
       echo "[agent] POST-TASK OK: host Ollama still has $MODEL loaded ($POST_LOADED)"

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -1055,6 +1055,9 @@ export async function dispatchTask(
   }
 
   log(`  Dispatching: ${gemmaclawArgs.join(" ")} agent --local --session-id ${sessionId}`);
+  log(
+    `    Inner agent model: ${resolveAgentProviderPrefix(config.backend)}/${config.model} (from ${path.join(benchHome, ".openclaw/openclaw.json")})`,
+  );
 
   // Write dispatch command to log file for debugging
   const logDir = config.logDir ?? path.join(os.tmpdir(), "gemmaclaw-benchmark-logs");


### PR DESCRIPTION
## Summary

The benchmark agent-mode container was silently running the wrong model.
The entrypoint set `OPENCLAW_HOME=/root/.openclaw` and wrote the gateway
config there, but `resolveGemmaclawStateDir()` (src/gemmaclaw/home.ts)
honors only `GEMMACLAW_HOME` -> `OPENCLAW_STATE_DIR` -> `~/.gemmaclaw`.
`OPENCLAW_HOME` is **not** a recognized override. The gateway therefore
fell back to a default `/root/.gemmaclaw/openclaw.json` and reported
`agent model: openai/gpt-5.4` even when the host was launching a Gemma
benchmark.

This was the proximate cause of the 2026-05-10 Q4 client_visit_logistics
rerun being stopped after audit found:
- container gateway log line: `[gateway] agent model: openai/gpt-5.4`
- host `/api/ps` showed only `qwen3.6:35b` resident, not gemma4:31b
- inner dispatch had no explicit `--model` (the inner agent CLI does not
  accept one; the model comes from config)

## What changed

`scripts/benchmark-docker-entrypoint.sh` (agent-mode block):
- **Set `GEMMACLAW_HOME=/root/.gemmaclaw` and `OPENCLAW_STATE_DIR`**, unset
  the legacy `OPENCLAW_HOME`. Now `resolveGemmaclawStateDir()` returns the
  path the entrypoint actually wrote to.
- **Write the config in canonical schema** (`agents.defaults.model.primary`
  + `models.providers.ollama.{baseUrl,api,models[]}`). The previous shape
  used a legacy top-level `{provider, model, ollamaUrl, sandbox}` that the
  schema validator rejects (`sandbox` removed; `models[]` required).
- **Verify host Ollama has the requested model** in `/api/tags` before
  starting the gateway. Hard `FAIL: model X is not present` otherwise.
- **Capture gateway stdout/stderr** to `/tmp/gemmaclaw-gateway-startup.log`
  and assert the resolved `[gateway] agent model: <ref>` line matches the
  expected `provider/model`. Hard `FAIL: gateway agent model is X,
  expected Y` otherwise.
- **Warm host Ollama** via `/api/generate keep_alive=30m` so the model is
  resident in VRAM before the harness dispatches the first task; verify
  `/api/ps` reports it loaded.
- **Post-task verification** logs whether `/api/ps` still has the model
  loaded (warn-only since Ollama may unload after the task finishes).

`src/gemmaclaw/benchmark/agent-runner.ts`:
- Log the inner per-task agent's expected `provider/model` and the path
  to its isolated config so the diagnostic chain is fully observable from
  container output (`Inner agent model: ollama/gemma4:31b (from
  /tmp/.../openclaw.json)`).

## Smoke test

Build cached image, mount patched entrypoint, run client_visit_logistics
with `--hard-cap 30 --no-activity-timeout 30` (intentionally short to
exit quickly):

```
[agent] Confirmed host Ollama has model: gemma4:31b
[agent] Waiting for gateway... Gateway ready after 7s
[agent] Verifying gateway resolved agent model = ollama/gemma4:31b
[agent] PREFLIGHT OK: gateway agent model = ollama/gemma4:31b
[agent] Warming host Ollama with gemma4:31b (keep_alive=30m)
[agent] Host Ollama loaded models: gemma4:31b
  Dispatching: node /app/gemmaclaw.mjs agent --local --session-id ...
    Inner agent model: ollama/gemma4:31b (from /tmp/.../openclaw.json)
[agent] POST-TASK OK: host Ollama still has gemma4:31b loaded (gemma4:31b)
```

## Test plan

- [x] `pnpm test src/gemmaclaw/benchmark/agent-runner.test.ts` (23 tests)
- [x] `pnpm check:changed` (78 tests across 7 files: lint, typecheck,
      import-cycles, webhook/pairing guards, agent-runner)
- [x] Manual smoke in container: gateway model preflight, ollama warmup,
      and post-task /api/ps assertion all printed expected output.
- [ ] Wait for CI green, then admin-merge.
- [ ] After merge, sync the Q4 worktree to merged HEAD and rerun
      `run-task.sh client_visit_logistics` end-to-end with the long
      hard-cap to confirm the model selection chain on a real task run.