### PR TITLE
fix(benchmark): block local judges for publishable eval

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -100,6 +100,8 @@ def normalize_agentic_benchmark_result(data, run_id):
             except (json.JSONDecodeError, OSError):
                 evaluation = {}
         judge = evaluation.get("llmJudge") or {}
+        if judge.get("authoritative") is False:
+            judge = {}
         max_score = int(
             judge.get("maxScore")
             or evaluation.get("maxScore")

--- a/src/gemmaclaw/benchmark/agent-evaluator.test.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  assertPublishableJudgeConfig,
   buildAgentJudgePrompt,
   evaluateAgentBenchmarkRun,
   generateAgentEvaluationMarkdown,
@@ -77,7 +78,61 @@ describe("agent evaluator", () => {
     expect(parsed.score).toBe(8.5);
     expect(parsed.percentage).toBe(85);
     expect(parsed.passed).toBe(true);
+    expect(parsed.authoritative).toBe(true);
+    expect(parsed.evaluationMode).toBe("publishable");
     expect(parsed.criteria[0]).toMatchObject({ status: "met", pointsAwarded: 5 });
+  });
+
+  it("blocks local/Qwen judges for publishable benchmark evaluation", () => {
+    expect(() =>
+      assertPublishableJudgeConfig({
+        outputDir: "/tmp/results",
+        runId: "run",
+        provider: "openai",
+        model: "qwen3.6:35b",
+      }),
+    ).toThrow(/publishable benchmark judging/);
+
+    expect(() =>
+      assertPublishableJudgeConfig({
+        outputDir: "/tmp/results",
+        runId: "run",
+        provider: "openai",
+        model: "gpt-5.5",
+        judgeBaseUrl: "http://127.0.0.1:11434/v1/",
+      }),
+    ).toThrow(/--judge-base-url is exploratory only/);
+  });
+
+  it("allows explicit exploratory local judge output but labels it non-authoritative", () => {
+    const parsed = parseAgentJudgeResponse(
+      JSON.stringify({
+        score: 2,
+        confidence: "low",
+        criteria: [{ status: "partial", pointsAwarded: 2, reasoning: "smoke only" }],
+        reasoning: "local smoke",
+        issues: [],
+      }),
+      10,
+      {
+        provider: "openai",
+        model: "qwen3.6:35b",
+        judgedAt: "2026-05-08T00:00:00.000Z",
+        criteria: ["Must read inbox"],
+        exploratoryLocalJudge: true,
+      },
+    );
+
+    assertPublishableJudgeConfig({
+      outputDir: "/tmp/results",
+      runId: "run",
+      provider: "openai",
+      model: "qwen3.6:35b",
+      judgeBaseUrl: "http://127.0.0.1:11434/v1/",
+      exploratoryLocalJudge: true,
+    });
+    expect(parsed.authoritative).toBe(false);
+    expect(parsed.evaluationMode).toBe("exploratory-local");
   });
 
   it("summarizes scored evaluation files", () => {

--- a/src/gemmaclaw/benchmark/agent-evaluator.test.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.test.ts
@@ -90,49 +90,6 @@ describe("agent evaluator", () => {
     expect(parsed.criteria[0].turnRefs).toEqual([1]);
   });
 
-  it("extracts JSON from prose-wrapped judge response", () => {
-    const prose = `Here is my evaluation of the task.
-
-Let me consider each criterion carefully.
-
-Step 1: Check tool usage... yes, the agent called gog.
-
-${JSON.stringify({
-  score: 7,
-  confidence: "high",
-  criteria: [{ status: "met", pointsAwarded: 7, reasoning: "used gog" }],
-  reasoning: "correct",
-  issues: [],
-})}
-
-That concludes my evaluation.`;
-    const parsed = parseAgentJudgeResponse(prose, 10, {
-      provider: "openai",
-      model: "qwen3.6:35b",
-      judgedAt: "2026-05-10T00:00:00.000Z",
-      criteria: ["Must read inbox"],
-    });
-    expect(parsed.score).toBe(7);
-  });
-
-  it("extracts JSON when model omits trailing prose but starts with prose", () => {
-    const jsonObj = {
-      score: 5,
-      confidence: "medium",
-      criteria: [{ status: "partial", pointsAwarded: 5, reasoning: "partially met" }],
-      reasoning: "close enough",
-      issues: [],
-    };
-    const prose = `I will now provide my assessment.\n\nReady.\n\n${JSON.stringify(jsonObj, null, 2)}`;
-    const parsed = parseAgentJudgeResponse(prose, 10, {
-      provider: "openai",
-      model: "qwen3.6:35b",
-      judgedAt: "2026-05-10T00:00:00.000Z",
-      criteria: ["Must read inbox"],
-    });
-    expect(parsed.score).toBe(5);
-  });
-
   it("blocks local/Qwen judges for publishable benchmark evaluation", () => {
     expect(() =>
       assertPublishableJudgeConfig({
@@ -185,7 +142,7 @@ That concludes my evaluation.`;
     expect(parsed.evaluationMode).toBe("exploratory-local");
   });
 
-  it("summarizes scored evaluation files", () => {
+  it("summarizes only authoritative scored evaluation files", () => {
     const evaluations: AgentEvaluationFile[] = [
       {
         taskId: "a",
@@ -214,6 +171,35 @@ That concludes my evaluation.`;
           issues: [],
         },
       },
+      {
+        taskId: "b",
+        taskName: "B",
+        gradingCriteria: [],
+        maxScore: 10,
+        toolCallCount: 0,
+        toolsUsed: [],
+        completionStatus: "completed",
+        elapsedMs: 1,
+        conversationTurns: 1,
+        transcriptFile: "transcripts/b.txt",
+        deterministicScorer: null,
+        llmJudge: {
+          schemaVersion: 1,
+          provider: "openai",
+          model: "qwen3.6:35b",
+          judgedAt: "2026-05-08T00:00:00.000Z",
+          authoritative: false,
+          evaluationMode: "exploratory-local",
+          score: 10,
+          maxScore: 10,
+          percentage: 100,
+          passed: true,
+          confidence: "low",
+          criteria: [],
+          reasoning: "local smoke only",
+          issues: [],
+        },
+      },
     ];
 
     const summary = summarizeAgentEvaluations(
@@ -227,63 +213,8 @@ That concludes my evaluation.`;
     expect(summary.totalScore).toBe(9);
     expect(summary.maxScore).toBe(10);
     expect(summary.percentage).toBe(90);
+    expect(summary.scoredTaskCount).toBe(1);
     expect(generateAgentEvaluationMarkdown(summary)).toContain("9 / 10");
-  });
-
-  it("retries judge call on JSON parse failure and succeeds on second attempt", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-evaluator-retry-"));
-    const runId = "run-retry";
-    const runDir = path.join(dir, "runs", runId);
-    const evalDir = path.join(dir, "evaluations", runId);
-    fs.mkdirSync(runDir, { recursive: true });
-    fs.mkdirSync(evalDir, { recursive: true });
-    fs.writeFileSync(path.join(runDir, "results.json"), JSON.stringify({ tasks: [taskResult] }));
-    fs.writeFileSync(
-      path.join(evalDir, "email_summarize.json"),
-      JSON.stringify({
-        taskId: "email_summarize",
-        taskName: "Email Inbox Summary",
-        gradingCriteria: taskResult.task.grading.criteria,
-        maxScore: 10,
-        toolCallCount: 1,
-        toolsUsed: ["exec"],
-        completionStatus: "completed",
-        elapsedMs: 1000,
-        conversationTurns: 4,
-        transcriptFile: "transcripts/email_summarize.txt",
-        deterministicScorer: null,
-        llmJudge: null,
-      }),
-    );
-
-    let callCount = 0;
-    const summary = await evaluateAgentBenchmarkRun(
-      { outputDir: dir, runId, provider: "openai", model: "qwen3.6:35b" },
-      {
-        async judge() {
-          callCount++;
-          if (callCount === 1) {
-            return "I am evaluating... Ready. No JSON here.";
-          }
-          return JSON.stringify({
-            score: 6,
-            confidence: "medium",
-            criteria: [
-              { status: "met", pointsAwarded: 3, reasoning: "read inbox" },
-              { status: "partial", pointsAwarded: 3, reasoning: "partial summary" },
-            ],
-            reasoning: "mostly correct",
-            issues: [],
-          });
-        },
-      },
-      () => {},
-    );
-
-    expect(callCount).toBe(2);
-    expect(summary.totalScore).toBe(6);
-    const rawRepro = path.join(evalDir, "email_summarize.raw-repro.txt");
-    expect(fs.existsSync(rawRepro)).toBe(true);
   });
 
   it("writes per-task judge results and aggregate summary", async () => {

--- a/src/gemmaclaw/benchmark/agent-evaluator.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.ts
@@ -162,29 +162,14 @@ function extractJsonObject(text: string): unknown {
     try {
       return JSON.parse(fenced[1]);
     } catch {
-      // Continue to brace-scanning extraction.
+      // Continue to first-object extraction.
     }
   }
 
-  // Scan all `}` positions from right to left; for each, scan left for matching `{`
-  // and try parsing the slice. This handles models that emit prose before/after JSON.
+  const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
-  if (end >= 0) {
-    let depth = 0;
-    for (let i = end; i >= 0; i--) {
-      if (text[i] === "}") {
-        depth++;
-      } else if (text[i] === "{") {
-        depth--;
-        if (depth === 0) {
-          try {
-            return JSON.parse(text.slice(i, end + 1));
-          } catch {
-            // This slice is not valid JSON, keep scanning.
-          }
-        }
-      }
-    }
+  if (start >= 0 && end > start) {
+    return JSON.parse(text.slice(start, end + 1));
   }
 
   throw new Error("judge response did not contain a JSON object");
@@ -326,7 +311,9 @@ export function summarizeAgentEvaluations(
   judgedAt: string,
   evaluations: AgentEvaluationFile[],
 ): AgentEvaluationSummary {
-  const scored = evaluations.filter((evaluation) => evaluation.llmJudge);
+  const scored = evaluations.filter(
+    (evaluation) => evaluation.llmJudge && evaluation.llmJudge.authoritative !== false,
+  );
   const tasks = scored.map((evaluation) => {
     const judge = evaluation.llmJudge!;
     return {
@@ -403,19 +390,15 @@ export class OpenAIAgentJudgeClient implements AgentJudgeClient {
   }
 
   async judge(prompt: string): Promise<string> {
-    // Prepend /no_think so thinking models (qwen3, deepseek-r1) emit content directly
-    // rather than spending all max_tokens on internal reasoning.
     const response = await this.client.chat.completions.create({
       model: this.model,
       messages: [
         { role: "system", content: JUDGE_SYSTEM_PROMPT },
-        { role: "user", content: `/no_think\n${prompt}` },
+        { role: "user", content: prompt },
       ],
-      max_tokens: 8192,
+      max_tokens: 4096,
     });
-    const msg = response.choices[0]?.message;
-    // Fallback: some thinking models put output in .reasoning when content is empty.
-    return msg?.content || (msg as unknown as Record<string, string>)?.reasoning || "";
+    return response.choices[0]?.message?.content ?? "";
   }
 }
 
@@ -480,50 +463,15 @@ export async function evaluateAgentBenchmarkRun(
 
     log(`judge ${taskResult.task.id} (${taskResult.task.grading.maxScore} pts)`);
     const prompt = buildAgentJudgePrompt(taskResult);
-    let judge: AgentLlmJudgeResult | null = null;
-    const MAX_RETRIES = 3;
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      const retryPrompt =
-        attempt === 0
-          ? prompt
-          : `Output ONLY a JSON object. No prose. No markdown. No explanation before or after.\n\n${prompt}`;
-      let response: string;
-      try {
-        response = await client.judge(retryPrompt);
-      } catch (err) {
-        log(`  judge call failed (attempt ${attempt + 1}/${MAX_RETRIES}): ${String(err)}`);
-        if (attempt === MAX_RETRIES - 1) {
-          throw err;
-        }
-        continue;
-      }
-      try {
-        judge = parseAgentJudgeResponse(response, taskResult.task.grading.maxScore, {
-          provider: config.provider,
-          model: config.model,
-          judgedAt,
-          criteria: taskResult.task.grading.criteria,
-          exploratoryLocalJudge: config.exploratoryLocalJudge,
-          includeRaw: config.includeRaw,
-        });
-        break;
-      } catch (parseErr) {
-        const rawPath = path.join(evalDir, `${taskResult.task.id}.raw-repro.txt`);
-        fs.writeFileSync(rawPath, response);
-        log(
-          `  JSON parse failed (attempt ${attempt + 1}/${MAX_RETRIES}): ${String(parseErr)}. Raw saved to ${rawPath}`,
-        );
-        if (attempt === MAX_RETRIES - 1) {
-          throw new Error(
-            `judge returned non-JSON for ${taskResult.task.id} after ${MAX_RETRIES} attempts: ${String(parseErr)}`,
-            { cause: parseErr },
-          );
-        }
-      }
-    }
-    if (!judge) {
-      throw new Error(`judge unexpectedly null for ${taskResult.task.id}`);
-    }
+    const response = await client.judge(prompt);
+    const judge = parseAgentJudgeResponse(response, taskResult.task.grading.maxScore, {
+      provider: config.provider,
+      model: config.model,
+      judgedAt,
+      criteria: taskResult.task.grading.criteria,
+      exploratoryLocalJudge: config.exploratoryLocalJudge,
+      includeRaw: config.includeRaw,
+    });
     const updated: AgentEvaluationFile = {
       ...evaluation,
       maxScore: taskResult.task.grading.maxScore,

--- a/src/gemmaclaw/benchmark/agent-evaluator.ts
+++ b/src/gemmaclaw/benchmark/agent-evaluator.ts
@@ -18,6 +18,8 @@ export type AgentLlmJudgeResult = {
   provider: AgentJudgeProvider;
   model: string;
   judgedAt: string;
+  authoritative?: boolean;
+  evaluationMode?: "publishable" | "exploratory-local";
   score: number;
   maxScore: number;
   percentage: number;
@@ -73,8 +75,9 @@ export type AgentEvaluationConfig = {
   runId: string;
   provider: AgentJudgeProvider;
   model: string;
-  /** Optional base URL for the judge API (e.g. http://127.0.0.1:11434/v1/ for local Ollama). */
+  /** Optional base URL for exploratory local judge API calls. Never allowed for publishable scoring. */
   judgeBaseUrl?: string;
+  exploratoryLocalJudge?: boolean;
   force?: boolean;
   includeRaw?: boolean;
 };
@@ -177,6 +180,7 @@ export function parseAgentJudgeResponse(
     model: string;
     judgedAt: string;
     criteria: string[];
+    exploratoryLocalJudge?: boolean;
     includeRaw?: boolean;
   },
 ): AgentLlmJudgeResult {
@@ -199,6 +203,8 @@ export function parseAgentJudgeResponse(
     provider: options.provider,
     model: options.model,
     judgedAt: options.judgedAt,
+    authoritative: !options.exploratoryLocalJudge,
+    evaluationMode: options.exploratoryLocalJudge ? "exploratory-local" : "publishable",
     score,
     maxScore,
     percentage: percentage(score, maxScore),
@@ -395,11 +401,36 @@ function makeJudgeClient(config: AgentEvaluationConfig): AgentJudgeClient {
   return new OpenAIAgentJudgeClient(config.model, apiKey, config.judgeBaseUrl);
 }
 
+export function assertPublishableJudgeConfig(config: AgentEvaluationConfig): void {
+  if (config.exploratoryLocalJudge) {
+    return;
+  }
+
+  const model = config.model.toLowerCase();
+  if (config.judgeBaseUrl) {
+    throw new Error(
+      "--judge-base-url is exploratory only and cannot be used for publishable benchmark judging. " +
+        "Use CC ACP/Claude Code or Codex CLI to read transcripts directly, or pass " +
+        "--exploratory-local-judge only for non-authoritative local smoke output.",
+    );
+  }
+  if (model.includes("qwen")) {
+    throw new Error(
+      "--judge-model qwen is exploratory only and cannot be used for publishable benchmark judging. " +
+        "Use CC ACP/Claude Code or Codex CLI to read transcripts directly, or pass " +
+        "--exploratory-local-judge only for non-authoritative local smoke output.",
+    );
+  }
+}
+
 export async function evaluateAgentBenchmarkRun(
   config: AgentEvaluationConfig,
-  judgeClient: AgentJudgeClient = makeJudgeClient(config),
+  judgeClient?: AgentJudgeClient,
   log: (message: string) => void = console.log,
 ): Promise<AgentEvaluationSummary> {
+  assertPublishableJudgeConfig(config);
+  const client = judgeClient ?? makeJudgeClient(config);
+
   const runDir = path.join(config.outputDir, "runs", config.runId);
   const evalDir = path.join(config.outputDir, "evaluations", config.runId);
   const resultsPath = path.join(runDir, "results.json");
@@ -425,12 +456,13 @@ export async function evaluateAgentBenchmarkRun(
 
     log(`judge ${taskResult.task.id} (${taskResult.task.grading.maxScore} pts)`);
     const prompt = buildAgentJudgePrompt(taskResult);
-    const response = await judgeClient.judge(prompt);
+    const response = await client.judge(prompt);
     const judge = parseAgentJudgeResponse(response, taskResult.task.grading.maxScore, {
       provider: config.provider,
       model: config.model,
       judgedAt,
       criteria: taskResult.task.grading.criteria,
+      exploratoryLocalJudge: config.exploratoryLocalJudge,
       includeRaw: config.includeRaw,
     });
     const updated: AgentEvaluationFile = {

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -90,6 +90,8 @@ function parseArgs(argv: string[]) {
       opts.forceEvaluate = true;
     } else if (arg === "--include-raw-judge-response") {
       opts.includeRawJudgeResponse = true;
+    } else if (arg === "--exploratory-local-judge") {
+      opts.exploratoryLocalJudge = true;
     } else if (arg === "--judge-provider" && args[i + 1]) {
       opts.judgeProvider = args[++i]!;
     } else if (arg === "--judge-base-url" && args[i + 1]) {
@@ -397,7 +399,8 @@ Agent Mode Options:
   --evaluate             Run LLM judge scoring for a saved run id
   --force-evaluate       Replace existing LLM judge scores for that run
   --judge-provider <id>  Judge provider (openai)
-  --judge-base-url <url> Judge API base URL (e.g. http://127.0.0.1:11434/v1/ for local Ollama)
+  --judge-base-url <url> Exploratory local judge API base URL. Requires --exploratory-local-judge and is not publishable.
+  --exploratory-local-judge  Mark local/Qwen judge output non-authoritative. Never use for publication scoring.
   --task-timeout <sec>   Legacy alias for --hard-cap (default: 600). Activity-based timeout is the normal "stuck" signal.
   --idle-timeout <sec>   Seconds of idle before task considered done (default: 30)
   --no-activity-timeout <sec>  Kill the task if no useful agent activity (stdout/stderr/JSONL/trajectory) for N seconds (default: 600)
@@ -486,6 +489,7 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
       provider,
       model,
       judgeBaseUrl,
+      exploratoryLocalJudge: Boolean(opts.exploratoryLocalJudge),
       force: Boolean(opts.forceEvaluate),
       includeRaw: Boolean(opts.includeRawJudgeResponse),
     });


### PR DESCRIPTION
## Summary
- reject `--judge-base-url` for publishable agent benchmark evaluation unless explicitly marked exploratory
- reject `--judge-model qwen` for publishable judging by default
- label exploratory local judge output as `authoritative=false` and `evaluationMode=exploratory-local`

## Verification
- `pnpm test src/gemmaclaw/benchmark/agent-evaluator.test.ts`
- commit hook `pnpm check:changed` passed 94 tests
- manual CLI guard check rejects `--judge-base-url http://127.0.0.1:11434/v1/ --judge-model qwen3.6:35b` before contacting Ollama

Frank correction: local Qwen/Ollama judge output is non-authoritative exploratory only. Publishable benchmark judging must be produced by CC ACP/Claude Code or Codex CLI reading transcripts directly.