### PR TITLE
fix(site): make benchmark drilldowns mobile adaptive

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -2674,6 +2674,7 @@ CSS = """
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -2693,21 +2694,25 @@ CSS = """
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -2716,6 +2721,7 @@ CSS = """
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -2732,8 +2738,8 @@ CSS = """
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -2926,6 +2932,37 @@ CSS = """
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/benchmarking.html
+++ b/site/benchmarking.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/community.html
+++ b/site/community.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/goals.html
+++ b/site/goals.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/index.html
+++ b/site/index.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/self-hosting.html
+++ b/site/self-hosting.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */

--- a/site/setup.html
+++ b/site/setup.html
@@ -369,6 +369,7 @@
     .model-detail {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 12px; padding: 1.5rem; margin: 1rem 0;
+      min-width: 0;
     }
     .model-detail h3 { margin-top: 0; color: var(--fg); }
     .detail-meta {
@@ -388,21 +389,25 @@
     .task-status.pass { color: var(--good); }
     .task-status.fail { color: #d14545; }
 
-    tr.task-detail > td { padding: 1.25rem 1.5rem; background: var(--bg); }
+    tr.task-detail > td {
+      padding: 1.25rem 1.5rem; background: var(--bg);
+      min-width: 0; max-width: 100%;
+    }
     .conv-meta {
       display: flex; flex-wrap: wrap; gap: 1.5rem;
       padding-bottom: 0.75rem; margin-bottom: 0.75rem;
       border-bottom: 1px solid var(--border);
       font-size: 0.85rem; color: var(--muted);
+      min-width: 0;
     }
     .conv-meta strong { color: var(--fg-soft); font-weight: 600; }
     .conv-desc {
       font-style: italic; color: var(--fg-soft);
       margin: 0 0 1rem 0; font-size: 0.95rem;
     }
-    .conv-section { margin: 0.75rem 0; }
-    .conv-thread { display: grid; gap: 0.65rem; }
-    .conv-turn { margin: 0; }
+    .conv-section { margin: 0.75rem 0; min-width: 0; max-width: 100%; }
+    .conv-thread { display: grid; gap: 0.65rem; min-width: 0; max-width: 100%; }
+    .conv-turn { margin: 0; min-width: 0; max-width: 100%; }
     details.conv-turn {
       background: var(--bg-elev); border: 1px solid var(--border);
       border-radius: 6px; overflow: hidden;
@@ -411,6 +416,7 @@
       cursor: pointer; padding: 0.55rem 0.75rem;
       font-size: 0.78rem; font-weight: 700; color: var(--fg-soft);
       background: var(--bg-elev-2);
+      white-space: normal; overflow-wrap: anywhere;
     }
     details.conv-turn .conv-block {
       border-left: 0; border-top: 1px solid var(--border); border-radius: 0;
@@ -427,8 +433,8 @@
       padding: 0.85rem 1rem; margin: 0; border-radius: 4px;
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem; color: var(--fg);
-      white-space: pre-wrap; word-break: break-word;
-      max-height: 24rem; overflow-y: auto;
+      white-space: pre-wrap; word-break: break-word; overflow-wrap: anywhere;
+      max-height: 24rem; max-width: 100%; overflow-x: hidden; overflow-y: auto;
     }
     .conv-prompt { border-left-color: var(--accent); }
     .conv-block + .conv-block { margin-top: 0.4rem; }
@@ -621,6 +627,37 @@
       .cli-cmd-card h4 { font-size: 0.95rem; }
       .task-explanation { padding: 0.6rem 0.8rem; }
       .task-prompt code { font-size: 0.72rem; }
+      .model-detail { padding: 1rem; overflow: hidden; }
+      .model-detail .table-wrap { overflow-x: hidden; border-radius: 8px; }
+      .model-detail .benchmark-table,
+      .model-detail .benchmark-table tbody,
+      .model-detail .benchmark-table tr,
+      .model-detail .benchmark-table td {
+        display: block; width: 100%; max-width: 100%; min-width: 0;
+      }
+      .model-detail .benchmark-table thead { display: none; }
+      .model-detail .benchmark-table tr.task-row {
+        padding: 0.75rem 0.8rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-row td {
+        padding: 0.15rem 0; border-bottom: 0;
+      }
+      .model-detail .benchmark-table tr.task-row td:first-child {
+        font-weight: 600; color: var(--fg);
+      }
+      .model-detail .benchmark-table tr.task-detail {
+        border-bottom: 1px solid var(--border);
+      }
+      .model-detail .benchmark-table tr.task-detail[style*="table-row"] {
+        display: block !important;
+      }
+      .model-detail .benchmark-table tr.task-detail > td {
+        padding: 0.9rem 0.8rem;
+      }
+      .conv-meta { display: grid; gap: 0.35rem; }
+      .conv-block { font-size: 0.76rem; padding: 0.75rem 0.8rem; }
+      .conv-judge { font-size: 0.84rem; padding: 0.75rem 0.8rem; }
     }
 
     /* Size class grouping */


### PR DESCRIPTION
Fixes the mobile benchmark detail overflow Frank saw when opening model/task sections.\n\nChanges:\n- Stack benchmark task tables inside model detail panels on narrow screens.\n- Add min-width/max-width constraints and wrapping for transcript, tool, and judge blocks.\n- Regenerate all generated site pages from the generator.\n\nVerification:\n- python3 scripts/site/generate-site.py\n- python3 -m py_compile scripts/site/generate-site.py\n- pnpm check:changed\n- Playwright mobile viewport 390px: opened gpt-5.5 model detail + task transcript, document/body scrollWidth stayed 390.\n- Playwright mobile viewport 390px: opened gemma4:31b Q4 detail + task transcript with judge annotation, document/body scrollWidth stayed 390.\n\nNote: this is only the mobile overflow fix. The broader benchmark grouping by model class, size range, dense/MoE, quant, and thinking level is tracked separately in the benchmark task.