### PR TITLE
Expand benchmark variation catalog

### DIFF
--- a/docs/cli/benchmark.md
+++ b/docs/cli/benchmark.md
@@ -32,6 +32,17 @@ openclaw benchmark sandbox --file tasks.json
 openclaw benchmark sandbox --file audit.txt --model gemma3:4b --gemini-api-key "$GEMINI_KEY"
 ```
 
+Gemmaclaw agent benchmark suites can also be run through the package script:
+
+```bash
+pnpm benchmark agent list --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513
+pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variants-gemini-flash-sample --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600
+```
+
+Use the 10-per-template sample before a full variation sweep. It runs 1,470
+tasks, 10 sampled cases from each of the 147 generated templates, while still
+covering the whole template catalog.
+
 ## Modes
 
 ### Docker mode (default)
@@ -75,6 +86,21 @@ openclaw benchmark --mock
 | `--context-length <n>` | Context window size (`num_ctx`)                                   |
 | `--gpu-layers <n>`     | Number of GPU layers (`num_gpu`)                                  |
 | `--batch-size <n>`     | Batch size (`num_batch`)                                          |
+
+## Agent variation sampling
+
+The `variants` suite expands each Gemmaclaw-owned benchmark template into 200
+controlled cases. A full run is 29,400 tasks. For harness validation, use a
+deterministic sample before spending model quota on the full suite:
+
+```bash
+pnpm benchmark agent list --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513
+pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variants-gemini-flash-sample --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600
+```
+
+`--sample-per-template` selects the same number of generated variations from
+each template. `--sample-seed` makes the selection stable, so failed sampled
+tasks can be reproduced, rerun, and compared across backends.
 
 ## Subcommands
 

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -2440,18 +2440,18 @@ def generate_benchmark_suite_variations():
         {
             "name": "Generated Template Variation Suite",
             "status": "Runnable, reference validation pending",
-            "tasks": "7350 generated tests",
+            "tasks": "29400 generated tests",
             "command": "pnpm benchmark agent --suite variants",
             "description": (
                 "Each of the 147 expanded Gemmaclaw tasks is treated as a reusable template "
-                "and generates 50 controlled fixture and wording variants. Use this suite "
+                "and generates 200 controlled fixture and wording variants. Use this suite "
                 "for scale testing before model score publication."
             ),
         },
         {
             "name": "Combined Research Suite",
             "status": "For development sweeps only",
-            "tasks": "7544 tasks",
+            "tasks": "29594 tasks",
             "command": "pnpm benchmark agent --suite all",
             "description": (
                 "Runs the default Gemmaclaw suite, expanded coverage tasks, and generated "
@@ -2514,7 +2514,7 @@ def load_expanded_agent_task_catalog():
             "description": (desc_a or desc_b or "").replace("\n", " ").strip(),
             "category": category_key,
             "difficulty": difficulty,
-            "variations": [f"variant_{task_id}_{i:02d}" for i in range(1, 51)],
+            "variations": [f"variant_{task_id}_{i:02d}" for i in range(1, 201)],
         })
     return tasks
 
@@ -2576,6 +2576,69 @@ def benchmark_category_label(category):
     return labels.get(category, category.replace("expanded_", "").replace("_", " ").title())
 
 
+VARIANT_PERSONAS = [
+    "operations lead",
+    "engineering manager",
+    "customer success owner",
+    "security reviewer",
+    "finance partner",
+    "research coordinator",
+    "product manager",
+    "support lead",
+    "data analyst",
+    "release captain",
+]
+
+
+VARIANT_CONTEXTS = [
+    "Monday morning handoff",
+    "Wednesday blocker review",
+    "Friday launch checkpoint",
+    "post-incident cleanup",
+    "quarterly planning packet",
+    "vendor follow-up queue",
+    "customer escalation window",
+    "internal audit prep",
+    "prototype evaluation",
+    "team health review",
+]
+
+
+VARIANT_DISTRACTORS = [
+    "stale duplicate instructions",
+    "one irrelevant promotional note",
+    "two conflicting timestamps",
+    "an external source asking for unsafe action",
+    "missing optional metadata",
+    "a partially duplicated file",
+    "a vague owner reference",
+    "a low-priority FYI thread",
+    "an outdated status line",
+    "a noisy log excerpt",
+]
+
+
+VARIANT_OUTPUT_FRAMES = [
+    "concise operator handoff",
+    "audit-ready reviewer packet",
+]
+
+
+def benchmark_variation_metadata(task, index):
+    persona = VARIANT_PERSONAS[index % len(VARIANT_PERSONAS)]
+    context = VARIANT_CONTEXTS[(index // len(VARIANT_PERSONAS)) % len(VARIANT_CONTEXTS)]
+    distractor = VARIANT_DISTRACTORS[(index * 7) % len(VARIANT_DISTRACTORS)]
+    output_frame = VARIANT_OUTPUT_FRAMES[(index // 100) % len(VARIANT_OUTPUT_FRAMES)]
+    return {
+        "persona": persona,
+        "context": context,
+        "distractor": distractor,
+        "output_frame": output_frame,
+        "artifact": f"{task['id']}_variation_output.md",
+        "command": f"pnpm benchmark agent --suite variants --task variant_{task['id']}_{index + 1:02d}",
+    }
+
+
 def generate_benchmark_test_catalog():
     """Render a clickable catalog of every expanded task template and generated variation."""
     default_tasks = load_default_agent_task_catalog()
@@ -2613,7 +2676,7 @@ def generate_benchmark_test_catalog():
     stat_cards = [
         ("Published baseline", str(total_default or 47), "Default comparable task suite"),
         ("Expanded templates", str(total_templates), "Every template listed below"),
-        ("Generated variations", f"{total_variations:,}", "50 variants under each template"),
+        ("Generated variations", f"{total_variations:,}", "200 variants under each template"),
         ("All registered tests", f"{(total_default or 47) + total_templates + total_variations:,}", "Default + expanded + variants"),
     ]
     stat_html = "".join(
@@ -2643,7 +2706,7 @@ def generate_benchmark_test_catalog():
         category_cards.append(f"""<a class="suite-category-card" href="#{cat_anchor}">
   <strong>{html_escape(benchmark_category_label(category))}</strong>
   <span>{len(cat_tasks)} templates</span>
-  <small>{len(cat_tasks) * 50:,} generated variations</small>
+  <small>{len(cat_tasks) * 200:,} generated variations</small>
 </a>""")
 
     category_sections = []
@@ -2675,20 +2738,47 @@ def generate_benchmark_test_catalog():
         for task in cat_tasks:
             template_anchor = f"template-{slugify(task['id'])}"
             variation_links = "".join(
-                f'<a id="{html_escape(variation_id)}" class="variation-chip" href="#{html_escape(variation_id)}" '
-                f'title="pnpm benchmark agent --suite variants --task {html_escape(variation_id)}">'
-                f'{html_escape(variation_id.replace("variant_", ""))}</a>'
-                for variation_id in task["variations"]
+                (
+                    lambda metadata: (
+                        f'<a id="{html_escape(variation_id)}" class="variation-chip" href="#{html_escape(variation_id)}" '
+                        f'data-variation-chip data-variation-id="{html_escape(variation_id)}" '
+                        f'data-template-name="{html_escape(task["name"])}" '
+                        f'data-persona="{html_escape(metadata["persona"])}" '
+                        f'data-context="{html_escape(metadata["context"])}" '
+                        f'data-distractor="{html_escape(metadata["distractor"])}" '
+                        f'data-output-frame="{html_escape(metadata["output_frame"])}" '
+                        f'data-artifact="{html_escape(metadata["artifact"])}" '
+                        f'data-command="{html_escape(metadata["command"])}" '
+                        f'title="{html_escape(metadata["command"])}">'
+                        f'{html_escape(variation_id.replace("variant_", ""))}</a>'
+                    )
+                )(benchmark_variation_metadata(task, index))
+                for index, variation_id in enumerate(task["variations"])
             )
             template_cards.append(f"""<details id="{template_anchor}" class="test-template-card">
   <summary>
     <span class="template-title">{html_escape(task["name"])}</span>
-    <span class="template-meta"><code>{html_escape(task["id"])}</code> · {html_escape(task["difficulty"])} · 50 variations</span>
+    <span class="template-meta"><code>{html_escape(task["id"])}</code> · {html_escape(task["difficulty"])} · 200 variations</span>
   </summary>
   <p>{html_escape(task["description"])}</p>
   <div class="template-command"><code>pnpm benchmark agent --suite expanded --task {html_escape(task["id"])}</code></div>
   <div class="variation-list" aria-label="Generated variations for {html_escape(task['name'])}">
     {variation_links}
+  </div>
+  <div class="variation-detail" data-variation-detail hidden>
+    <div class="variation-detail-header">
+      <span>Selected Variation</span>
+      <strong data-variation-detail-id></strong>
+    </div>
+    <dl>
+      <div><dt>Template</dt><dd data-variation-detail-template></dd></div>
+      <div><dt>Persona</dt><dd data-variation-detail-persona></dd></div>
+      <div><dt>Context</dt><dd data-variation-detail-context></dd></div>
+      <div><dt>Complication</dt><dd data-variation-detail-distractor></dd></div>
+      <div><dt>Output Frame</dt><dd data-variation-detail-output-frame></dd></div>
+      <div><dt>Artifact</dt><dd><code data-variation-detail-artifact></code></dd></div>
+      <div><dt>Run</dt><dd><code data-variation-detail-command></code></dd></div>
+    </dl>
   </div>
 </details>""")
         category_sections.append(f"""<section id="{cat_anchor}" class="suite-category-section">
@@ -2696,7 +2786,7 @@ def generate_benchmark_test_catalog():
     <h3>{html_escape(benchmark_category_label(category))}</h3>
     <a href="#benchmark-test-catalog">Back to catalog</a>
   </div>
-  <p>{len(cat_tasks)} test templates, {len(cat_tasks) * 50:,} generated variations.</p>
+  <p>{len(cat_tasks)} test templates, {len(cat_tasks) * 200:,} generated variations.</p>
   <div class="test-template-list">{''.join(template_cards)}</div>
 </section>""")
 
@@ -2716,14 +2806,50 @@ def generate_benchmarks_page(results, task_explanations_html="", agent_preview_h
     """Compact benchmark landing page. Each result links to a dedicated detail page."""
     test_catalog_html = generate_benchmark_test_catalog()
     catalog_scripts = """
+    function setVariationDetailText(panel, selector, value) {
+      const target = panel.querySelector(selector);
+      if (target) target.textContent = value || '';
+    }
+    function showBenchmarkVariation(chip, shouldScroll) {
+      if (!chip || !chip.matches('[data-variation-chip]')) return;
+      const parentDetails = chip.closest('details.test-template-card');
+      if (parentDetails) parentDetails.open = true;
+      const panel = parentDetails ? parentDetails.querySelector('[data-variation-detail]') : null;
+      if (!panel) return;
+      panel.hidden = false;
+      setVariationDetailText(panel, '[data-variation-detail-id]', chip.dataset.variationId);
+      setVariationDetailText(panel, '[data-variation-detail-template]', chip.dataset.templateName);
+      setVariationDetailText(panel, '[data-variation-detail-persona]', chip.dataset.persona);
+      setVariationDetailText(panel, '[data-variation-detail-context]', chip.dataset.context);
+      setVariationDetailText(panel, '[data-variation-detail-distractor]', chip.dataset.distractor);
+      setVariationDetailText(panel, '[data-variation-detail-output-frame]', chip.dataset.outputFrame);
+      setVariationDetailText(panel, '[data-variation-detail-artifact]', chip.dataset.artifact);
+      setVariationDetailText(panel, '[data-variation-detail-command]', chip.dataset.command);
+      document.querySelectorAll('[data-variation-chip][aria-current="true"]').forEach((active) => {
+        active.removeAttribute('aria-current');
+      });
+      chip.setAttribute('aria-current', 'true');
+      if (shouldScroll) panel.scrollIntoView({ block: 'center' });
+    }
     function openBenchmarkHashTarget() {
       if (!window.location.hash) return;
       const target = document.getElementById(window.location.hash.slice(1));
       if (!target) return;
       const parentDetails = target.closest('details.test-template-card');
       if (parentDetails) parentDetails.open = true;
-      target.scrollIntoView({ block: 'center' });
+      if (target.matches('[data-variation-chip]')) {
+        showBenchmarkVariation(target, true);
+      } else {
+        target.scrollIntoView({ block: 'center' });
+      }
     }
+    document.addEventListener('click', (event) => {
+      const chip = event.target.closest('[data-variation-chip]');
+      if (!chip) return;
+      event.preventDefault();
+      history.pushState(null, '', `#${chip.id}`);
+      showBenchmarkVariation(chip, true);
+    });
     window.addEventListener('hashchange', openBenchmarkHashTarget);
     window.addEventListener('DOMContentLoaded', openBenchmarkHashTarget);
 """
@@ -2906,7 +3032,10 @@ pnpm benchmark agent --run-id q4-rtx3090-v1 --rerun-failed
 pnpm benchmark agent --run-id q4-rtx3090-v1 --assemble
 
 # 7. Mock mode: test the harness without a real model (instant)
-pnpm benchmark agent --mock --run-id smoke</code></pre></div>
+pnpm benchmark agent --mock --run-id smoke
+
+# 8. Sample the 200-variation template suite before a full sweep
+pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variants-gemini-flash-sample --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600</code></pre></div>
 
       <h3>Backends</h3>
       <p>The benchmark supports two inference backends:</p>
@@ -2932,19 +3061,22 @@ pnpm benchmark agent --model gemma3:1b --backend llama-cpp --llama-cpp-url http:
         <tr><th>Suite</th><th>Tasks</th><th>Use</th><th>Command</th></tr>
         <tr><td><code>default</code></td><td>47</td><td>Published Gemmaclaw model comparisons</td><td><code>pnpm benchmark agent --suite default</code></td></tr>
         <tr><td><code>expanded</code></td><td>147</td><td>Gemmaclaw expanded productivity, research, writing, coding, analysis, log, meeting, memory, skill, and integration tasks</td><td><code>pnpm benchmark agent --suite expanded</code></td></tr>
-        <tr><td><code>variants</code></td><td>7350</td><td>147 Gemmaclaw-owned templates with 50 controlled variations each</td><td><code>pnpm benchmark agent --suite variants</code></td></tr>
-        <tr><td><code>all</code></td><td>7544</td><td>Development sweeps across every registered task family</td><td><code>pnpm benchmark agent --suite all</code></td></tr>
+        <tr><td><code>variants</code></td><td>29400</td><td>147 Gemmaclaw-owned templates with 200 controlled variations each</td><td><code>pnpm benchmark agent --suite variants</code></td></tr>
+        <tr><td><code>all</code></td><td>29594</td><td>Development sweeps across every registered task family</td><td><code>pnpm benchmark agent --suite all</code></td></tr>
       </table></div>
 
       <h3>Template Variation Suite</h3>
-      <p>The benchmark now includes 7350 generated tests by turning every expanded Gemmaclaw task into a reusable template with 50 controlled variants underneath it. A template defines the skill being measured, fixture schema, expected behavior, and grading rubric. Variants alter role, context, distractors, wording, and artifact requirements while preserving the same core capability target.</p>
+      <p>The benchmark now includes 29400 generated tests by turning every expanded Gemmaclaw task into a reusable template with 200 controlled variants underneath it. A template defines the skill being measured, fixture schema, expected behavior, and grading rubric. Variants alter role, context, distractors, wording, output framing, and artifact requirements while preserving the same core capability target.</p>
+      <p>For harness validation, use a deterministic sample before running the full 29400-case suite. The standard smoke path is 10 variants per template, which gives 1470 tasks across all 147 templates and still exercises every template family.</p>
+      <div class="code-block"><pre><code>pnpm benchmark agent list --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513
+pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variants-gemini-flash-sample --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600</code></pre></div>
       <div class="table-wrap"><table>
         <tr><th>Template Family</th><th>Variants</th><th>Capability</th></tr>
-        <tr><td>Expanded productivity</td><td>50 per task template</td><td>Calendar, inbox, task, and assistant workflow coverage</td></tr>
-        <tr><td>Expanded research and writing</td><td>50 per task template</td><td>Source synthesis, long-form reports, editing, and transformation</td></tr>
-        <tr><td>Expanded coding and skills</td><td>50 per task template</td><td>Code review, debugging, skill composition, and implementation planning</td></tr>
-        <tr><td>Expanded analysis and logs</td><td>50 per task template</td><td>CSV analysis, log triage, meeting extraction, and structured decisions</td></tr>
-        <tr><td>Expanded integrations</td><td>50 per task template</td><td>Safe simulated browser, calendar, email, and external-service workflows</td></tr>
+        <tr><td>Expanded productivity</td><td>200 per task template</td><td>Calendar, inbox, task, and assistant workflow coverage</td></tr>
+        <tr><td>Expanded research and writing</td><td>200 per task template</td><td>Source synthesis, long-form reports, editing, and transformation</td></tr>
+        <tr><td>Expanded coding and skills</td><td>200 per task template</td><td>Code review, debugging, skill composition, and implementation planning</td></tr>
+        <tr><td>Expanded analysis and logs</td><td>200 per task template</td><td>CSV analysis, log triage, meeting extraction, and structured decisions</td></tr>
+        <tr><td>Expanded integrations</td><td>200 per task template</td><td>Safe simulated browser, calendar, email, and external-service workflows</td></tr>
       </table></div>
       <p>Generated variants are not publishable by default. They must pass reference e2e validation, harness-bug review, clean model runs, judge evaluation, and site QA before they appear as comparable results.</p>
 
@@ -2954,6 +3086,8 @@ pnpm benchmark agent --model gemma3:1b --backend llama-cpp --llama-cpp-url http:
         <tr><td><code>--model &lt;name&gt;</code></td><td>(auto from hardware)</td><td>Model to test (e.g. gemma4:e4b, gemma4:31b)</td></tr>
         <tr><td><code>--backend &lt;type&gt;</code></td><td>ollama</td><td>Backend: ollama or llama-cpp</td></tr>
         <tr><td><code>--suite &lt;name&gt;</code></td><td>default</td><td>Task suite: default, expanded, variants, or all</td></tr>
+        <tr><td><code>--sample-per-template &lt;n&gt;</code></td><td>(off)</td><td>For generated variation suites, run a deterministic sample of n variants from each template</td></tr>
+        <tr><td><code>--sample-seed &lt;text&gt;</code></td><td>default</td><td>Seed used to pick stable sampled variants across repeated runs</td></tr>
         <tr><td><code>--quant &lt;level&gt;</code></td><td>(auto-detected)</td><td>Quantization to record (Q4_K_M, Q8_0, FP16)</td></tr>
         <tr><td><code>--thinking &lt;level&gt;</code></td><td>default</td><td>Thinking level (off, low, medium, high)</td></tr>
         <tr><td><code>--filter &lt;text&gt;</code></td><td>(all tasks)</td><td>Run tasks matching text (id or name)</td></tr>
@@ -3586,6 +3720,62 @@ CSS = """
     .variation-chip:hover {
       border-color: var(--accent);
       color: var(--accent);
+    }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
 
     /* Search */

