### PR TITLE
feat(benchmark): add --judge-base-url for local Ollama judge support

### DIFF
--- a/src/gemmaclaw/benchmark/agent-evaluator.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.ts
@@ -73,6 +73,8 @@ export type AgentEvaluationConfig = {
   runId: string;
   provider: AgentJudgeProvider;
   model: string;
+  /** Optional base URL for the judge API (e.g. http://127.0.0.1:11434/v1/ for local Ollama). */
+  judgeBaseUrl?: string;
   force?: boolean;
   includeRaw?: boolean;
 };
@@ -365,27 +367,33 @@ export class OpenAIAgentJudgeClient implements AgentJudgeClient {
   private readonly client: OpenAI;
   private readonly model: string;
 
-  constructor(model: string, apiKey = process.env.OPENAI_API_KEY) {
-    this.client = new OpenAI({ apiKey });
+  constructor(model: string, apiKey = process.env.OPENAI_API_KEY, baseURL?: string) {
+    this.client = new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) });
     this.model = model;
   }
 
   async judge(prompt: string): Promise<string> {
-    const response = await this.client.responses.create({
+    const response = await this.client.chat.completions.create({
       model: this.model,
-      input: [
+      messages: [
         { role: "system", content: JUDGE_SYSTEM_PROMPT },
         { role: "user", content: prompt },
       ],
-      max_output_tokens: 4096,
+      max_tokens: 4096,
     });
-    return response.output_text ?? "";
+    return response.choices[0]?.message?.content ?? "";
   }
+}
+
+function makeJudgeClient(config: AgentEvaluationConfig): AgentJudgeClient {
+  // Local Ollama: accepts any API key value, uses OpenAI-compatible /v1/ API.
+  const apiKey = config.judgeBaseUrl ? "ollama" : process.env.OPENAI_API_KEY;
+  return new OpenAIAgentJudgeClient(config.model, apiKey, config.judgeBaseUrl);
 }
 
 export async function evaluateAgentBenchmarkRun(
   config: AgentEvaluationConfig,
-  judgeClient: AgentJudgeClient = new OpenAIAgentJudgeClient(config.model),
+  judgeClient: AgentJudgeClient = makeJudgeClient(config),
   log: (message: string) => void = console.log,
 ): Promise<AgentEvaluationSummary> {
   const runDir = path.join(config.outputDir, "runs", config.runId);

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -92,6 +92,8 @@ function parseArgs(argv: string[]) {
       opts.includeRawJudgeResponse = true;
     } else if (arg === "--judge-provider" && args[i + 1]) {
       opts.judgeProvider = args[++i]!;
+    } else if (arg === "--judge-base-url" && args[i + 1]) {
+      opts.judgeBaseUrl = args[++i]!;
     } else if (arg === "--context-length" && args[i + 1]) {
       opts.contextLength = args[++i]!;
     } else if (arg === "--gpu-layers" && args[i + 1]) {
@@ -395,6 +397,7 @@ Agent Mode Options:
   --evaluate             Run LLM judge scoring for a saved run id
   --force-evaluate       Replace existing LLM judge scores for that run
   --judge-provider <id>  Judge provider (openai)
+  --judge-base-url <url> Judge API base URL (e.g. http://127.0.0.1:11434/v1/ for local Ollama)
   --task-timeout <sec>   Legacy alias for --hard-cap (default: 600). Activity-based timeout is the normal "stuck" signal.
   --idle-timeout <sec>   Seconds of idle before task considered done (default: 30)
   --no-activity-timeout <sec>  Kill the task if no useful agent activity (stdout/stderr/JSONL/trajectory) for N seconds (default: 600)
@@ -476,11 +479,13 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
     const provider: AgentJudgeProvider = judgeProviderInput;
     const model = (opts.judgeModel as string | undefined) ?? "gpt-5.5";
     const outputDir = (opts.outputDir as string) ?? "benchmark-results";
+    const judgeBaseUrl = opts.judgeBaseUrl as string | undefined;
     await evaluateAgentBenchmarkRun({
       outputDir,
       runId,
       provider,
       model,
+      judgeBaseUrl,
       force: Boolean(opts.forceEvaluate),
       includeRaw: Boolean(opts.includeRawJudgeResponse),
     });


### PR DESCRIPTION
Adds --judge-base-url option so the LLM judge can use any OpenAI-compatible API endpoint (e.g. local Ollama). Switches to chat.completions which works with both OpenAI and Ollama. 92 tests pass.