### PR TITLE
fix(benchmark): detect GPU via Ollama host when running in container

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -496,11 +496,38 @@ export async function collectMetadata(
     /* ollama not available or model not loaded */
   }
 
+  // When running inside a Docker container (no local GPU passthrough) but using
+  // the Ollama backend, the host Ollama server is doing GPU-backed inference.
+  // Query /api/ps to detect actual GPU VRAM in use so the manifest accurately
+  // records that this was a GPU-backed run.
+  let effectiveHardware = hardware;
+  if (!hardware.gpu.detected && config.ollamaUrl) {
+    try {
+      const psResp = await httpGet(`${config.ollamaUrl}/api/ps`, 10_000);
+      const ps = JSON.parse(psResp) as { models?: { size_vram?: number }[] };
+      const totalVram = (ps.models ?? []).reduce((sum, m) => sum + (m.size_vram ?? 0), 0);
+      if (totalVram > 0) {
+        effectiveHardware = {
+          ...hardware,
+          gpu: {
+            detected: true,
+            nvidia: true,
+            apple: false,
+            name: "GPU (via Ollama host)",
+            vramBytes: totalVram,
+          },
+        };
+      }
+    } catch {
+      /* ollama ps not available or container not using ollama host */
+    }
+  }
+
   return {
     model: config.model,
     quant: config.quant,
     thinkingLevel: config.thinkingLevel,
-    hardware,
+    hardware: effectiveHardware,
     gatewayUrl: config.gatewayUrl,
     ollamaUrl: config.ollamaUrl,
     gitSha,

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -518,7 +518,12 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
   } else {
     console.log(`Ollama:   ${config.ollamaUrl}`);
   }
-  console.log(`GPU:      ${hardware.gpu.name ?? "not detected"}`);
+  const gpuDisplay =
+    hardware.gpu.name ??
+    (config.backend === "ollama" && !hardware.gpu.detected
+      ? "via Ollama host (detect after run)"
+      : "not detected");
+  console.log(`GPU:      ${gpuDisplay}`);
   console.log(`Output:   ${outputDir}`);
   if (config.mock) {
     console.log(`Mode:     MOCK (no real model)`);


### PR DESCRIPTION
## Summary

- When the benchmark runs inside a Docker container without GPU passthrough, `hardware.gpu.detected` was always `false` even though inference was GPU-backed via the host Ollama server
- In `collectMetadata`, when no local GPU is detected and an Ollama URL is configured, query `/api/ps` on the Ollama host and use `size_vram` from the loaded model to populate `hardware.gpu` as detected
- The `name` field is set to `"GPU (via Ollama host)"` to make container/host boundary explicit in manifests and site output
- Update the console header in `cli-standalone` to say `"via Ollama host (detect after run)"` instead of `"not detected"` for Ollama-backend runs without local GPU

## Test plan

- [x] `pnpm tsgo --singleThreaded --checkers 1` passes (no type errors)
- [x] All 78 unit tests in `vitest.unit.config.ts` pass (including agent-runner.test.ts)
- [x] Full test suite (505 tests, 70 shards) passes