--- a/site/benchmark-results/gemma4-26b-q4-high.html
+++ b/site/benchmark-results/gemma4-26b-q4-high.html
@@ -491,6 +491,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/benchmark-results/gemma4-31b-q4-high.html
+++ b/site/benchmark-results/gemma4-31b-q4-high.html
@@ -491,6 +491,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/benchmark-results/gemma4-e4b-q4-high.html
+++ b/site/benchmark-results/gemma4-e4b-q4-high.html
@@ -491,6 +491,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/benchmarking.html
+++ b/site/benchmarking.html
@@ -500,6 +500,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {
@@ -1027,7 +1083,10 @@ pnpm benchmark agent --run-id q4-rtx3090-v1 --rerun-failed
 pnpm benchmark agent --run-id q4-rtx3090-v1 --assemble
 
 # 7. Mock mode: test the harness without a real model (instant)
-pnpm benchmark agent --mock --run-id smoke</code></pre></div>
+pnpm benchmark agent --mock --run-id smoke
+
+# 8. Sample the 200-variation template suite before a full sweep
+pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variants-gemini-flash-sample --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600</code></pre></div>
 
       <h3>Backends</h3>
       <p>The benchmark supports two inference backends:</p>
@@ -1053,19 +1112,22 @@ pnpm benchmark agent --model gemma3:1b --backend llama-cpp --llama-cpp-url http:
         <tr><th>Suite</th><th>Tasks</th><th>Use</th><th>Command</th></tr>
         <tr><td><code>default</code></td><td>47</td><td>Published Gemmaclaw model comparisons</td><td><code>pnpm benchmark agent --suite default</code></td></tr>
         <tr><td><code>expanded</code></td><td>147</td><td>Gemmaclaw expanded productivity, research, writing, coding, analysis, log, meeting, memory, skill, and integration tasks</td><td><code>pnpm benchmark agent --suite expanded</code></td></tr>
-        <tr><td><code>variants</code></td><td>7350</td><td>147 Gemmaclaw-owned templates with 50 controlled variations each</td><td><code>pnpm benchmark agent --suite variants</code></td></tr>
-        <tr><td><code>all</code></td><td>7544</td><td>Development sweeps across every registered task family</td><td><code>pnpm benchmark agent --suite all</code></td></tr>
+        <tr><td><code>variants</code></td><td>29400</td><td>147 Gemmaclaw-owned templates with 200 controlled variations each</td><td><code>pnpm benchmark agent --suite variants</code></td></tr>
+        <tr><td><code>all</code></td><td>29594</td><td>Development sweeps across every registered task family</td><td><code>pnpm benchmark agent --suite all</code></td></tr>
       </table></div>
 
       <h3>Template Variation Suite</h3>
-      <p>The benchmark now includes 7350 generated tests by turning every expanded Gemmaclaw task into a reusable template with 50 controlled variants underneath it. A template defines the skill being measured, fixture schema, expected behavior, and grading rubric. Variants alter role, context, distractors, wording, and artifact requirements while preserving the same core capability target.</p>
+      <p>The benchmark now includes 29400 generated tests by turning every expanded Gemmaclaw task into a reusable template with 200 controlled variants underneath it. A template defines the skill being measured, fixture schema, expected behavior, and grading rubric. Variants alter role, context, distractors, wording, output framing, and artifact requirements while preserving the same core capability target.</p>
+      <p>For harness validation, use a deterministic sample before running the full 29400-case suite. The standard smoke path is 10 variants per template, which gives 1470 tasks across all 147 templates and still exercises every template family.</p>
+      <div class="code-block"><pre><code>pnpm benchmark agent list --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513
+pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variants-gemini-flash-sample --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600</code></pre></div>
       <div class="table-wrap"><table>
         <tr><th>Template Family</th><th>Variants</th><th>Capability</th></tr>
-        <tr><td>Expanded productivity</td><td>50 per task template</td><td>Calendar, inbox, task, and assistant workflow coverage</td></tr>
-        <tr><td>Expanded research and writing</td><td>50 per task template</td><td>Source synthesis, long-form reports, editing, and transformation</td></tr>
-        <tr><td>Expanded coding and skills</td><td>50 per task template</td><td>Code review, debugging, skill composition, and implementation planning</td></tr>
-        <tr><td>Expanded analysis and logs</td><td>50 per task template</td><td>CSV analysis, log triage, meeting extraction, and structured decisions</td></tr>
-        <tr><td>Expanded integrations</td><td>50 per task template</td><td>Safe simulated browser, calendar, email, and external-service workflows</td></tr>
+        <tr><td>Expanded productivity</td><td>200 per task template</td><td>Calendar, inbox, task, and assistant workflow coverage</td></tr>
+        <tr><td>Expanded research and writing</td><td>200 per task template</td><td>Source synthesis, long-form reports, editing, and transformation</td></tr>
+        <tr><td>Expanded coding and skills</td><td>200 per task template</td><td>Code review, debugging, skill composition, and implementation planning</td></tr>
+        <tr><td>Expanded analysis and logs</td><td>200 per task template</td><td>CSV analysis, log triage, meeting extraction, and structured decisions</td></tr>
+        <tr><td>Expanded integrations</td><td>200 per task template</td><td>Safe simulated browser, calendar, email, and external-service workflows</td></tr>
       </table></div>
       <p>Generated variants are not publishable by default. They must pass reference e2e validation, harness-bug review, clean model runs, judge evaluation, and site QA before they appear as comparable results.</p>
 
@@ -1075,6 +1137,8 @@ pnpm benchmark agent --model gemma3:1b --backend llama-cpp --llama-cpp-url http:
         <tr><td><code>--model &lt;name&gt;</code></td><td>(auto from hardware)</td><td>Model to test (e.g. gemma4:e4b, gemma4:31b)</td></tr>
         <tr><td><code>--backend &lt;type&gt;</code></td><td>ollama</td><td>Backend: ollama or llama-cpp</td></tr>
         <tr><td><code>--suite &lt;name&gt;</code></td><td>default</td><td>Task suite: default, expanded, variants, or all</td></tr>
+        <tr><td><code>--sample-per-template &lt;n&gt;</code></td><td>(off)</td><td>For generated variation suites, run a deterministic sample of n variants from each template</td></tr>
+        <tr><td><code>--sample-seed &lt;text&gt;</code></td><td>default</td><td>Seed used to pick stable sampled variants across repeated runs</td></tr>
         <tr><td><code>--quant &lt;level&gt;</code></td><td>(auto-detected)</td><td>Quantization to record (Q4_K_M, Q8_0, FP16)</td></tr>
         <tr><td><code>--thinking &lt;level&gt;</code></td><td>default</td><td>Thinking level (off, low, medium, high)</td></tr>
         <tr><td><code>--filter &lt;text&gt;</code></td><td>(all tasks)</td><td>Run tasks matching text (id or name)</td></tr>

--- a/site/community.html
+++ b/site/community.html
@@ -500,6 +500,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/goals.html
+++ b/site/goals.html
@@ -500,6 +500,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/index.html
+++ b/site/index.html
@@ -500,6 +500,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/self-hosting.html
+++ b/site/self-hosting.html
@@ -500,6 +500,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/site/setup.html
+++ b/site/setup.html
@@ -500,6 +500,62 @@
       border-color: var(--accent);
       color: var(--accent);
     }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
 
     /* Search */
     .search-bar {

--- a/src/gemmaclaw/benchmark/agent-container-guard.test.ts
+++ b/src/gemmaclaw/benchmark/agent-container-guard.test.ts
@@ -130,10 +130,27 @@ describe("agent benchmark container guard", () => {
     expect(resolveAgentBenchmarkTasks({}).length).toBe(47);
     expect(resolveAgentBenchmarkTasks({ suite: "default" }).length).toBe(47);
     expect(resolveAgentBenchmarkTasks({ suite: "expanded" }).length).toBe(147);
-    expect(resolveAgentBenchmarkTasks({ suite: "variants" }).length).toBe(7350);
-    expect(resolveAgentBenchmarkTasks({ suite: "all" }).length).toBe(7544);
+    expect(resolveAgentBenchmarkTasks({ suite: "variants" }).length).toBe(29400);
+    expect(resolveAgentBenchmarkTasks({ suite: "all" }).length).toBe(29594);
     expect(() => resolveAgentBenchmarkTasks({ suite: "missing" })).toThrow(
       /Unsupported agent benchmark suite/,
     );
+  });
+
+  it("samples generated variations per template with a stable seed", () => {
+    const tasks = resolveAgentBenchmarkTasks({ suite: "variants" });
+    const first = selectAgentBenchmarkTaskIds(tasks, {
+      samplePerTemplate: "10",
+      sampleSeed: "ci-sample",
+    });
+    const second = selectAgentBenchmarkTaskIds(tasks, {
+      samplePerTemplate: "10",
+      sampleSeed: "ci-sample",
+    });
+    expect(first).toHaveLength(1470);
+    expect(second).toEqual(first);
+    expect(
+      new Set(first.map((id) => id.replace(/^variant_/, "").replace(/_\d{2,3}$/, ""))).size,
+    ).toBe(147);
   });
 });

