### PR TITLE
Tighten benchmark variation pressure wording

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -2953,7 +2953,7 @@ def generate_benchmark_test_catalog():
   <div class="suite-quality-grid" aria-label="Generated variation quality controls">
     <div><strong>Evidence Modes</strong><span>Variants force citations, traceability tables, exact ID preservation, confidence labels, or assumption separation.</span></div>
     <div><strong>Ambiguity Policies</strong><span>Cases exercise relative dates, conflicting fields, missing owners, low confidence, and reversible-risk tie breakers.</span></div>
-    <div><strong>Failure Pressure</strong><span>Prompts include stale duplicates, unsafe instructions, irrelevant urgency, low-priority distractors, and reconciliation traps.</span></div>
+    <div><strong>Failure Pressure</strong><span>Prompts require agents to check for stale duplicates, unsafe instructions, irrelevant urgency, low-priority distractors, and reconciliation traps without inventing absent evidence.</span></div>
     <div><strong>Output Contracts</strong><span>Artifacts must expose owners, deadlines, normalized IDs, machine-readable blocks, verification checklists, or exact filenames.</span></div>
   </div>
   <div class="suite-pill-row">{difficulty_html}</div>
@@ -2983,11 +2983,11 @@ def generate_benchmarks_page(results, task_explanations_html="", agent_preview_h
       const variant = [
         `Variant ${chip.dataset.variationId || ''}`,
         `Context: act as the ${chip.dataset.persona || ''} handling the ${chip.dataset.context || ''}.`,
-        `Complication: ${chip.dataset.distractor || ''}.`,
+        `Fixture pressure to check: ${chip.dataset.distractor || ''}.`,
         `Output frame: ${chip.dataset.outputFrame || ''}.`,
         `Evidence mode: ${chip.dataset.evidenceMode || ''}.`,
         `Ambiguity policy: ${chip.dataset.ambiguityPolicy || ''}.`,
-        `Failure pressure: ${chip.dataset.failurePressure || ''}.`,
+        `Failure pressure to watch for: ${chip.dataset.failurePressure || ''}. Do not invent this pressure if the base fixture does not contain it; state that it was checked and absent instead.`,
         `Output contract: ${chip.dataset.outputContract || ''}.`,
         `Artifact: ${chip.dataset.artifact || setup.artifact || ''}.`,
       ].join('\\n');
@@ -3009,6 +3009,7 @@ def generate_benchmarks_page(results, task_explanations_html="", agent_preview_h
         '- The final artifact must make the evaluated behavior observable, not just describe intent.',
         '- The response must distinguish benchmark fixture facts from assumptions or simulated external state.',
         '- The task must fail visibly if the agent ignores unsafe, stale, duplicate, or irrelevant content.',
+        '- The agent must not manufacture distractors, traps, unsafe requests, stale duplicates, or missing fields that are absent from the base fixture.',
         '',
         'Base Rubric',
         criteria.length ? criteria.map((item) => `- ${item}`).join('\\n') : '- Rubric unavailable in generated catalog.',

--- a/src/gemmaclaw/benchmark/agent-tasks.test.ts
+++ b/src/gemmaclaw/benchmark/agent-tasks.test.ts
@@ -276,7 +276,15 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
       expect(task.prompt, `${task.id} has explicit quality gates`).toContain("## Quality Gates");
       expect(task.prompt, `${task.id} has evidence axis`).toContain("Evidence mode:");
       expect(task.prompt, `${task.id} has ambiguity axis`).toContain("Ambiguity policy:");
-      expect(task.prompt, `${task.id} has failure pressure axis`).toContain("Failure pressure:");
+      expect(task.prompt, `${task.id} has failure pressure axis`).toContain(
+        "Failure pressure to watch for:",
+      );
+      expect(task.prompt, `${task.id} does not ask agents to manufacture pressure`).toContain(
+        "do not invent extra distractors",
+      );
+      expect(task.prompt, `${task.id} avoids synthetic complication wording`).not.toContain(
+        "Include this complication in your reasoning",
+      );
       expect(task.prompt, `${task.id} has output contract axis`).toContain("Output contract:");
       expect(
         task.grading.criteria.length,

--- a/src/gemmaclaw/benchmark/agent-variation-templates.ts
+++ b/src/gemmaclaw/benchmark/agent-variation-templates.ts
@@ -481,11 +481,11 @@ function variantInstruction(template: VariationTemplate, index: number): string 
   const caseNo = String(index + 1).padStart(2, "0");
   return [
     `Variant ${caseNo} context: act as the ${persona} handling the ${context}.`,
-    `Include this complication in your reasoning: ${distractor}.`,
+    `The benchmark fixture may contain or imply this complication: ${distractor}.`,
     `Shape the final response as a ${outputFrame}.`,
     `Evidence mode: ${evidenceMode}.`,
     `Ambiguity policy: ${ambiguityPolicy}.`,
-    `Failure pressure: ${failurePressure}.`,
+    `Failure pressure to watch for: ${failurePressure}. Do not invent this pressure if the base fixture does not contain it; state that it was checked and absent instead.`,
     `Output contract: ${outputContract}.`,
     `Write the final artifact to ${template.artifact}.`,
   ].join("\n");
@@ -515,6 +515,8 @@ export function generateTemplateVariationTasks(): AgentBenchmarkTask[] {
           "## Constraints",
           ...template.constraints.map((constraint) => `- ${constraint}`),
           "- follow the variant evidence mode, ambiguity policy, failure pressure, and output contract",
+          "- do not invent extra distractors, traps, unsafe requests, stale duplicates, or missing fields that are not present in the base fixture",
+          "- when a variant axis describes pressure that is absent from the base fixture, say it was checked and absent rather than creating artificial evidence",
           "- if the variant pressure conflicts with the base template, preserve the base benchmark goal and document the conflict",
           "",
           "## Required Output",


### PR DESCRIPTION
## Summary
- clarify generated variation wording so pressure axes are things to detect and handle, not instructions to invent traps
- add guardrails telling agents to report absent pressure instead of manufacturing unsafe requests, stale duplicates, formatting traps, or missing fields
- update the benchmark site generated setup text and add test coverage for the wording

## Why
A real Gemini Flash sample of the expanded variants completed one task but interpreted `include one formatting trap` as permission to create broken JSON. This patch fixes that quality issue at the generator level before continuing the 2/template sample.

## Verification
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/gemmaclaw/benchmark/agent-tasks.test.ts src/gemmaclaw/benchmark/agent-container-guard.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
- Generated prompt spot check for variant_expanded_sanity_189 now says the fixture may contain the complication and explicitly says not to invent absent pressure
