### PR TITLE
fix(benchmark): disable thinking tokens and increase max_tokens for local judge

### DIFF
--- a/src/gemmaclaw/benchmark/agent-evaluator.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.ts
@@ -373,15 +373,19 @@ export class OpenAIAgentJudgeClient implements AgentJudgeClient {
   }
 
   async judge(prompt: string): Promise<string> {
+    // Prepend /no_think so thinking models (qwen3, deepseek-r1) emit content directly
+    // rather than spending all max_tokens on internal reasoning.
     const response = await this.client.chat.completions.create({
       model: this.model,
       messages: [
         { role: "system", content: JUDGE_SYSTEM_PROMPT },
-        { role: "user", content: prompt },
+        { role: "user", content: `/no_think\n${prompt}` },
       ],
-      max_tokens: 4096,
+      max_tokens: 8192,
     });
-    return response.choices[0]?.message?.content ?? "";
+    const msg = response.choices[0]?.message;
+    // Fallback: some thinking models put output in .reasoning when content is empty.
+    return msg?.content || (msg as unknown as Record<string, string>)?.reasoning || "";
   }
 }
 


### PR DESCRIPTION
## Summary

- Prepend `/no_think` to judge user message so qwen3/deepseek-r1 thinking models emit content directly instead of consuming all max_tokens on internal reasoning
- Increase max_tokens from 4096 to 8192 as safety margin for long transcripts  
- Add fallback to `message.reasoning` field for models that still populate only that field

## Why

qwen3.6:35b (the local Ollama judge for Q4 evaluation) spends output tokens on internal reasoning. With max_tokens=4096 and a complex task transcript, thinking consumed all tokens leaving content empty.

## Test plan

- [x] 92 unit tests pass
- [x] Local Ollama test confirmed: `/no_think` produces content in `message.content` field