### PR TITLE
maintenance: upstream sync 2026-05-12 (6 targeted upstream ports)

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -64,6 +64,7 @@ export async function runPreparedCliAgent(
           provider: params.provider,
           model: context.modelId,
           usage: resultParams.output.usage,
+          ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
           ...(resultParams.effectiveCliSessionId
             ? {
                 cliSessionBinding: {

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -24,7 +24,16 @@ export type AgentHarnessResetParams = {
   sessionId?: string;
   sessionKey?: string;
   sessionFile?: string;
-  reason?: "new" | "reset" | "idle" | "daily" | "compaction" | "deleted" | "unknown";
+  reason?:
+    | "new"
+    | "reset"
+    | "idle"
+    | "daily"
+    | "compaction"
+    | "deleted"
+    | "shutdown"
+    | "restart"
+    | "unknown";
 };
 
 export type AgentHarness = {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -317,7 +317,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps generic loops warn-only below global breaker threshold", () => {
+    it("blocks generic repeated no-progress calls at critical threshold", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
         toolName: fixture.toolName,
@@ -327,7 +327,7 @@ describe("tool-loop-detection", () => {
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
+        expect(loopResult.level).toBe("critical");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -538,10 +538,27 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: warn on repeated identical calls, then block only after
+  // outcomes prove the calls are not making progress.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    noProgressStreak >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(`Critical generic loop detected: ${toolName} repeated ${noProgressStreak} times`);
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: noProgressStreak,
+      message: `CRITICAL: Called ${toolName} with identical arguments and identical outcomes ${noProgressStreak} times. Session execution blocked to prevent runaway loops.`,
+      warningKey: `generic:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+    };
+  }
 
   if (
     !knownPollTool &&

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -20,12 +20,25 @@ type ExtractedLevel<T> = {
   hasDirective: boolean;
 };
 
+const compileDirectivePattern = (names: readonly string[], suffix = ""): RegExp => {
+  const namePattern = names.map(escapeRegExp).join("|");
+  return new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)${suffix}`, "i");
+};
+
+const THINK_DIRECTIVE_PATTERN = compileDirectivePattern(["thinking", "think", "t"]);
+const VERBOSE_DIRECTIVE_PATTERN = compileDirectivePattern(["verbose", "v"]);
+const TRACE_DIRECTIVE_PATTERN = compileDirectivePattern(["trace"]);
+const FAST_DIRECTIVE_PATTERN = compileDirectivePattern(["fast"]);
+const ELEVATED_DIRECTIVE_PATTERN = compileDirectivePattern(["elevated", "elev"]);
+const REASONING_DIRECTIVE_PATTERN = compileDirectivePattern(["reasoning", "reason"]);
+const NOTICE_DIRECTIVE_PATTERN = compileDirectivePattern(["notice", "notices"]);
+const STATUS_DIRECTIVE_PATTERN = compileDirectivePattern(["status"], `(?:\\s*:\\s*)?`);
+
 const matchLevelDirective = (
   body: string,
-  names: string[],
+  pattern: RegExp,
 ): { start: number; end: number; rawLevel?: string } | null => {
-  const namePattern = names.map(escapeRegExp).join("|");
-  const match = body.match(new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)`, "i"));
+  const match = body.match(pattern);
   if (!match || match.index === undefined) {
     return null;
   }
@@ -52,10 +65,10 @@ const matchLevelDirective = (
 
 const extractLevelDirective = <T>(
   body: string,
-  names: string[],
+  pattern: RegExp,
   normalize: (raw?: string) => T | undefined,
 ): ExtractedLevel<T> => {
-  const match = matchLevelDirective(body, names);
+  const match = matchLevelDirective(body, pattern);
   if (!match) {
     return { cleaned: body.trim(), hasDirective: false };
   }
@@ -77,12 +90,9 @@ const extractLevelDirective = <T>(
 
 const extractSimpleDirective = (
   body: string,
-  names: string[],
+  pattern: RegExp,
 ): { cleaned: string; hasDirective: boolean } => {
-  const namePattern = names.map(escapeRegExp).join("|");
-  const match = body.match(
-    new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)(?:\\s*:\\s*)?`, "i"),
-  );
+  const match = body.match(pattern);
   const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();
   return {
     cleaned,
@@ -99,7 +109,7 @@ export function extractThinkDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["thinking", "think", "t"], normalizeThinkLevel);
+  const extracted = extractLevelDirective(body, THINK_DIRECTIVE_PATTERN, normalizeThinkLevel);
   return {
     cleaned: extracted.cleaned,
     thinkLevel: extracted.level,
@@ -117,7 +127,7 @@ export function extractVerboseDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["verbose", "v"], normalizeVerboseLevel);
+  const extracted = extractLevelDirective(body, VERBOSE_DIRECTIVE_PATTERN, normalizeVerboseLevel);
   return {
     cleaned: extracted.cleaned,
     verboseLevel: extracted.level,
@@ -135,7 +145,7 @@ export function extractTraceDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["trace"], normalizeTraceLevel);
+  const extracted = extractLevelDirective(body, TRACE_DIRECTIVE_PATTERN, normalizeTraceLevel);
   return {
     cleaned: extracted.cleaned,
     traceLevel: extracted.level,
@@ -153,7 +163,7 @@ export function extractFastDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["fast"], normalizeFastMode);
+  const extracted = extractLevelDirective(body, FAST_DIRECTIVE_PATTERN, normalizeFastMode);
   return {
     cleaned: extracted.cleaned,
     fastMode: extracted.level,
@@ -171,7 +181,7 @@ export function extractNoticeDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["notice", "notices"], normalizeNoticeLevel);
+  const extracted = extractLevelDirective(body, NOTICE_DIRECTIVE_PATTERN, normalizeNoticeLevel);
   return {
     cleaned: extracted.cleaned,
     noticeLevel: extracted.level,
@@ -189,7 +199,7 @@ export function extractElevatedDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["elevated", "elev"], normalizeElevatedLevel);
+  const extracted = extractLevelDirective(body, ELEVATED_DIRECTIVE_PATTERN, normalizeElevatedLevel);
   return {
     cleaned: extracted.cleaned,
     elevatedLevel: extracted.level,
@@ -207,7 +217,11 @@ export function extractReasoningDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ["reasoning", "reason"], normalizeReasoningLevel);
+  const extracted = extractLevelDirective(
+    body,
+    REASONING_DIRECTIVE_PATTERN,
+    normalizeReasoningLevel,
+  );
   return {
     cleaned: extracted.cleaned,
     reasoningLevel: extracted.level,
@@ -223,7 +237,7 @@ export function extractStatusDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  return extractSimpleDirective(body, ["status"]);
+  return extractSimpleDirective(body, STATUS_DIRECTIVE_PATTERN);
 }
 
 export type { ElevatedLevel, NoticeLevel, ReasoningLevel, ThinkLevel, TraceLevel, VerboseLevel };

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -27728,6 +27728,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["advanced", "url-secret"],
     },
   },
-  version: "2026.4.23",
+  version: "2026.5.0",
   generatedAt: "2026-03-22T21:17:33.302Z",
 };

--- a/src/gateway/active-sessions-shutdown-tracker.ts
+++ b/src/gateway/active-sessions-shutdown-tracker.ts
@@ -1,0 +1,47 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+// Module-level tracker of sessions that have received `session_start` but not
+// yet a paired `session_end`. The close handler drains this set on gateway
+// shutdown / restart so downstream `session_end` plugins (e.g. claude-mem)
+// can finalize sessions that were active when the process stopped, instead
+// of leaving ghost rows in `active` state across restarts (see #57790).
+//
+// Membership is keyed by `sessionId`. The existing session lifecycle paths
+// (`emitGatewaySessionStartPluginHook` /
+// `emitGatewaySessionEndPluginHook` in `session-reset-service.ts`) call into
+// this tracker so a session that has already been finalized by replace /
+// reset / delete / compaction is forgotten before the shutdown drain ever
+// runs. That is what keeps the shutdown finalizer from double-firing.
+
+export type ActiveSessionForShutdown = {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  sessionId: string;
+  storePath: string;
+  sessionFile?: string;
+  agentId?: string;
+};
+
+const trackedSessions = new Map<string, ActiveSessionForShutdown>();
+
+export function noteActiveSessionForShutdown(entry: ActiveSessionForShutdown): void {
+  if (!entry.sessionId) {
+    return;
+  }
+  trackedSessions.set(entry.sessionId, entry);
+}
+
+export function forgetActiveSessionForShutdown(sessionId: string | undefined): void {
+  if (!sessionId) {
+    return;
+  }
+  trackedSessions.delete(sessionId);
+}
+
+export function listActiveSessionsForShutdown(): ActiveSessionForShutdown[] {
+  return Array.from(trackedSessions.values());
+}
+
+export function clearActiveSessionsForShutdownTracker(): void {
+  trackedSessions.clear();
+}

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -35,6 +35,11 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import {
+  forgetActiveSessionForShutdown,
+  listActiveSessionsForShutdown,
+  noteActiveSessionForShutdown,
+} from "./active-sessions-shutdown-tracker.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import {
   archiveSessionTranscriptsDetailed,
@@ -50,6 +55,83 @@ import {
 } from "./session-utils.js";
 
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
+const SHUTDOWN_DRAIN_DEFAULT_TOTAL_TIMEOUT_MS = 2_000;
+
+export type DrainActiveSessionsForShutdownResult = {
+  emittedSessionIds: string[];
+  timedOut: boolean;
+};
+
+/**
+ * Drain all tracked active sessions by emitting `session_end` for each one.
+ * Called by the gateway close handler on SIGTERM/SIGINT to ensure downstream
+ * session_end plugins (e.g. claude-mem) finalize ghost sessions.
+ */
+export async function drainActiveSessionsForShutdown(params: {
+  reason: "shutdown" | "restart";
+  totalTimeoutMs?: number;
+}): Promise<DrainActiveSessionsForShutdownResult> {
+  const tracked = listActiveSessionsForShutdown();
+  if (tracked.length === 0) {
+    return { emittedSessionIds: [], timedOut: false };
+  }
+  const totalTimeoutMs = Math.max(
+    100,
+    Math.floor(params.totalTimeoutMs ?? SHUTDOWN_DRAIN_DEFAULT_TOTAL_TIMEOUT_MS),
+  );
+  const emittedSessionIds: string[] = [];
+  const hookRunner = getGlobalHookRunner();
+  let settledEmissions = 0;
+  const drain = Promise.allSettled(
+    tracked.map(async (entry) => {
+      try {
+        forgetActiveSessionForShutdown(entry.sessionId);
+        emittedSessionIds.push(entry.sessionId);
+        if (!hookRunner?.hasHooks("session_end")) {
+          return;
+        }
+        const transcript = resolveStableSessionEndTranscript({
+          sessionId: entry.sessionId,
+          storePath: entry.storePath,
+          sessionFile: entry.sessionFile,
+          agentId: entry.agentId,
+        });
+        const payload = buildSessionEndHookPayload({
+          sessionId: entry.sessionId,
+          sessionKey: entry.sessionKey,
+          cfg: entry.cfg,
+          reason: params.reason,
+          sessionFile: transcript.sessionFile,
+          transcriptArchived: transcript.transcriptArchived,
+        });
+        await hookRunner.runSessionEnd(payload.event, payload.context);
+      } catch (err) {
+        logVerbose(`session_end hook failed during shutdown drain: ${String(err)}`);
+      } finally {
+        settledEmissions++;
+      }
+    }),
+  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), totalTimeoutMs);
+    timer.unref?.();
+  });
+  try {
+    const result = await Promise.race([drain.then(() => "ok" as const), timeout]);
+    if (result === "timeout") {
+      logVerbose(
+        `shutdown session-end drain timed out after ${totalTimeoutMs}ms with ${tracked.length - settledEmissions} session_end handler(s) still pending`,
+      );
+      return { emittedSessionIds, timedOut: true };
+    }
+    return { emittedSessionIds, timedOut: false };
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined {
   if (!entry) {
@@ -100,7 +182,16 @@ export function emitGatewaySessionEndPluginHook(params: {
   storePath: string;
   sessionFile?: string;
   agentId?: string;
-  reason: "new" | "reset" | "idle" | "daily" | "compaction" | "deleted" | "unknown";
+  reason:
+    | "new"
+    | "reset"
+    | "idle"
+    | "daily"
+    | "compaction"
+    | "deleted"
+    | "shutdown"
+    | "restart"
+    | "unknown";
   archivedTranscripts?: ArchivedSessionTranscript[];
   nextSessionId?: string;
   nextSessionKey?: string;
@@ -108,6 +199,10 @@ export function emitGatewaySessionEndPluginHook(params: {
   if (!params.sessionId) {
     return;
   }
+  // Drop this session from the shutdown finalizer's tracked set unconditionally
+  // -- even when no plugin hooks are registered for `session_end`, the session
+  // is being closed here and must not be re-finalized by a later shutdown drain.
+  forgetActiveSessionForShutdown(params.sessionId);
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("session_end")) {
     return;
@@ -139,10 +234,24 @@ export function emitGatewaySessionStartPluginHook(params: {
   sessionKey: string;
   sessionId?: string;
   resumedFrom?: string;
+  storePath?: string;
+  sessionFile?: string;
+  agentId?: string;
 }): void {
   if (!params.sessionId) {
     return;
   }
+  // Track the session for the shutdown finalizer even when no plugin hooks are
+  // registered locally, so a later restart still emits a typed `session_end`
+  // for sessions that opened while a `session_end` plugin was attached.
+  noteActiveSessionForShutdown({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    storePath: params.storePath ?? "",
+    sessionFile: params.sessionFile,
+    agentId: params.agentId,
+  });
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("session_start")) {
     return;

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -380,6 +380,8 @@ export type PluginHookSessionEndReason =
   | "daily"
   | "compaction"
   | "deleted"
+  | "shutdown"
+  | "restart"
   | "unknown";
 
 export type PluginHookSessionEndEvent = {


### PR DESCRIPTION
## Summary

Selective upstream port from openclaw/openclaw main (upstream/main @ 3029da8ef9) into gemmaclaw (origin/main @ 4fb44a7d59). Full git merge with `--allow-unrelated-histories` is not viable since gemmaclaw was bootstrapped from an openclaw file copy, not a git clone. Strategy: identify high-value upstream improvements in shared `src/` files and apply them as targeted ports.

### Changes ported (6 upstream improvements)

- **`src/auto-reply/reply/directives.ts`** — precompile directive regexes at module init to avoid per-call recompilation overhead
- **`src/agents/tool-loop-detection.ts` + test** — add generic no-progress blocker for tool loops that produce output but make no measurable forward progress
- **`src/agents/cli-runner.ts`** — persist `lastCallUsage` alongside `usage` in `runPreparedCliAgent` output params so downstream can access last-call token counts
- **`src/gateway/active-sessions-shutdown-tracker.ts`** (new module) — tracks sessions that received `session_start` but not a paired `session_end`, enabling graceful drain on gateway shutdown/restart to prevent ghost active rows across restarts
- **`src/gateway/session-reset-service.ts`** — wire shutdown tracker into session start/end hooks; add `drainActiveSessionsOnShutdown` for close handler
- **`src/plugins/hook-types.ts` + `src/agents/harness/types.ts`** — add `"shutdown"` and `"restart"` to `PluginHookSessionEndReason` and `AgentHarnessResetParams.reason` unions

### Upstream context

- Upstream base: `upstream/main @ 3029da8ef9`
- Gemmaclaw base: `origin/main @ 4fb44a7d59`
- Total upstream delta: 5612 commits (majority are benchmark, chore, test, and docs changes not applicable to gemmaclaw)
- Targeted approach: 6 commits selected from gateway session reliability, CLI fix, auto-reply, and type expansion categories

### Regression gate results

- `pnpm build` — PASS
- `pnpm check:changed` (pre-commit hook) — PASS: typecheck core+tests, lint (0 warnings/errors), import cycles clean, 2632 gateway tests, 1155 plugin tests, 31 unit-fast all passed
- `gemmaclaw --version` — `Gemmaclaw 2026.5.0 (57d8763)` ✓
- `gemmaclaw setup --help` — PASS
- `gemmaclaw backup --help` — PASS
- Live smoke — BLOCKED: active gemma4:31b benchmark running (benchmark guard prevents concurrent Ollama access). Docker and qwen3.6:35b are available. Run `bash scripts/e2e/gemmaclaw-setup-live-smoke.sh` after benchmark completes before admin merge.

### No Gemmaclaw product features removed

Gemmaclaw-specific setup wizard, Docker sandbox, backup/restore, shared folder, and benchmark harness are unaffected.

## Merge requirements

- [ ] CI green
- [ ] Live smoke (`bash scripts/e2e/gemmaclaw-setup-live-smoke.sh`) run after active benchmark completes