### PR TITLE
fix(benchmark): explicit exec+gog usage in TOOLS.md for MoE models

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -781,8 +781,13 @@ const BENCHMARK_WORKSPACE_FILES: Record<string, string> = {
   "TOOLS.md": [
     "# Benchmark Tools",
     "",
-    "Use `gog` for mock Gmail, Calendar, Drive, Contacts, People, and Tasks data.",
-    "The benchmark harness places a fake gog executable first on PATH.",
+    "Use the `exec` tool to run `gog` CLI commands for mock Gmail, Calendar, Drive, Contacts, People, and Tasks data.",
+    "The benchmark harness places a fake gog executable first on PATH. Call it via exec, not as a direct function name.",
+    "Examples:",
+    '  exec command="gog gmail list"',
+    '  exec command="gog calendar list --this-week"',
+    "  exec command=\"gog calendar create --start 2025-05-14T10:00:00 --end 2025-05-14T12:00:00 --summary 'Meeting' --location 'Room B'\"",
+    '  exec command="gog contacts list"',
     "",
   ].join("\n"),
   "MEMORY.md": [


### PR DESCRIPTION
## Summary

- Update BENCHMARK_WORKSPACE_FILES TOOLS.md to explicitly say to use exec with gog CLI commands instead of calling gog as a direct function name
- Add concrete examples showing the correct invocation pattern
- All 94 benchmark tests pass

## Problem

The gemma4:26b MoE model was calling gog as a direct Ollama function name instead of using the exec tool with gog CLI command strings. The old TOOLS.md said "Use gog for mock Gmail, Calendar..." which the 26b model's aggressive function-calling behavior matched to a non-existent gog function, resulting in "Tool gog not found" errors for 19/28 benchmark tasks.

## Fix

New TOOLS.md content explicitly says to use the exec tool, states "Call it via exec, not as a direct function name", and includes concrete examples showing correct exec+gog pattern.

## Test Plan
- All 94 benchmark unit tests pass