### PR TITLE
fix(benchmark): kill child on session provider error to prevent stuck tasks

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -7,6 +7,7 @@ import {
   clearTaskStartedMarker,
   computeConfigHash,
   extractAssistantResponseFromStdout,
+  extractSessionProviderError,
   isAgentBackendType,
   loadTaskArtifacts,
   parseSessionEntry,
@@ -548,5 +549,117 @@ describe("per-task benchmark artifacts", () => {
       outputDir,
     );
     expect(assembled.tasks.map((entry) => entry.task.id)).toEqual([task.id, secondTask.id]);
+  });
+});
+
+describe("extractSessionProviderError", () => {
+  it("returns errorMessage for an assistant message with stopReason=error", () => {
+    const entry = {
+      type: "message",
+      timestamp: "2026-05-10T19:59:20.876Z",
+      message: {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        api: "ollama",
+        provider: "ollama",
+        model: "gemma4:31b",
+        errorMessage: "fetch failed | Headers Timeout Error",
+      },
+    };
+    expect(extractSessionProviderError(entry)).toBe("fetch failed | Headers Timeout Error");
+  });
+
+  it("returns errorMessage when role/stopReason are at the top level (no nested message)", () => {
+    const entry = {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage: "connection reset",
+    };
+    expect(extractSessionProviderError(entry)).toBe("connection reset");
+  });
+
+  it("returns undefined for a normal assistant message without stopReason=error", () => {
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is my response." }],
+        stopReason: "end_turn",
+      },
+    };
+    expect(extractSessionProviderError(entry)).toBeUndefined();
+  });
+
+  it("returns undefined when stopReason is not error", () => {
+    const entry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [],
+        stopReason: "max_tokens",
+        errorMessage: "something",
+      },
+    };
+    expect(extractSessionProviderError(entry)).toBeUndefined();
+  });
+
+  it("returns undefined when errorMessage is missing or empty", () => {
+    expect(
+      extractSessionProviderError({
+        message: { role: "assistant", content: [], stopReason: "error", errorMessage: "" },
+      }),
+    ).toBeUndefined();
+    expect(
+      extractSessionProviderError({
+        message: { role: "assistant", content: [], stopReason: "error" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for user messages", () => {
+    const entry = {
+      type: "message",
+      message: {
+        role: "user",
+        content: "hello",
+        stopReason: "error",
+        errorMessage: "some error",
+      },
+    };
+    expect(extractSessionProviderError(entry)).toBeUndefined();
+  });
+
+  it("returns undefined for non-message entries", () => {
+    expect(extractSessionProviderError({ type: "session.started" })).toBeUndefined();
+    expect(extractSessionProviderError(null)).toBeUndefined();
+    expect(extractSessionProviderError("string")).toBeUndefined();
+  });
+
+  it("handles provider error across full session JSONL with recovery clearing the error", () => {
+    // Simulates: error entry followed by a successful assistant turn
+    const errorEntry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "fetch failed | Headers Timeout Error",
+      },
+    };
+    const successEntry = {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Recovered response." }],
+        stopReason: "end_turn",
+      },
+    };
+    expect(extractSessionProviderError(errorEntry)).toBe("fetch failed | Headers Timeout Error");
+    // Successful turn produces assistant turns — caller resets the error window.
+    expect(parseSessionEntry(successEntry).some((t) => t.role === "assistant")).toBe(true);
+    // Error entry produces no conversation turns.
+    expect(parseSessionEntry(errorEntry)).toEqual([]);
   });
 });

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -992,6 +992,37 @@ export function extractAssistantResponseFromStdout(stdout: string): string | und
   return text.length > 0 ? text : undefined;
 }
 
