### PR TITLE
fix(benchmark): continue past container failures instead of crashing

### DIFF
--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -343,20 +343,23 @@ async function runAgentModeInDocker(opts: Record<string, string | boolean>): Pro
     dockerArgs.push(AGENT_BENCHMARK_DOCKER_IMAGE, ...forwardedArgs);
 
     console.log(`\n[container ${index + 1}/${selectedTaskIds.length}] ${taskId}`);
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve) => {
       const child = spawn("docker", dockerArgs, { cwd: repoRoot, stdio: "inherit" });
-      child.on("error", reject);
+      child.on("error", (err) => {
+        console.error(
+          `\n[container ${index + 1}/${selectedTaskIds.length}] ${taskId}: SPAWN ERROR: ${err.message} — task skipped, continuing to next`,
+        );
+        restoreHostOutputOwnership(hostOutputDir);
+        resolve();
+      });
       child.on("close", (code) => {
         restoreHostOutputOwnership(hostOutputDir);
-        if (code === 0) {
-          resolve();
-        } else {
-          reject(
-            new Error(
-              `containerized agent benchmark task ${taskId} failed with exit code ${code ?? 1}`,
-            ),
+        if (code !== 0) {
+          console.error(
+            `\n[container ${index + 1}/${selectedTaskIds.length}] ${taskId}: CONTAINER FAILED (exit ${code ?? 1}) — task skipped, continuing to next`,
           );
         }
+        resolve();
       });
     });
   }


### PR DESCRIPTION
## Summary
- When a per-task Docker container exited non-zero, the outer benchmark loop rejected the promise and terminated the entire run
- Any transient container failure (inner agent crash, gateway OOM, etc.) aborted all remaining tasks
- Changed the container dispatch loop to resolve on all exits and log failures clearly
- Failed tasks have no result.json written so they get retried on the next benchmark run

## Root cause
Container 5/47 (email_action_response) in the Q5_K_M thinking=high benchmark exited non-zero (inner agent crashed immediately after gog state seeding, likely transient). The outer cli-standalone.ts had no error handling and the entire 47-task benchmark terminated at task 5.

## Test plan
- [x] Unit tests pass (115/115 verified in pre-commit hook)