--- a/src/gemmaclaw/benchmark/agent-container-guard.ts
+++ b/src/gemmaclaw/benchmark/agent-container-guard.ts
@@ -65,22 +65,57 @@ export function selectAgentBenchmarkTaskIds(
     return [taskId];
   }
 
+  let selectedTasks = tasks;
+
   if (opts.filter) {
     const filter = String(opts.filter).toLowerCase();
-    const selected = tasks.filter(
+    selectedTasks = tasks.filter(
       (task) =>
         task.id.toLowerCase().includes(filter) ||
         task.name.toLowerCase().includes(filter) ||
         task.category.toLowerCase().includes(filter) ||
         task.difficulty.toLowerCase().includes(filter),
     );
-    if (selected.length === 0) {
+    if (selectedTasks.length === 0) {
       throw new Error(`No agent benchmark tasks match filter: ${opts.filter}`);
     }
-    return selected.map((task) => task.id);
   }
 
-  return tasks.map((task) => task.id);
+  if (opts.samplePerTemplate) {
+    const sampleSize = Number.parseInt(String(opts.samplePerTemplate), 10);
+    if (!Number.isInteger(sampleSize) || sampleSize <= 0) {
+      throw new Error(
+        `--sample-per-template must be a positive integer, got: ${opts.samplePerTemplate}`,
+      );
+    }
+    const seed = String(opts.sampleSeed ?? "gemmaclaw-benchmark-sample");
+    const grouped = new Map<string, AgentBenchmarkTask[]>();
+    for (const task of selectedTasks) {
+      const templateId = variationTemplateId(task.id);
+      grouped.set(templateId, [...(grouped.get(templateId) ?? []), task]);
+    }
+    selectedTasks = [...grouped.values()].flatMap((group) =>
+      seededSample(group, Math.min(sampleSize, group.length), seed),
+    );
+  }
+
+  return selectedTasks.map((task) => task.id);
+}
+
+function variationTemplateId(taskId: string): string {
+  return taskId.replace(/^variant_/, "").replace(/_\d{2,3}$/, "");
+}
+
+function seededSample<T extends { id: string }>(items: T[], count: number, seed: string): T[] {
+  return items
+    .map((item) => ({
+      item,
+      score: crypto.createHash("sha256").update(`${seed}:${item.id}`).digest("hex"),
+    }))
+    .toSorted((a, b) => a.score.localeCompare(b.score))
+    .slice(0, count)
+    .map(({ item }) => item)
+    .toSorted((a, b) => a.id.localeCompare(b.id));
 }
 
 export function assertSingleAgentBenchmarkTaskInContainer(params: {

--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -23,6 +23,7 @@ import {
   resolveFakeGogBinDir,
   readOpenAICodexAuthProfilesFromStore,
   resolveOpenAICodexAuthProfileStoreCandidates,
+  resolveIdleCompletionMs,
   resolveTimeoutBudgets,
   resolveGeminiHome,
   runAgentBenchmark,
@@ -291,6 +292,18 @@ describe("resolveTimeoutBudgets", () => {
     });
     expect(noActivityMs).toBe(600_000);
     expect(hardCapMs).toBe(28_800_000);
+  });
+});
+
+describe("resolveIdleCompletionMs", () => {
+  it("honors explicit short idle completion settings with a small safety floor", () => {
+    expect(resolveIdleCompletionMs(10)).toBe(10_000);
+    expect(resolveIdleCompletionMs(1)).toBe(5_000);
+  });
+
+  it("uses the default completion idle when the configured value is disabled or invalid", () => {
+    expect(resolveIdleCompletionMs(0)).toBe(30_000);
+    expect(resolveIdleCompletionMs(Number.NaN)).toBe(30_000);
   });
 });
 

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -1606,6 +1606,12 @@ export function resolveTimeoutBudgets(config: AgentBenchmarkConfig): {
   };
 }
 
