### PR TITLE
fix(benchmark): robust JSON extraction and retry for local judge prose responses

### DIFF
--- a/src/gemmaclaw/benchmark/agent-evaluator.test.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.test.ts
@@ -59,7 +59,13 @@ describe("agent evaluator", () => {
         score: 8.5,
         confidence: "high",
         criteria: [
-          { status: "met", pointsAwarded: 5, reasoning: "read inbox", evidence: "gog" },
+          {
+            status: "met",
+            pointsAwarded: 5,
+            reasoning: "read inbox",
+            evidence: "turn #2: gog gmail search",
+            turnRefs: [1],
+          },
           { status: "partial", pointsAwarded: 3.5, reasoning: "summary ok" },
         ],
         reasoning: "good",
@@ -78,6 +84,50 @@ describe("agent evaluator", () => {
     expect(parsed.percentage).toBe(85);
     expect(parsed.passed).toBe(true);
     expect(parsed.criteria[0]).toMatchObject({ status: "met", pointsAwarded: 5 });
+    expect(parsed.criteria[0].turnRefs).toEqual([1]);
+  });
+
+  it("extracts JSON from prose-wrapped judge response", () => {
+    const prose = `Here is my evaluation of the task.
+
+Let me consider each criterion carefully.
+
+Step 1: Check tool usage... yes, the agent called gog.
+
+${JSON.stringify({
+  score: 7,
+  confidence: "high",
+  criteria: [{ status: "met", pointsAwarded: 7, reasoning: "used gog" }],
+  reasoning: "correct",
+  issues: [],
+})}
+
+That concludes my evaluation.`;
+    const parsed = parseAgentJudgeResponse(prose, 10, {
+      provider: "openai",
+      model: "qwen3.6:35b",
+      judgedAt: "2026-05-10T00:00:00.000Z",
+      criteria: ["Must read inbox"],
+    });
+    expect(parsed.score).toBe(7);
+  });
+
+  it("extracts JSON when model omits trailing prose but starts with prose", () => {
+    const jsonObj = {
+      score: 5,
+      confidence: "medium",
+      criteria: [{ status: "partial", pointsAwarded: 5, reasoning: "partially met" }],
+      reasoning: "close enough",
+      issues: [],
+    };
+    const prose = `I will now provide my assessment.\n\nReady.\n\n${JSON.stringify(jsonObj, null, 2)}`;
+    const parsed = parseAgentJudgeResponse(prose, 10, {
+      provider: "openai",
+      model: "qwen3.6:35b",
+      judgedAt: "2026-05-10T00:00:00.000Z",
+      criteria: ["Must read inbox"],
+    });
+    expect(parsed.score).toBe(5);
   });
 
   it("summarizes scored evaluation files", () => {
@@ -123,6 +173,62 @@ describe("agent evaluator", () => {
     expect(summary.maxScore).toBe(10);
     expect(summary.percentage).toBe(90);
     expect(generateAgentEvaluationMarkdown(summary)).toContain("9 / 10");
+  });
+
+  it("retries judge call on JSON parse failure and succeeds on second attempt", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-evaluator-retry-"));
+    const runId = "run-retry";
+    const runDir = path.join(dir, "runs", runId);
+    const evalDir = path.join(dir, "evaluations", runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.mkdirSync(evalDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, "results.json"), JSON.stringify({ tasks: [taskResult] }));
+    fs.writeFileSync(
+      path.join(evalDir, "email_summarize.json"),
+      JSON.stringify({
+        taskId: "email_summarize",
+        taskName: "Email Inbox Summary",
+        gradingCriteria: taskResult.task.grading.criteria,
+        maxScore: 10,
+        toolCallCount: 1,
+        toolsUsed: ["exec"],
+        completionStatus: "completed",
+        elapsedMs: 1000,
+        conversationTurns: 4,
+        transcriptFile: "transcripts/email_summarize.txt",
+        deterministicScorer: null,
+        llmJudge: null,
+      }),
+    );
+
+    let callCount = 0;
+    const summary = await evaluateAgentBenchmarkRun(
+      { outputDir: dir, runId, provider: "openai", model: "qwen3.6:35b" },
+      {
+        async judge() {
+          callCount++;
+          if (callCount === 1) {
+            return "I am evaluating... Ready. No JSON here.";
+          }
+          return JSON.stringify({
+            score: 6,
+            confidence: "medium",
+            criteria: [
+              { status: "met", pointsAwarded: 3, reasoning: "read inbox" },
+              { status: "partial", pointsAwarded: 3, reasoning: "partial summary" },
+            ],
+            reasoning: "mostly correct",
+            issues: [],
+          });
+        },
+      },
+      () => {},
+    );
+
+    expect(callCount).toBe(2);
+    expect(summary.totalScore).toBe(6);
+    const rawRepro = path.join(evalDir, "email_summarize.raw-repro.txt");
+    expect(fs.existsSync(rawRepro)).toBe(true);
   });
 
   it("writes per-task judge results and aggregate summary", async () => {

--- a/src/gemmaclaw/benchmark/agent-evaluator.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.ts
@@ -10,7 +10,10 @@ export type AgentJudgeCriterionResult = {
   status: "met" | "partial" | "not_met";
   pointsAwarded: number;
   reasoning: string;
+  /** Brief text evidence from transcript, e.g. "turn #3: gog calendar create..." */
   evidence?: string;
+  /** Transcript turn index(es) where the issue/evidence was observed (0-based) */
+  turnRefs?: number[];
 };
 
 export type AgentLlmJudgeResult = {
@@ -156,14 +159,29 @@ function extractJsonObject(text: string): unknown {
     try {
       return JSON.parse(fenced[1]);
     } catch {
-      // Continue to first-object extraction.
+      // Continue to brace-scanning extraction.
     }
   }
 
-  const start = text.indexOf("{");
+  // Scan all `}` positions from right to left; for each, scan left for matching `{`
+  // and try parsing the slice. This handles models that emit prose before/after JSON.
   const end = text.lastIndexOf("}");
-  if (start >= 0 && end > start) {
-    return JSON.parse(text.slice(start, end + 1));
+  if (end >= 0) {
+    let depth = 0;
+    for (let i = end; i >= 0; i--) {
+      if (text[i] === "}") {
+        depth++;
+      } else if (text[i] === "{") {
+        depth--;
+        if (depth === 0) {
+          try {
+            return JSON.parse(text.slice(i, end + 1));
+          } catch {
+            // This slice is not valid JSON, keep scanning.
+          }
+        }
+      }
+    }
   }
 
   throw new Error("judge response did not contain a JSON object");
@@ -185,12 +203,16 @@ export function parseAgentJudgeResponse(
   const criteriaInput = Array.isArray(parsed.criteria) ? parsed.criteria : [];
   const criteria = options.criteria.map((criterion, index) => {
     const item = (criteriaInput[index] ?? {}) as Record<string, unknown>;
+    const turnRefs = Array.isArray(item.turnRefs)
+      ? (item.turnRefs as unknown[]).filter((v) => Number.isInteger(v)).map(Number)
+      : undefined;
     return {
       criterion,
       status: normalizeStatus(item.status),
       pointsAwarded: roundScore(clampScore(Number(item.pointsAwarded), maxScore)),
       reasoning: stringFromUnknown(item.reasoning),
       ...(item.evidence ? { evidence: stringFromUnknown(item.evidence) } : {}),
+      ...(turnRefs && turnRefs.length > 0 ? { turnRefs } : {}),
     };
   });
 
@@ -266,7 +288,7 @@ export function buildAgentJudgePrompt(result: AgentTaskResult): string {
     "Full transcript:",
     transcript,
     "",
-    "Return ONLY this JSON shape:",
+    "Return ONLY this JSON shape (no prose before or after, no markdown fences):",
     JSON.stringify(
       {
         score: 0,
@@ -276,7 +298,9 @@ export function buildAgentJudgePrompt(result: AgentTaskResult): string {
           status: "met | partial | not_met",
           pointsAwarded: 0,
           reasoning: "short reason",
-          evidence: "brief transcript evidence",
+          evidence:
+            "brief transcript quote or turn reference, e.g. turn #3: gog calendar create ...",
+          turnRefs: [0],
         })),
         reasoning: "overall scoring rationale",
         issues: ["important misses or risks, empty if none"],
@@ -425,14 +449,49 @@ export async function evaluateAgentBenchmarkRun(
 
     log(`judge ${taskResult.task.id} (${taskResult.task.grading.maxScore} pts)`);
     const prompt = buildAgentJudgePrompt(taskResult);
-    const response = await judgeClient.judge(prompt);
-    const judge = parseAgentJudgeResponse(response, taskResult.task.grading.maxScore, {
-      provider: config.provider,
-      model: config.model,
-      judgedAt,
-      criteria: taskResult.task.grading.criteria,
-      includeRaw: config.includeRaw,
-    });
+    let judge: AgentLlmJudgeResult | null = null;
+    const MAX_RETRIES = 3;
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      const retryPrompt =
+        attempt === 0
+          ? prompt
+          : `Output ONLY a JSON object. No prose. No markdown. No explanation before or after.\n\n${prompt}`;
+      let response: string;
+      try {
+        response = await judgeClient.judge(retryPrompt);
+      } catch (err) {
+        log(`  judge call failed (attempt ${attempt + 1}/${MAX_RETRIES}): ${String(err)}`);
+        if (attempt === MAX_RETRIES - 1) {
+          throw err;
+        }
+        continue;
+      }
+      try {
+        judge = parseAgentJudgeResponse(response, taskResult.task.grading.maxScore, {
+          provider: config.provider,
+          model: config.model,
+          judgedAt,
+          criteria: taskResult.task.grading.criteria,
+          includeRaw: config.includeRaw,
+        });
+        break;
+      } catch (parseErr) {
+        const rawPath = path.join(evalDir, `${taskResult.task.id}.raw-repro.txt`);
+        fs.writeFileSync(rawPath, response);
+        log(
+          `  JSON parse failed (attempt ${attempt + 1}/${MAX_RETRIES}): ${String(parseErr)}. Raw saved to ${rawPath}`,
+        );
+        if (attempt === MAX_RETRIES - 1) {
+          throw new Error(
+            `judge returned non-JSON for ${taskResult.task.id} after ${MAX_RETRIES} attempts: ${String(parseErr)}`,
+            { cause: parseErr },
+          );
+        }
+      }
+    }
+    if (!judge) {
+      throw new Error(`judge unexpectedly null for ${taskResult.task.id}`);
+    }
     const updated: AgentEvaluationFile = {
       ...evaluation,
       maxScore: taskResult.task.grading.maxScore,


### PR DESCRIPTION
## Summary
- extractJsonObject: depth-tracking brace scan from rightmost } backwards handles models that emit prose before/after the JSON object (Qwen judge outputted reasoning prose without a final JSON block, causing evaluation to crash)
- evaluateAgentBenchmarkRun: retry judge call up to 3 times on JSON parse failure; escalating prompt on retries; persists failed raw response to <task-id>.raw-repro.txt for debugging
- AgentJudgeCriterionResult.turnRefs: optional transcript turn index array for linking judge critique to specific conversation turns
- buildAgentJudgePrompt: requests turn references in evidence field; updated JSON shape example

## Test plan
- All 7 evaluator unit tests pass (prose-wrapped extraction, retry path, turn refs)
- Full 258-test suite green