### PR TITLE
fix(benchmark): cap Ollama active-generation extension at 90 min per task

### DIFF
--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -2018,9 +2018,19 @@ export async function dispatchTask(
     // prevents false timeouts during extended thinking phases (e.g. Q5_K_M/
     // Q6_K with thinking=high can generate 40+ min thinking traces with no
     // JSONL/trajectory/stdout output while Ollama is actively generating).
+    //
+    // Extension cap: limit total Ollama-active extensions to 90 minutes per
+    // task. Q5_K_M/Q6_K thinking=high can enter pathological thinking loops
+    // where the model continuously generates thinking tokens for hours with no
+    // useful output. Without the cap, `lastActivityMs` resets indefinitely and
+    // the task only terminates at the hard cap (28800s). With the cap, after
+    // 90 min of continuous "Ollama active" extensions the no-activity timer
+    // resumes and kills the stuck task within noActivityMs.
     let ollamaCheckInFlight = false;
     let lastOllamaCheckMs = 0;
+    let ollamaActiveFirstExtensionMs: number | null = null;
     const OLLAMA_CHECK_INTERVAL_MS = 30_000;
+    const OLLAMA_ACTIVE_EXTENSION_CAP_MS = 90 * 60 * 1000; // 90 min per task
     const scheduleOllamaActiveCheck = () => {
       if (config.backend !== "ollama" || ollamaCheckInFlight) {
         return;
@@ -2034,7 +2044,19 @@ export async function dispatchTask(
       void isOllamaModelActive(config.ollamaUrl, config.model)
         .then((active) => {
           if (active) {
-            lastActivityMs = Date.now();
+            const nowMs = Date.now();
+            if (ollamaActiveFirstExtensionMs === null) {
+              ollamaActiveFirstExtensionMs = nowMs;
+            }
+            const extensionMs = nowMs - ollamaActiveFirstExtensionMs;
+            if (extensionMs < OLLAMA_ACTIVE_EXTENSION_CAP_MS) {
+              lastActivityMs = nowMs;
+            }
+            // else: cap exceeded — stop extending so noActivity timer fires
+          } else {
+            // Model no longer in VRAM; reset so a fresh generation gets a
+            // full 90-min window
+            ollamaActiveFirstExtensionMs = null;
           }
         })
         .finally(() => {


### PR DESCRIPTION
## Problem

Q5_K_M and Q6_K with `thinking=high` enter pathological thinking loops where the model generates tokens continuously for hours with no useful output (no JSONL turns, no trajectory events, no assistant responses).

PR #165 added Ollama active-generation monitoring to prevent false timeouts during legitimate extended thinking phases. However, it reset `lastActivityMs` unconditionally whenever the model was loaded in VRAM — so a stuck model that never produces output was never killed by the no-activity timer. Tasks ran until the 8-hour hard cap.

Observed: `email_action_response` ran for 6+ hours on Q5_K_M thinking=high with all container files frozen. No JSONL/trajectory/stdout growth throughout.

## Fix

Track when the first Ollama-active extension is granted (`ollamaActiveFirstExtensionMs`). Stop resetting `lastActivityMs` once the extension has been active for 90 continuous minutes. The no-activity timer then fires within `noActivityMs` (≤ 3600s) after the cap is hit.

The 90-minute cap covers legitimate Q5_K_M/Q6_K thinking traces (observed up to ~40 min) while killing pathological loops within 90 min + noActivityMs (≤ 2.5h total per task). Resets when the model leaves VRAM.

49 tests pass.