+export function resolveIdleCompletionMs(idleTimeoutSeconds: number): number {
+  const idleSec =
+    Number.isFinite(idleTimeoutSeconds) && idleTimeoutSeconds > 0 ? idleTimeoutSeconds : 30;
+  return Math.max(Math.round(idleSec * 1000), 5_000);
+}
+
 export async function dispatchTask(
   task: AgentBenchmarkTask,
   config: AgentBenchmarkConfig,
@@ -1622,7 +1628,6 @@ export async function dispatchTask(
 }> {
   const startMs = Date.now();
   const { hardCapMs, noActivityMs } = resolveTimeoutBudgets(config);
-  const idleMs = config.idleTimeoutSeconds * 1000;
 
   // Create isolated benchmark home for this task
   const benchHome = config.gemmaclawHome
@@ -2106,7 +2111,7 @@ export async function dispatchTask(
     // assistant turn: keep the legacy short threshold so a model that finishes
     // streaming and quietly waits is treated as done. Activity-based timeout
     // (below) handles the "stuck before any assistant turn" case.
-    const idleCompletionMs = Math.max(idleMs * 4, 120_000);
+    const idleCompletionMs = resolveIdleCompletionMs(config.idleTimeoutSeconds);
 
     // Polling loop concurrent with child execution
     while (true) {

--- a/src/gemmaclaw/benchmark/agent-tasks.test.ts
+++ b/src/gemmaclaw/benchmark/agent-tasks.test.ts
@@ -201,8 +201,8 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
 
     expect(AGENT_BENCHMARK_TASKS).toHaveLength(47);
     expect(EXPANDED_AGENT_BENCHMARK_TASKS).toHaveLength(147);
-    expect(GENERATED_AGENT_VARIATION_TASKS).toHaveLength(7350);
-    expect(ALL_AGENT_BENCHMARK_TASKS).toHaveLength(7544);
+    expect(GENERATED_AGENT_VARIATION_TASKS).toHaveLength(29400);
+    expect(ALL_AGENT_BENCHMARK_TASKS).toHaveLength(29594);
     expect([...expandedIds].some((id) => defaultIds.has(id))).toBe(false);
     expect([...variationIds].some((id) => defaultIds.has(id) || expandedIds.has(id))).toBe(false);
   });
@@ -247,14 +247,14 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
   it("declares template targets for scaling toward 1000+ benchmark variations", () => {
     expect(BENCHMARK_TEST_TEMPLATE_TARGETS).toHaveLength(EXPANDED_AGENT_BENCHMARK_TASKS.length);
     expect(
-      BENCHMARK_TEST_TEMPLATE_TARGETS.every((template) => template.targetVariations === 50),
+      BENCHMARK_TEST_TEMPLATE_TARGETS.every((template) => template.targetVariations === 200),
     ).toBe(true);
     expect(
       BENCHMARK_TEST_TEMPLATE_TARGETS.reduce(
         (total, template) => total + template.targetVariations,
         0,
       ),
-    ).toBe(7350);
+    ).toBe(29400);
   });
 
   it("keeps all generated template variations high quality and public-safe", () => {
@@ -263,10 +263,10 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
     for (const task of GENERATED_AGENT_VARIATION_TASKS) {
       expect(seenIds.has(task.id), `${task.id} is unique`).toBe(false);
       seenIds.add(task.id);
-      const templateId = task.id.replace(/^variant_/, "").replace(/_\d{2}$/, "");
+      const templateId = task.id.replace(/^variant_/, "").replace(/_\d{2,3}$/, "");
       countsByTemplate.set(templateId, (countsByTemplate.get(templateId) ?? 0) + 1);
 
-      expect(task.id, `${task.id} uses variant prefix`).toMatch(/^variant_[a-z0-9_]+_\d{2}$/);
+      expect(task.id, `${task.id} uses variant prefix`).toMatch(/^variant_[a-z0-9_]+_\d{2,3}$/);
       expect(task.category, `${task.id} uses variant category`).toMatch(/^variant_/);
       expect(task.name.trim().length, `${task.id} has a name`).toBeGreaterThan(10);
       expect(task.description.trim().length, `${task.id} has a description`).toBeGreaterThan(40);
@@ -293,6 +293,6 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
     }
 
     expect(countsByTemplate.size).toBe(EXPANDED_AGENT_BENCHMARK_TASKS.length);
-    expect([...countsByTemplate.values()].every((count) => count === 50)).toBe(true);
+    expect([...countsByTemplate.values()].every((count) => count === 200)).toBe(true);
   });
 });

