### PR TITLE
fix(benchmark): default no-activity timeout to taskTimeoutSeconds for large models

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -192,6 +192,16 @@ describe("resolveTimeoutBudgets", () => {
     expect(bigCap).toBe(50_000_000);
   });
 
+  it("defaults activity timeout to taskTimeoutSeconds when it exceeds 600s", () => {
+    const { noActivityMs } = resolveTimeoutBudgets({ ...base, taskTimeoutSeconds: 3600 });
+    expect(noActivityMs).toBe(3_600_000);
+    const { noActivityMs: noActivity600 } = resolveTimeoutBudgets({
+      ...base,
+      taskTimeoutSeconds: 600,
+    });
+    expect(noActivity600).toBe(600_000);
+  });
+
   it("respects explicit hardCapSeconds and noActivityTimeoutSeconds", () => {
     const { hardCapMs, noActivityMs } = resolveTimeoutBudgets({
       ...base,

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -1416,9 +1416,11 @@ function mergeProviderConversation(
  * the activity-based "no useful progress" timeout in milliseconds.
  *
  * Defaults:
- *   - noActivityTimeoutSeconds: 600 (10 min). Reset by stdout/stderr/JSONL/
- *     trajectory activity. Triggering this returns completionStatus=timeout
- *     with a no-activity reason.
+ *   - noActivityTimeoutSeconds: max(taskTimeoutSeconds, 600). When the caller
+ *     sets a long taskTimeoutSeconds (e.g. 3600 for a large thinking model),
+ *     the no-activity watchdog automatically matches it so long thinking blocks
+ *     are not incorrectly classified as stalls. Minimum is always 600 (10 min).
+ *     Explicit noActivityTimeoutSeconds overrides this heuristic.
  *   - hardCapSeconds: max(taskTimeoutSeconds, 28800). Acts only as a runaway
  *     ceiling; activity-based timeout is the normal "task is stuck" signal.
  *
@@ -1432,7 +1434,9 @@ export function resolveTimeoutBudgets(config: AgentBenchmarkConfig): {
   const noActivitySec =
     typeof config.noActivityTimeoutSeconds === "number" && config.noActivityTimeoutSeconds > 0
       ? config.noActivityTimeoutSeconds
-      : 600;
+      : config.taskTimeoutSeconds > 600
+        ? config.taskTimeoutSeconds
+        : 600;
   const hardCapInputSec =
     typeof config.hardCapSeconds === "number" && config.hardCapSeconds > 0
       ? config.hardCapSeconds


### PR DESCRIPTION
## Summary

- When `--task-timeout 3600` is set (large thinking model runs) but `--no-activity-timeout` is not explicitly passed, the watchdog defaulted to 600s — killing containers mid-thinking on 31B Q5K_M models
- `resolveTimeoutBudgets` now defaults `noActivityTimeoutSeconds` to `taskTimeoutSeconds` when it exceeds 600s, matching operator intent for large model runs
- `computeConfigHash` encodes the explicit `noActivityTimeoutSeconds` value (null when unset), so this fix preserves artifact reuse across harness upgrades — existing completed task artifacts remain valid
- Added test case: "defaults activity timeout to taskTimeoutSeconds when it exceeds 600s"

## Test plan
- [x] All 101 unit tests pass (verified locally)
- [ ] CI green