### PR TITLE
fix(benchmark): record per-task quality inspection

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -397,6 +397,14 @@ describe("per-task benchmark artifacts", () => {
     // After a clean mock run the started marker must be cleared so a future
     // audit can distinguish "ran to completion" from "killed mid-flight".
     expect(fs.existsSync(path.join(runDir, "tasks/email_summarize/started.json"))).toBe(false);
+    const taskArtifact = JSON.parse(
+      fs.readFileSync(path.join(runDir, "tasks/email_summarize/result.json"), "utf-8"),
+    ) as { result: AgentTaskResult };
+    const taskResult = taskArtifact.result;
+    expect(taskResult.qualityInspection?.schemaVersion).toBe(1);
+    expect(taskResult.qualityInspection?.issues.map((issue) => issue.kind)).toContain(
+      "llm_judge_missing",
+    );
   });
 
   it("preserves a leftover started.json when writeTaskArtifact never runs (silent kill semantics)", () => {
@@ -449,9 +457,14 @@ describe("per-task benchmark artifacts", () => {
     const withActivity = computeConfigHash({ ...config, noActivityTimeoutSeconds: 600 });
     const withHardCap = computeConfigHash({ ...config, hardCapSeconds: 28_800 });
     const withValidationOff = computeConfigHash({ ...config, validatePerTask: false });
+    const withQualityInspectionOff = computeConfigHash({
+      ...config,
+      qualityInspectPerTask: false,
+    });
     expect(baseHash).not.toBe(withActivity);
     expect(baseHash).not.toBe(withHardCap);
     expect(baseHash).not.toBe(withValidationOff);
+    expect(baseHash).not.toBe(withQualityInspectionOff);
   });
 
   it("assembles aggregate outputs from saved per-task artifacts", () => {

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -32,8 +32,11 @@ import {
   type AgentBenchmarkTask,
 } from "./agent-tasks.js";
 import {
+  inspectTaskQuality,
+  summarizeQualityInspection,
   summarizeValidation,
   validateTaskArtifact,
+  type QualityInspectionResult,
   type ValidationResult,
 } from "./agent-validator.js";
 
@@ -89,6 +92,12 @@ export type AgentBenchmarkConfig = {
   hardCapSeconds?: number;
   /** When true, run the validation gate after each task. Defaults to true. */
   validatePerTask?: boolean;
+  /**
+   * When true, run a lightweight quality/readiness inspection after each task.
+   * This records score-readiness warnings before the next task is dispatched.
+   * Defaults to true.
+   */
+  qualityInspectPerTask?: boolean;
   /**
    * When true and per-task validation produces a block-severity issue, the
    * runner reruns the task once before recording a final failure. Defaults
@@ -156,6 +165,11 @@ export type AgentTaskResult = {
    * site generator can surface validation issues without rerunning the gate.
    */
   validation?: ValidationResult;
+  /**
+   * Lightweight score-readiness inspection for this task. This is not the LLM
+   * judge score; it catches malformed artifacts/tool usage before publication.
+   */
+  qualityInspection?: QualityInspectionResult;
   /** Number of times this task was rerun by the validation gate (0 = first try). */
   validationRerunCount?: number;
 };
@@ -319,6 +333,7 @@ export function computeConfigHash(config: AgentBenchmarkConfig): string {
     noActivityTimeoutSeconds: config.noActivityTimeoutSeconds ?? null,
     hardCapSeconds: config.hardCapSeconds ?? null,
     validatePerTask: config.validatePerTask !== false,
+    qualityInspectPerTask: config.qualityInspectPerTask !== false,
     validationRerunOnFail: config.validationRerunOnFail !== false,
     ollamaUrl: config.ollamaUrl,
     quant: config.quant,
@@ -1833,6 +1848,7 @@ export async function runAgentBenchmark(
   // these flags) get the new safety net automatically. Pass
   // `validatePerTask: false` to opt out for synthetic / unit-test runs.
   const validatePerTask = config.validatePerTask !== false;
+  const qualityInspectPerTask = config.qualityInspectPerTask !== false;
   const validationRerunOnFail = config.validationRerunOnFail !== false;
 
   /**
@@ -1940,8 +1956,9 @@ export async function runAgentBenchmark(
     copyIfExists(attempt.sessionJsonlPath, taskSessionCopyPath(runDir, task.id));
     copyIfExists(attempt.trajectoryJsonlPath, taskTrajectoryCopyPath(runDir, task.id));
 
+    let validation: ValidationResult | undefined;
     if (validatePerTask) {
-      let validation = validateTaskArtifact({
+      validation = validateTaskArtifact({
         runDir,
         task,
         result: attempt.taskResult,
@@ -1982,6 +1999,19 @@ export async function runAgentBenchmark(
         attempt.taskResult.completionStatus = "error";
         attempt.taskResult.error = `validation_failed: ${summarizeValidation(validation)}`;
       }
+      writeTaskArtifact(runDir, runId, configHash, attempt.taskResult);
+    }
+
+    if (qualityInspectPerTask) {
+      const qualityInspection = inspectTaskQuality({
+        runDir,
+        task,
+        result: attempt.taskResult,
+        validation,
+        llmJudgePresent: false,
+      });
+      attempt.taskResult.qualityInspection = qualityInspection;
+      log(`  quality: ${summarizeQualityInspection(qualityInspection)}`);
       writeTaskArtifact(runDir, runId, configHash, attempt.taskResult);
     }
 

--- a/src/gemmaclaw/benchmark/agent-validator.test.ts
+++ b/src/gemmaclaw/benchmark/agent-validator.test.ts
@@ -8,7 +8,9 @@ import {
   HOST_OAUTH_MARKERS,
   HOST_PATH_MARKERS,
   REAL_ACCOUNT_MARKERS,
+  inspectTaskQuality,
   summarizeValidation,
+  summarizeQualityInspection,
   validateTaskArtifact,
 } from "./agent-validator.js";
 
@@ -204,5 +206,98 @@ describe("validateTaskArtifact", () => {
     expect(REAL_ACCOUNT_MARKERS).toContain("wsfccorp@gmail.com");
     expect(HOST_OAUTH_MARKERS.length).toBeGreaterThan(0);
     expect(HOST_PATH_MARKERS).toContain("/home/frank/.config/gogcli/state");
+  });
+});
+
+describe("inspectTaskQuality", () => {
+  it("records score-readiness info when an LLM judge is missing", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, {
+      transcript: "[user] Check inbox\n[assistant] You have 3 emails.",
+    });
+    const validation = validateTaskArtifact({
+      runDir,
+      task: baseTask,
+      result: makeResult(),
+      fakeGogLogPath: path.join(runDir, "fake-gog.log"),
+    });
+
+    const inspection = inspectTaskQuality({
+      runDir,
+      task: baseTask,
+      result: makeResult(),
+      validation,
+      llmJudgePresent: false,
+      inspectedAt: "2026-05-10T19:40:00.000Z",
+    });
+
+    expect(inspection.publishable).toBe(false);
+    expect(inspection.issues.map((issue) => issue.kind)).toContain("llm_judge_missing");
+    expect(summarizeQualityInspection(inspection)).toContain("info:llm_judge_missing");
+  });
+
+  it("flags malformed tool usage for critical post-task review", () => {
+    const runDir = freshRunDir();
+    const transcript = [
+      '[tool_call] exec {"command":"gog calendar create \\"Backend\\" \\"2026-05-13T10:00:00\\""}',
+      '[tool_result] {"id":"evt_1","calendarId":"Backend","summary":"2026-05-13T10:00:00","start":null,"end":null}',
+      "[tool_result] {}",
+      "(Command exited with code 3)",
+    ].join("\n");
+    writeTaskArtifacts(runDir, baseTask.id, { transcript });
+    const result = makeResult({
+      conversation: [
+        { role: "user", content: "Schedule meetings" },
+        {
+          role: "tool_call",
+          toolName: "exec",
+          toolArgs: { command: 'gog tasks create --notes "Budget: $1200"' },
+          content: '{"command":"gog tasks create --notes \\"Budget: $1200\\""}',
+        },
+        { role: "tool_result", content: transcript },
+        { role: "assistant", content: "Done." },
+      ],
+    });
+
+    const inspection = inspectTaskQuality({
+      runDir,
+      task: baseTask,
+      result,
+      validation: { valid: true, issues: [] },
+      llmJudgePresent: true,
+      inspectedAt: "2026-05-10T19:41:00.000Z",
+    });
+
+    expect(inspection.issues.map((issue) => issue.kind)).toEqual(
+      expect.arrayContaining([
+        "tool_command_failed",
+        "malformed_calendar_output",
+        "shell_dollar_expansion_risk",
+      ]),
+    );
+    expect(inspection.publishable).toBe(true);
+  });
+
+  it("blocks publication when validation blocked or task did not complete", () => {
+    const runDir = freshRunDir();
+    writeTaskArtifacts(runDir, baseTask.id, { transcript: "" });
+    const validation = validateTaskArtifact({
+      runDir,
+      task: baseTask,
+      result: makeResult({ conversation: [], completionStatus: "error" }),
+    });
+
+    const inspection = inspectTaskQuality({
+      runDir,
+      task: baseTask,
+      result: makeResult({ conversation: [], completionStatus: "error" }),
+      validation,
+      llmJudgePresent: true,
+    });
+
+    expect(inspection.publishable).toBe(false);
+    expect(inspection.issues.map((issue) => issue.kind)).toEqual(
+      expect.arrayContaining(["validation_blocked", "task_not_completed"]),
+    );
   });
 });

--- a/src/gemmaclaw/benchmark/agent-validator.ts
+++ b/src/gemmaclaw/benchmark/agent-validator.ts
@@ -75,6 +75,31 @@ export type ValidationResult = {
   deterministicScore?: ReturnType<typeof evaluateDeterministicAgentTaskConversation>;
 };
 
+export type QualityInspectionSeverity = "block" | "warn" | "info";
+
+export type QualityInspectionIssueKind =
+  | "validation_blocked"
+  | "task_not_completed"
+  | "llm_judge_missing"
+  | "tool_command_failed"
+  | "malformed_calendar_output"
+  | "shell_dollar_expansion_risk"
+  | "deterministic_score_low";
+
+export type QualityInspectionIssue = {
+  kind: QualityInspectionIssueKind;
+  severity: QualityInspectionSeverity;
+  message: string;
+  evidence?: string;
+};
+
+export type QualityInspectionResult = {
+  schemaVersion: 1;
+  inspectedAt: string;
+  publishable: boolean;
+  issues: QualityInspectionIssue[];
+};
+
 /**
  * Markers that indicate real-user contamination in a benchmark transcript.
  * Frank's real Gmail addresses, the corporate sender pattern, and the
@@ -386,6 +411,172 @@ export function validateTaskArtifact(input: ValidateTaskArtifactInput): Validati
 export function summarizeValidation(result: ValidationResult): string {
   if (result.issues.length === 0) {
     return "validation: ok";
+  }
+  return result.issues
+    .map((issue) => `${issue.severity}:${issue.kind}:${issue.message}`)
+    .join("; ");
+}
+
+function pushQualityIssue(issues: QualityInspectionIssue[], issue: QualityInspectionIssue): void {
+  const duplicate = issues.some(
+    (existing) => existing.kind === issue.kind && existing.message === issue.message,
+  );
+  if (!duplicate) {
+    issues.push(issue);
+  }
+}
+
+function transcriptContainsCommandFailure(transcript: string): string | undefined {
+  const match = transcript.match(/\(Command exited with code [1-9][0-9]*\)/);
+  if (!match) {
+    return undefined;
+  }
+  const start = Math.max(0, match.index! - 160);
+  const end = Math.min(transcript.length, match.index! + match[0].length + 160);
+  return clip(transcript.slice(start, end));
+}
+
+function transcriptContainsMalformedCalendarOutput(transcript: string): string | undefined {
+  const patterns = [
+    /"calendarId":\s*"[^"]+"\s*,\s*"summary":\s*"[^"]*"\s*,[\s\S]{0,500}?"start":\s*null\s*,\s*"end":\s*null/,
+    /"start":\s*null\s*,\s*"end":\s*null/,
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(transcript);
+    if (!match) {
+      continue;
+    }
+    const start = Math.max(0, match.index - 160);
+    const end = Math.min(transcript.length, match.index + match[0].length + 160);
+    return clip(transcript.slice(start, end));
+  }
+  return undefined;
+}
+
+function transcriptContainsShellDollarExpansionRisk(
+  conversation: ConversationTurn[],
+): string | undefined {
+  for (const turn of conversation) {
+    if (turn.role !== "tool_call") {
+      continue;
+    }
+    const body = `${turn.content}\n${JSON.stringify(turn.toolArgs ?? {})}`;
+    const match = body.match(/\$\d/);
+    if (!match) {
+      continue;
+    }
+    const start = Math.max(0, match.index! - 120);
+    const end = Math.min(body.length, match.index! + match[0].length + 120);
+    return clip(body.slice(start, end));
+  }
+  return undefined;
+}
+
+/**
+ * Lightweight per-task quality inspection for score readiness.
+ *
+ * This is not a replacement for the LLM judge. It is a durable stop-and-look
+ * gate between "the harness produced an artifact" and "this artifact is safe
+ * to carry forward into evaluation/site publishing." It records model-quality
+ * warnings without rerunning to improve scores, while still blocking harness
+ * and artifact failures that would make a score misleading.
+ */
+export function inspectTaskQuality(input: {
+  runDir: string;
+  task: AgentBenchmarkTask;
+  result: ValidatableTaskResult;
+  validation?: ValidationResult;
+  llmJudgePresent?: boolean;
+  inspectedAt?: string;
+}): QualityInspectionResult {
+  const { runDir, task, result, validation } = input;
+  const issues: QualityInspectionIssue[] = [];
+  const taskDir = path.join(runDir, "tasks", task.id);
+  const transcript =
+    readIfExists(path.join(taskDir, "transcript.txt")) || transcriptText(result.conversation ?? []);
+
+  if (validation && !validation.valid) {
+    pushQualityIssue(issues, {
+      kind: "validation_blocked",
+      severity: "block",
+      message: "Per-task validation failed; this result must not be evaluated or published.",
+      evidence: summarizeValidation(validation),
+    });
+  }
+
+  if (result.completionStatus !== "completed") {
+    pushQualityIssue(issues, {
+      kind: "task_not_completed",
+      severity: "block",
+      message: `Task completionStatus is ${result.completionStatus}; inspect before scoring.`,
+      evidence: result.error,
+    });
+  }
+
+  if (!input.llmJudgePresent) {
+    pushQualityIssue(issues, {
+      kind: "llm_judge_missing",
+      severity: "info",
+      message:
+        "No LLM judge score is attached yet. This artifact is runnable, but not a publishable evaluated result.",
+    });
+  }
+
+  const commandFailure = transcriptContainsCommandFailure(transcript);
+  if (commandFailure) {
+    pushQualityIssue(issues, {
+      kind: "tool_command_failed",
+      severity: "warn",
+      message:
+        "A tool command exited nonzero inside a completed task. Preserve as model behavior unless it is a harness bug, but grade critically.",
+      evidence: commandFailure,
+    });
+  }
+
+  const malformedCalendar = transcriptContainsMalformedCalendarOutput(transcript);
+  if (malformedCalendar) {
+    pushQualityIssue(issues, {
+      kind: "malformed_calendar_output",
+      severity: "warn",
+      message:
+        "A calendar tool result has null start/end fields, usually caused by malformed command usage. Grade critically and inspect for harness ambiguity.",
+      evidence: malformedCalendar,
+    });
+  }
+
+  const shellDollarRisk = transcriptContainsShellDollarExpansionRisk(result.conversation ?? []);
+  if (shellDollarRisk) {
+    pushQualityIssue(issues, {
+      kind: "shell_dollar_expansion_risk",
+      severity: "warn",
+      message:
+        "A shell-exec tool call contains an unescaped dollar-number pattern. Shell expansion can corrupt benchmark side effects such as $1200 -> 200.",
+      evidence: shellDollarRisk,
+    });
+  }
+
+  const deterministicScore = validation?.deterministicScore;
+  if (deterministicScore && !deterministicScore.passed) {
+    pushQualityIssue(issues, {
+      kind: "deterministic_score_low",
+      severity: "warn",
+      message: `Deterministic scorer failed: ${deterministicScore.score}/${deterministicScore.maxScore}.`,
+      evidence: deterministicScore.details,
+    });
+  }
+
+  const hasBlocker = issues.some((issue) => issue.severity === "block");
+  return {
+    schemaVersion: 1,
+    inspectedAt: input.inspectedAt ?? new Date().toISOString(),
+    publishable: !hasBlocker && Boolean(input.llmJudgePresent),
+    issues,
+  };
+}
+
+export function summarizeQualityInspection(result: QualityInspectionResult): string {
+  if (result.issues.length === 0) {
+    return "quality: ok";
   }
   return result.issues
     .map((issue) => `${issue.severity}:${issue.kind}:${issue.message}`)

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -114,6 +114,10 @@ function parseArgs(argv: string[]) {
       opts.validatePerTask = true;
     } else if (arg === "--no-validate-per-task") {
       opts.validatePerTask = false;
+    } else if (arg === "--quality-inspect-per-task") {
+      opts.qualityInspectPerTask = true;
+    } else if (arg === "--no-quality-inspect-per-task") {
+      opts.qualityInspectPerTask = false;
     } else if (arg === "--validation-rerun-on-fail") {
       opts.validationRerunOnFail = true;
     } else if (arg === "--no-validation-rerun-on-fail") {
@@ -173,6 +177,7 @@ function buildAgentBenchmarkConfig(
       : undefined,
     hardCapSeconds: opts.hardCap ? Number.parseInt(String(opts.hardCap), 10) : undefined,
     validatePerTask: opts.validatePerTask !== false,
+    qualityInspectPerTask: opts.qualityInspectPerTask !== false,
     validationRerunOnFail: opts.validationRerunOnFail !== false,
     filter: (opts.task as string) ?? (opts.filter as string) ?? undefined,
     mock: Boolean(opts.mock),
@@ -347,6 +352,7 @@ async function runAgentModeInDocker(opts: Record<string, string | boolean>): Pro
         : undefined,
       hardCapSeconds: opts.hardCap ? Number.parseInt(String(opts.hardCap), 10) : undefined,
       validatePerTask: opts.validatePerTask !== false,
+      qualityInspectPerTask: opts.qualityInspectPerTask !== false,
       validationRerunOnFail: opts.validationRerunOnFail !== false,
       filter: opts.task ? String(opts.task) : (opts.filter as string | undefined),
       mock: false,
@@ -394,6 +400,7 @@ Agent Mode Options:
   --no-activity-timeout <sec>  Kill the task if no useful agent activity (stdout/stderr/JSONL/trajectory) for N seconds (default: 600)
   --hard-cap <sec>       Hard wall-clock ceiling per task as a runaway guard (default: 28800 = 8h)
   --validate-per-task    Run the per-task validation gate after each task (default: on). Use --no-validate-per-task to opt out.
+  --quality-inspect-per-task  Record score-readiness inspection after each task (default: on). Use --no-quality-inspect-per-task to opt out.
   --validation-rerun-on-fail  Rerun a task once if validation produces a block-severity issue (default: on)
   --judge-model <name>   Model for LLM judge (default: same as test model)
   --mock                 Mock mode: no real model, deterministic pass/fail


### PR DESCRIPTION
## Summary

- add a per-task benchmark quality inspection artifact after validation
- record warnings for failed tool commands, malformed calendar outputs, shell dollar expansion risks, low deterministic score, missing judge score, and incomplete runs
- add CLI flags to keep the new inspection on by default while allowing explicit opt-out for synthetic runs

## Validation

- `pnpm test src/gemmaclaw/benchmark/agent-validator.test.ts src/gemmaclaw/benchmark/agent-runner.test.ts`
- `pnpm check:changed`