--- a/src/gemmaclaw/benchmark/agent-variation-templates.ts
+++ b/src/gemmaclaw/benchmark/agent-variation-templates.ts
@@ -10,7 +10,7 @@ type VariationTemplate = {
   name: string;
   category: AgentTaskCategory;
   difficulty: AgentTaskDifficulty;
-  targetVariations: 50;
+  targetVariations: number;
   description: string;
   capability: string;
   artifact: string;
@@ -60,6 +60,8 @@ const VARIANT_DISTRACTORS = [
   "an outdated status line",
   "a noisy log excerpt",
 ];
+
+const VARIANT_OUTPUT_FRAMES = ["concise operator handoff", "audit-ready reviewer packet"];
 
 export const CURATED_BENCHMARK_TEST_TEMPLATE_TARGETS: VariationTemplate[] = [
   {
@@ -394,7 +396,7 @@ export const BENCHMARK_TEST_TEMPLATE_TARGETS: VariationTemplate[] =
     name: task.name,
     category: task.category,
     difficulty: task.difficulty,
-    targetVariations: 50,
+    targetVariations: 200,
     description: task.description,
     capability: `${task.category.replace(/^expanded_/, "").replace(/_/g, " ")} agent workflow`,
     artifact: `${task.id}_variation_output.md`,
@@ -415,10 +417,12 @@ function variantInstruction(template: VariationTemplate, index: number): string 
   const context =
     VARIANT_CONTEXTS[Math.floor(index / VARIANT_PERSONAS.length) % VARIANT_CONTEXTS.length];
   const distractor = VARIANT_DISTRACTORS[(index * 7) % VARIANT_DISTRACTORS.length];
+  const outputFrame = VARIANT_OUTPUT_FRAMES[Math.floor(index / 100) % VARIANT_OUTPUT_FRAMES.length];
   const caseNo = String(index + 1).padStart(2, "0");
   return [
     `Variant ${caseNo} context: act as the ${persona} handling the ${context}.`,
     `Include this complication in your reasoning: ${distractor}.`,
+    `Shape the final response as a ${outputFrame}.`,
     `Write the final artifact to ${template.artifact}.`,
   ].join("\n");
 }

--- a/src/gemmaclaw/benchmark/cli-standalone.ts
+++ b/src/gemmaclaw/benchmark/cli-standalone.ts
@@ -115,6 +115,10 @@ function parseArgs(argv: string[]) {
       opts.quant = args[++i]!;
     } else if (arg === "--suite" && args[i + 1]) {
       opts.suite = args[++i]!;
+    } else if (arg === "--sample-per-template" && args[i + 1]) {
+      opts.samplePerTemplate = args[++i]!;
+    } else if (arg === "--sample-seed" && args[i + 1]) {
+      opts.sampleSeed = args[++i]!;
     } else if (arg === "--task-timeout" && args[i + 1]) {
       opts.taskTimeout = args[++i]!;
     } else if (arg === "--idle-timeout" && args[i + 1]) {
@@ -441,6 +445,8 @@ Agent Mode Options:
   --backend <type>       Backend to test (ollama, llama-cpp, openai-codex, google-gemini-cli, openrouter)
   --thinking <level>     Thinking/reasoning level (off, low, medium, high, xhigh)
   --suite <name>          Task suite: default, expanded, variants, all (default: default)
+  --sample-per-template <n>  Deterministically sample N generated variations per template
+  --sample-seed <value>   Seed for --sample-per-template (default: gemmaclaw-benchmark-sample)
   --gateway-url <url>    Gemmaclaw gateway URL (default: http://localhost:3001)
   --ollama-url <url>     Ollama API URL (default: http://127.0.0.1:11434)
   --filter <text>        Run only tasks matching text (id, name, category, difficulty)
@@ -494,6 +500,7 @@ Examples:
   pnpm benchmark agent --filter security             # Run only security tasks
   pnpm benchmark agent --suite expanded --filter coding  # Run expanded coding tasks
   pnpm benchmark agent --suite variants --filter security  # Run generated template variations
+  pnpm benchmark agent --suite variants --sample-per-template 10 --backend google-gemini-cli --model gemini-3-flash-preview
   pnpm benchmark agent --gateway-url http://192.168.1.50:3001  # Remote gateway
   pnpm benchmark agent list                          # List all tasks
   pnpm benchmark agent --mock                        # Smoke test without a model
@@ -504,6 +511,8 @@ Examples:
 
 function listAgentTasks(opts: Record<string, string | boolean>): void {
   const tasks = resolveAgentBenchmarkTasks(opts);
+  const selectedTaskIds = new Set(selectAgentBenchmarkTaskIds(tasks, opts));
+  const selectedTasks = tasks.filter((task) => selectedTaskIds.has(task.id));
   const suite = String(opts.suite ?? "default");
   console.log("\nAvailable Agent Benchmark Tasks:\n");
   console.log(`Suite: ${suite}\n`);
@@ -513,7 +522,7 @@ function listAgentTasks(opts: Record<string, string | boolean>): void {
   console.log("-".repeat(100));
 
   let totalPoints = 0;
-  for (const task of tasks) {
+  for (const task of selectedTasks) {
     console.log(
       `${task.id.padEnd(30)} ${task.difficulty.padEnd(12)} ${String(task.grading.maxScore).padStart(4)} ${task.category.padEnd(18)} ${task.name}`,
     );
@@ -521,7 +530,7 @@ function listAgentTasks(opts: Record<string, string | boolean>): void {
   }
 
   console.log("-".repeat(100));
-  console.log(`${tasks.length} tasks, ${totalPoints} max points\n`);
+  console.log(`${selectedTasks.length} tasks, ${totalPoints} max points\n`);
 }
 
 async function runAgentMode(opts: Record<string, string | boolean>): Promise<void> {
@@ -617,6 +626,9 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
   if (config.filter) {
     console.log(`Filter:   ${config.filter}`);
   }
+  if (opts.samplePerTemplate) {
+    console.log(`Sample:   ${opts.samplePerTemplate} per template`);
+  }
   if (config.runId) {
     console.log(`Run id:   ${config.runId}`);
   }
@@ -629,9 +641,11 @@ async function runAgentMode(opts: Record<string, string | boolean>): Promise<voi
   }
   console.log("");
 
+  const selectedTaskIds = new Set(selectAgentBenchmarkTaskIds(tasks, opts));
+  const selectedTasks = tasks.filter((task) => selectedTaskIds.has(task.id));
   const result = opts.assemble
-    ? assembleAgentBenchmarkRun(tasks, config, outputDir)
-    : await runAgentBenchmark(tasks, config, hardware);
+    ? assembleAgentBenchmarkRun(selectedTasks, config, outputDir)
+    : await runAgentBenchmark(selectedTasks, config, hardware);
 
   // Print summary
   console.log("\n========================================");


### PR DESCRIPTION
## Summary
- expand generated benchmark variations from 50 to 200 per expanded template, for 29,400 generated variant tasks
- add deterministic `--sample-per-template` and `--sample-seed` support to agent benchmark list/run paths
- fix benchmark catalog variation clicks and hash deep links so each selected variation shows metadata and the runnable command
- document the Gemini Flash OAuth 10-per-template sample command in the benchmark guide and site
- reduce completed-task idle tail so sampled Gemini runs honor `--idle-timeout` instead of waiting a hard 120 seconds

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`
- `pnpm benchmark agent list --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513` returned 1,470 sampled tasks, 10 per each of 147 templates
- `pnpm benchmark agent --suite variants --sample-per-template 10 --sample-seed gemini-flash-smoke-20260513 --mock --model gemini-3-flash-preview --backend google-gemini-cli --run-id variant-sample-mock-20260513 --output-dir /home/frank/gemmaclaw-benchmarks/variant-sample-mock-20260513` completed 1,470/1,470 with 0 errors and 0 timeouts
- Gemini Flash OAuth Docker preflight: `pnpm benchmark agent --suite variants --task variant_expanded_sanity_02 --backend google-gemini-cli --model gemini-3-flash-preview --run-id variant-sample-gemini-flash-preflight-fast-20260513 --output-dir /home/frank/gemmaclaw-benchmarks/variant-sample-gemini-flash-preflight-fast-20260513 --idle-timeout 10 --no-activity-timeout 120 --hard-cap 600` completed 1/1 with validation ok
- Chrome MCP local UI check: deep link `benchmarks.html#variant_expanded_sanity_200` opens the template and shows the selected variation detail; clicking `expanded_sanity_02` updates the detail panel in place