+/**
+ * Extract a provider-level error from a session JSONL entry.
+ *
+ * OpenClaw records LLM API failures (e.g. "fetch failed | Headers Timeout
+ * Error") as assistant messages with stopReason="error" and an errorMessage
+ * field. The content array is empty so parseSessionEntry produces no turns,
+ * making the polling loop oblivious to the failure. After recording this error
+ * the embedded agent may keep running (retrying the provider call) and
+ * continuously emit stderr that resets the activity timer, causing the
+ * no-activity watchdog to never fire.
+ *
+ * Returns the errorMessage string when the entry is an assistant message with
+ * stopReason="error" and a non-empty errorMessage; returns undefined otherwise.
+ */
+export function extractSessionProviderError(entry: unknown): string | undefined {
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+  const msg = isRecord(entry.message) ? entry.message : entry;
+  if (!isRecord(msg)) {
+    return undefined;
+  }
+  const role = typeof msg.role === "string" ? msg.role : "";
+  const stopReason = typeof msg.stopReason === "string" ? msg.stopReason : "";
+  const errorMessage = typeof msg.errorMessage === "string" ? msg.errorMessage : "";
+  if (role === "assistant" && stopReason === "error" && errorMessage.length > 0) {
+    return errorMessage;
+  }
+  return undefined;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -1360,6 +1391,17 @@ export async function dispatchTask(
     let lastActivityMs = Date.now();
     const conversation: ConversationTurn[] = [];
 
+    // Provider-error recovery tracking. When the session JSONL records an
+    // assistant message with stopReason="error" (e.g. "fetch failed | Headers
+    // Timeout Error"), the embedded agent may keep running and emitting stderr
+    // retries that prevent the no-activity watchdog from firing. Track the
+    // first such error so we can enforce a bounded recovery window.
+    // Grace period: 3 minutes (180 s). If no new successful assistant turn
+    // appears within that window after a provider error, we kill the child.
+    let lastProviderErrorMs: number | null = null;
+    let lastProviderErrorMsg = "";
+    const providerErrorRecoveryMs = 180_000; // 3 min
+
     const parseJsonl = () => {
       if (!fs.existsSync(jsonlPath)) {
         return;
@@ -1372,14 +1414,33 @@ export async function dispatchTask(
           lastIoMs = Date.now();
           lastActivityMs = Date.now();
           conversation.length = 0;
+          let latestProviderError: string | undefined;
           for (const line of lines) {
             try {
               const entry = JSON.parse(line);
               const turns = parseSessionEntry(entry);
-              conversation.push(...turns);
+              if (turns.length > 0) {
+                conversation.push(...turns);
+                // A new successful assistant turn clears the provider-error
+                // recovery window — the agent recovered.
+                if (turns.some((t) => t.role === "assistant" || t.role === "tool_call")) {
+                  lastProviderErrorMs = null;
+                  lastProviderErrorMsg = "";
+                  latestProviderError = undefined;
+                }
+              } else {
+                const providerErr = extractSessionProviderError(entry);
+                if (providerErr) {
+                  latestProviderError = providerErr;
+                }
+              }
             } catch {
               // Skip unparseable lines
             }
+          }
+          if (latestProviderError && lastProviderErrorMs === null) {
+            lastProviderErrorMs = Date.now();
+            lastProviderErrorMsg = latestProviderError;
           }
         }
       } catch {
@@ -1478,6 +1539,30 @@ export async function dispatchTask(
           trajectoryJsonlPath: trajectoryPath,
           fakeGogLogPath,
         };
+      }
+
+      // (3) Provider-error recovery: when the session JSONL records an
+      // assistant message with stopReason="error" (e.g. "fetch failed | Headers
+      // Timeout Error"), the embedded agent may keep running (retrying the
+      // provider) and emit stderr that continuously resets the activity timer.
+      // If no new successful assistant or tool-call turn arrives within the
+      // recovery window, treat the task as a provider error and kill the child.
+      if (lastProviderErrorMs !== null) {
+        const sinceProviderError = Date.now() - lastProviderErrorMs;
+        if (sinceProviderError > providerErrorRecoveryMs) {
+          await killChild(
+            `provider-error-no-recovery: ${lastProviderErrorMsg.slice(0, 100)} (${Math.round(sinceProviderError / 1000)}s since error, no recovery)`,
+          );
+          return {
+            conversation,
+            elapsedMs: Date.now() - startMs,
+            completionStatus: "error",
+            error: `provider error (no recovery in ${Math.round(providerErrorRecoveryMs / 1000)}s): ${lastProviderErrorMsg}`,
+            sessionJsonlPath: jsonlPath,
+            trajectoryJsonlPath: trajectoryPath,
+            fakeGogLogPath,
+          };
+        }
       }
 
       // Child exited naturally


### PR DESCRIPTION
## Summary

- Adds `extractSessionProviderError()` to detect assistant session JSONL entries with `stopReason=error` and a non-empty `errorMessage` (e.g. `fetch failed | Headers Timeout Error`)
- The polling loop in `dispatchTask()` now tracks the first such error and enforces a 3-minute recovery window
- If no new successful assistant or tool-call turn arrives within the window, the child is killed and the task exits with `completionStatus=error` capturing the provider error
- A subsequent successful turn from a genuine retry clears the window so real recoveries work

## Why

`weekly_action_plan` failed twice because Ollama returned "fetch failed | Headers Timeout Error" after a long post-tool-call generation. OpenClaw recorded the error in session JSONL with `stopReason=error` but kept running (retrying the provider). The retry loop emitted stderr that continuously reset the no-activity watchdog (600 s), so the task stayed alive indefinitely with no `result.json` written. The Docker container eventually received SIGTERM from outside, exiting with code 143, with no captured result artifact.

## Test plan

- [x] `extractSessionProviderError` unit tests for: nested message format, flat format, stopReason≠error, missing errorMessage, user messages, non-message entries, recovery-clears-error sequence
- [x] All 92 tests pass (`pnpm check:changed`)