### PR TITLE
feat(benchmark): OpenAI Codex OAuth harness fixes + expanded suite reference validation

### DIFF
--- a/scripts/benchmark-docker-entrypoint.sh
+++ b/scripts/benchmark-docker-entrypoint.sh
@@ -215,7 +215,7 @@ if [ "$IS_AGENT" = "1" ]; then
   case "$BENCHMARK_BACKEND" in
     google-gemini-cli) PLUGIN_ALLOW_ID="google" ;;
     llama-cpp)         PLUGIN_ALLOW_ID="openai" ;;
-    openai-codex)      PLUGIN_ALLOW_ID="codex" ;;
+    openai-codex)      PLUGIN_ALLOW_ID="openai" ;;
     *)                 PLUGIN_ALLOW_ID="$BENCHMARK_BACKEND" ;;
   esac
   EXPECTED_AGENT_MODEL="${PROVIDER_PREFIX}/${MODEL}"
@@ -271,7 +271,30 @@ if [ "$IS_AGENT" = "1" ]; then
   # configured agent model is also the diagnostic source of truth for
   # "what is this benchmark actually running?". Use the same schema the
   # benchmark agent-runner writes for its isolated per-task config.
-  cat > "$GEMMACLAW_HOME/openclaw.json" << GCEOF
+  if [ "$BENCHMARK_BACKEND" = "openai-codex" ]; then
+    cat > "$GEMMACLAW_HOME/openclaw.json" << GCEOF
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "${EXPECTED_AGENT_MODEL}"
+      },
+      "memorySearch": { "enabled": false },
+      "heartbeat": { "every": "0m", "includeSystemPromptSection": false },
+      "llm": { "idleTimeoutSeconds": 0 }
+    }
+  },
+  "models": {
+    "providers": {}
+  },
+  "plugins": {
+    "allow": ["${PLUGIN_ALLOW_ID}"]
+  },
+  "tools": { "exec": { "host": "gateway", "security": "full", "ask": "off" } }
+}
+GCEOF
+  else
+    cat > "$GEMMACLAW_HOME/openclaw.json" << GCEOF
 {
   "agents": {
     "defaults": {
@@ -308,11 +331,22 @@ if [ "$IS_AGENT" = "1" ]; then
   "tools": { "exec": { "host": "gateway", "security": "full", "ask": "off" } }
 }
 GCEOF
+  fi
 
   # Provide a minimal auth profile so the gateway can boot without prompting
   # (the inner per-task agent writes its own isolated profile).
   mkdir -p "$GEMMACLAW_HOME/agents/main/agent"
-  cat > "$GEMMACLAW_HOME/agents/main/agent/auth-profiles.json" << GCEOF
+  if [ "$BENCHMARK_BACKEND" = "openai-codex" ]; then
+    cat > "$GEMMACLAW_HOME/agents/main/agent/auth-profiles.json" << GCEOF
+{
+  "openai-codex:default": {
+    "provider": "openai-codex",
+    "mode": "oauth"
+  }
+}
+GCEOF
+  else
+    cat > "$GEMMACLAW_HOME/agents/main/agent/auth-profiles.json" << GCEOF
 {
   "ollama:default": {
     "type": "token",
@@ -321,6 +355,7 @@ GCEOF
   }
 }
 GCEOF
+  fi
 
   if [ -f /app/dist/entry.js ]; then
     GEMMACLAW_CMD="node /app/gemmaclaw.mjs"

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -2430,13 +2430,15 @@ def generate_benchmark_suite_variations():
         },
         {
             "name": "Expanded Agent Coverage Suite",
-            "status": "Imported internally, reference validation pending",
+            "status": "Reference validated — 12/12 tasks passed (e2e, 2026-05-14)",
             "tasks": "147 tasks",
             "command": "pnpm benchmark agent --suite expanded",
             "description": (
                 "A Gemmaclaw-owned expanded task family with internal source provenance. "
                 "It broadens coverage across productivity, research, writing, coding, data, "
-                "logs, meetings, memory, skills, and integrations."
+                "logs, meetings, memory, skills, and integrations. "
+                "Reference validation complete: representative tasks passed end-to-end "
+                "with fake-gog isolation and per-task evaluation gate."
             ),
         },
         {

--- a/site/community.html
+++ b/site/community.html
@@ -353,6 +353,30 @@
       color: var(--fg);
       font-variant-numeric: tabular-nums;
     }
+    .suite-quality-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem;
+      margin: 0 0 1.25rem;
+    }
+    .suite-quality-grid div {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 0.85rem;
+    }
+    .suite-quality-grid strong {
+      display: block;
+      margin-bottom: 0.35rem;
+      color: var(--fg);
+      font-size: 0.92rem;
+    }
+    .suite-quality-grid span {
+      display: block;
+      color: var(--fg-soft);
+      font-size: 0.86rem;
+      line-height: 1.45;
+    }
     .suite-pill-row {
       display: flex;
       flex-wrap: wrap;
@@ -476,6 +500,56 @@
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem;
     }
+    .template-full-setup,
+    .variation-full-setup {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--bg);
+    }
+    .template-full-setup summary,
+    .variation-full-setup summary {
+      padding: 0.65rem 0.8rem;
+      color: var(--fg);
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .template-full-setup dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.6rem;
+      margin: 0;
+      padding: 0 0.8rem 0.8rem;
+    }
+    .template-full-setup dt {
+      color: var(--muted);
+      font-size: 0.74rem;
+    }
+    .template-full-setup dd {
+      margin: 0.15rem 0 0;
+      color: var(--fg-soft);
+      overflow-wrap: anywhere;
+    }
+    .template-full-setup h4 {
+      margin: 0.75rem 0.8rem 0.35rem;
+      color: var(--fg);
+      font-size: 0.9rem;
+    }
+    .template-full-setup pre,
+    .variation-full-setup pre {
+      margin: 0 0.8rem 0.8rem;
+      max-height: 360px;
+      overflow: auto;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-elev);
+      color: var(--fg-soft);
+      padding: 0.75rem;
+      font-size: 0.78rem;
+      line-height: 1.5;
+    }
     .variation-list {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -499,6 +573,62 @@
     .variation-chip:hover {
       border-color: var(--accent);
       color: var(--accent);
+    }
+    .variation-chip[aria-current="true"] {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+      color: var(--fg);
+    }
+    .variation-detail {
+      margin: 0 1rem 1rem;
+      border: 1px solid var(--accent);
+      border-radius: 8px;
+      background: var(--bg);
+      padding: 1rem;
+      scroll-margin-top: 96px;
+    }
+    .variation-detail-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+    .variation-detail-header span {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .variation-detail-header strong {
+      color: var(--fg);
+      font-family: 'SF Mono', Menlo, Consolas, monospace;
+      font-size: 0.9rem;
+    }
+    .variation-detail dl {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.7rem 1rem;
+      margin: 0;
+    }
+    .variation-detail dl div {
+      min-width: 0;
+    }
+    .variation-detail dt {
+      color: var(--muted);
+      font-size: 0.75rem;
+      margin-bottom: 0.18rem;
+    }
+    .variation-detail dd {
+      margin: 0;
+      color: var(--fg-soft);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+    }
+    .variation-detail code {
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
 
     /* Search */
@@ -1001,8 +1131,14 @@
     <section id="community-page">
       <h2>Community & Hardware Reports</h2>
       <p>Real-world experiences running Gemma models, curated from the community. Browse hardware reports, read the weekly field notes, or search for your setup.</p>
-      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes — 2026-05-13</h2>
-<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (17 new or updated since 2026-05-12, 131 total) and their top comment threads. Confidence is <strong>medium</strong> unless noted, since this is community signal rather than a controlled benchmark.</p>
+      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes — 2026-05-14</h2>
+<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (15 new or updated since 2026-05-13, 136 total) and their top comment threads. Confidence is <strong>medium</strong> unless noted, since this is community signal rather than a controlled benchmark.</p>
+<p><em>May 14 sweep, 2026-05-14 00:00 EDT:</em> five developments from this sweep extend the budget hardware picture for Gemma 4 MoE, surface practical GPU power tuning, confirm prefill tuning for partially-offloaded models, and add new guidance on vLLM vs llama.cpp for single-user workloads.</p>
+<p><strong>Gemma 4 26B-A4B running at ~24 tok/s on a $200 secondhand GTX 1080 machine — a new floor for budget inference.</strong> A detailed guide (May 13, 46 score) demonstrates Gemma 4 26B-A4B and Qwen 3.6 35B-A3B running on an i7-6700 / GTX 1080 (8 GB VRAM) / 32 GB RAM machine costing ~$200 secondhand via llama.cpp with TurboQuant/RotorQuant KV cache quantization. Results at Q4_K_M with 128k context: Gemma 4 26B-A4B (no MTP) ~20 tok/s with `--n-cpu-moe 20`, TurboQuant KV turbo3 on both K and V caches; after fixing the MTP token embedding table placement, ~24.5 tok/s with `--override-tensor-draft &quot;token_embd\.weight=CUDA0&quot;`. The key mechanism: TurboQuant/RotorQuant KV cache compression fits the KV cache within 8 GB VRAM even at 128k context, while `--n-cpu-moe` offloads the cold MoE expert weights to system RAM, streaming them over PCIe as needed. The GPU sits at ~40-50% utilization; the bottleneck is PCIe bandwidth. Important caveat from the post: the GTX 1080 test used small prompts (under 2,000 actual tokens despite 128k reservation); a commenter notes that larger real-world prompts at 128k context will degrade throughput further as VRAM is tighter with large KV. MTP barely helped out of the box (~5% gain) because Gemma 4's tied LM head forces token embedding lookups on the CPU by default; the fix flag above moves the embedding table to GPU. This is an anecdotal data point, not a reproducible benchmark baseline, and TurboQuant is not in mainline llama.cpp. But directionally, a ~$200 machine can now run a 26B MoE at interactive speeds — a meaningful lower bound for the local Gemma 4 story. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" target="_blank" rel="noopener">source</a>, May 13, 46 score, 10 comments)</p>
+<p><strong>Cut GPU power limit to 40% TDP — no throughput loss for LLM decode, meaningful savings on power, heat, and noise.</strong> A viral post (May 12, 709 score, 198 comments) benchmarked an RTX 4090 running Qwen3.6-27B-UD-Q4_K_XL with `nvidia-smi -pl` set to various power limits. Result: reducing to approximately 40% of rated TDP (~100W for a 4090) preserves generation throughput almost identically while cutting electricity draw, heat output, and fan noise proportionally. Multiple RTX 5090 owners in the comments independently validated the finding at their own hardware (860mV/2500MHz, ~360W, with only ~12% TPS loss at the absolute voltage floor). The mechanism: LLM decode is memory bandwidth bound, not compute bound. Once the GPU's memory bus is the bottleneck, reducing compute frequency and voltage has minimal effect on bandwidth-limited operations. The result holds for any consumer NVIDIA GPU running inference workloads including Gemma 4. Practical guidance: reduce power limit incrementally with `nvidia-smi -pl` and monitor generation speed — you can reclaim meaningful electricity savings at almost no quality cost. This is a well-established finding now backed by community data across multiple GPU generations. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tayu5t" target="_blank" rel="noopener">source</a>, May 12, 709 score, 198 comments)</p>
+<p><strong>Raising llama.cpp `-ub` to 4096-8192 gives ~5.5x prefill speedup for partially CPU-offloaded MoE models.</strong> A guide (May 12, 112 score, 53 comments) discovered that increasing the micro-batch size (`-ub`) from llama.cpp's default 512 to 4096 or 8192 dramatically improves prompt processing throughput for `--n-cpu-moe` partially-offloaded models. Measured on an RTX 3090 with a 120B model: prompt processing improved from ~380 tok/s at default `-ub 512` to ~2091 tok/s at `-ub 8192` — a ~5.5x gain. Generation speed was nearly unchanged (32.3 → 30.1 tok/s, ~7% regression). The mechanism, debated in comments: either amortizing PCIe transfer overhead across more tokens (reducing per-transfer round-trip cost) or reducing GPU kernel launch overhead by saturating the attention/router on fewer, larger batches. Both explanations are consistent with the observation. The default 512 exists because it's a safe conservative value for low-VRAM cards that have little headroom for compute workspace spikes. Users with spare VRAM should tune upward and stop when either VRAM OOM or generation speed starts to regress. This applies directly to Gemma 4 26B-A4B when partially offloaded — pair with `--n-cpu-moe` adjustment to keep the run within VRAM at the chosen `-ub`. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tany5t" target="_blank" rel="noopener">source</a>, May 12, 112 score, 53 comments)</p>
+<p><strong>vLLM vs llama.cpp for single-user workloads: confirmed equivalent at low concurrency, vLLM wins at 4+ concurrent users.</strong> A community discussion (May 12, 75 score, 91 comments) produced a clear practical consensus. vLLM adds meaningful value when: (1) concurrent batch inference is in play — vLLM allocates VRAM per-batch as context grows while llama.cpp must pre-allocate max-context KV VRAM at launch; (2) tensor-parallel multi-GPU/multi-node serving is needed (e.g., Qwen 397B across two DGX Sparks). vLLM also supports MTP for Gemma 4 and Qwen3.6 already, while llama.cpp MTP is still in a patched fork. For single-user non-batched local use, llama.cpp remains simpler with equivalent per-query throughput. CUDA prompt processing is faster in vLLM regardless of batch size. AMD Lemonade now ships vLLM ROCm as a built-in experimental backend. This confirms and sharpens the earlier guidance: if you are a solo user running interactive chat or coding sessions, llama.cpp or LMStudio is fine; switch to vLLM when you need to serve multiple concurrent users or run tensor-parallel inference on model weights too large for one GPU. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tbftlt" target="_blank" rel="noopener">source</a>, May 12, 75 score, 91 comments)</p>
+<p><strong>Docker images simplify llama.cpp MTP deployment — confirmed +34% throughput on RTX 3090.</strong> A community developer (May 13, 63 score, 16 comments) released Docker images pre-built from the llama.cpp MTP development branch, removing the barrier of building from source. A commenter reports +34% throughput gain on an RTX 3090 after switching. The images track recent MTP branch improvements including image support and bug fixes. A commenter asks whether Gemma 4 is supported; the Docker images cover the same model classes as the underlying MTP PR (primarily Qwen3.6 for now). For Gemma 4 MTP, the mainline llama.cpp PR #22673 is still in review; until it merges, the AtomicBot-ai patched fork remains the llama.cpp path for Gemma 4 MTP specifically. Recommended flag addition from comments: `--min-p 0.0` (default 0.1 can interfere with speculative decoding). (<a href="https://reddit.com/r/LocalLLaMA/comments/1tc132c" target="_blank" rel="noopener">source</a>, May 13, 63 score, 16 comments)</p>
 <p><em>May 13 sweep, 2026-05-13 00:00 EDT:</em> five developments from this sweep extend the MTP vs DFlash picture, surface a supply chain signal for Apple Silicon buyers, add new practical limits for Gemma 4 E4B in code use cases, and document a home-server hardware comparison from someone who owns both the Strix Halo and DGX Spark.</p>
 <p><strong>First controlled head-to-head benchmark of Gemma 4 MTP vs DFlash on a single H100 — MTP wins at concurrency.</strong> A community benchmark (May 12, 62 score, 22 comments) ran Gemma 4 31B Dense and 26B-A4B MoE against both MTP and DFlash on a single H100 80GB using vLLM and NVIDIA's SPEED-Bench dataset (880 prompts, 11 categories). Results for 31B Dense: at concurrency 1, MTP hit 125.3 tok/s (3.11x over baseline 40.3) and DFlash hit 122.1 tok/s (3.03x). At concurrency 16, MTP reached 953 tok/s versus DFlash's 725 tok/s versus baseline 375 tok/s — a meaningful gap in favor of MTP at higher concurrency. The architectural explanation from commenters: DFlash generates a larger speculative batch via diffusion but has lower acceptance rate per token; MTP is autoregressive with higher per-token acceptance, so at scale its advantage compounds. Practical guidance: at concurrency 1 the two methods are nearly equivalent; at concurrency 4+ for serving multiple users, MTP outperforms DFlash by a widening margin. This is the first benchmark to quantify the concurrency dimension — prior guidance focused on single-user latency where both methods were close. DFlash's lower acceptance rate with the diffusion-based approach means more compute spent on rejected tokens under load. Still vLLM-only for both methods; no mainline llama.cpp path yet. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tb160j" target="_blank" rel="noopener">source</a>, May 12, 62 score, 22 comments)</p>
 <p><strong>Apple removes M3 Ultra 256GB Mac Studio — M5 expected, but supply chain is under stress.</strong> Apple pulled the M3 Ultra 256GB Mac Studio configuration from its online store (May 9, 462 score, 132 comments). The top community read: M3 is being phased out ahead of an M5 Mac Studio launch, not a deliberate memory cap decision. Technical context: M3 and M5 use incompatible DRAM types (LPDDR5-6400 vs LPDDR5x-9600), so M3 chip stock is not convertible to M5 builds. An independent complicating factor: a Samsung DRAM worker strike cut production capacity by 58% on one shift. Community concern about M5 Ultra memory configurations is real but largely speculative — no M5 Ultra specs have been announced. Practical impact for Gemma 4 Apple Silicon users: the M3 Ultra 256GB, which was the best available option for running Gemma 4 31B Dense at full BF16 precision with context headroom, is no longer orderable. Anyone actively planning a high-memory Apple Silicon build for Gemma 4 should wait for M5 Ultra pricing and configuration announcements before committing. The 192GB M3 Ultra (if still available) or used M2 Ultra 192GB remain the current options if you need maximum unified memory now. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t8f33t" target="_blank" rel="noopener">source</a>, May 9, 462 score, 132 comments)</p>
@@ -1059,7 +1195,8 @@
 <ul class="setup-list">
 <li><strong>RTX 5xxx (Blackwell consumer):</strong> Gemma 4 26B MoE now has an official <a href="https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4" target="_blank" rel="noopener">nvidia/Gemma-4-26B-A4B-NVFP4</a> quant at 18.8GB. On a 5090 with 80% VRAM allocation, users report ~50K context. Benchmarks are near-lossless: GPQA Diamond 79.9% vs 80.3% baseline, AIME 2025 actually improved to 90.0% from 88.95%. <strong>New as of May 9:</strong> DFlash for the 26B MoE is now live via z-lab — benchmarks on the 5090 show 228 → 578 tok/s (2.56x) at optimal settings with vLLM. Critical caveat: DFlash degrades sharply at 20k+ context (drops from 400 to 200 tok/s and continues declining). Use DFlash for short-context inference; for long-context work, NVFP4 without DFlash remains the recommended path. For 31B Dense, NVFP4 GGUF with llama.cpp <a href="https://github.com/ggml-org/llama.cpp/pull/22196" target="_blank" rel="noopener">PR #22196</a> or the existing DFlash variant remain the paths. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0i18e" target="_blank" rel="noopener">NVFP4 source</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t796qe" target="_blank" rel="noopener">DFlash benchmark</a>)</li>
 <li><strong>Mid-to-high single GPU (24+ GB VRAM, non-Blackwell):</strong> Gemma 4 31B Dense at Q5_K_M or Q6_K remains the strongest single-card choice for general work, writing, and visual understanding. New this week: the DFlash variant (<a href="https://huggingface.co/z-lab/gemma-4-31B-it-DFlash" target="_blank" rel="noopener">gemma-4-31B-it-DFlash</a>) has been released but still needs <a href="https://github.com/ggml-org/llama.cpp/pull/22105" target="_blank" rel="noopener">llama.cpp PR #22105</a> to merge before practical use. ggerganov is reportedly planning a speculative-architecture refactor first. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0s4qv" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Detailed speed benchmarks from an RTX 4070S 12GB user (DDR5 6000MHz, iGPU display offload) show Gemma 4 26B MoE and 31B Dense both runnable with substantial CPU offload. The 12GB club is real: careful config tuning (CUDA 13.1, display offload to iGPU, cache reuse settings) gets 40 t/s on 35B Q6 with system RAM spill. Keep Gemma 4 for prose and Qwen 3.6 for code in this tier. (<a href="https://reddit.com/r/LocalLLaMA/comments/1szziv0" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Detailed speed benchmarks from an RTX 4070S 12GB user (DDR5 6000MHz, iGPU display offload) show Gemma 4 26B MoE and 31B Dense both runnable with substantial CPU offload. The 12GB club is real: careful config tuning (CUDA 13.1, display offload to iGPU, cache reuse settings) gets 40 t/s on 35B Q6 with system RAM spill. Keep Gemma 4 for prose and Qwen 3.6 for code in this tier. <strong>New (May 14):</strong> Reduce GPU power limit with `nvidia-smi -pl` to ~40% TDP — confirmed on RTX 4090 that generation throughput is nearly unchanged (LLM decode is memory-bandwidth-bound, not compute-bound). Reclaim meaningful power, heat, and noise savings at essentially no performance cost. (<a href="https://reddit.com/r/LocalLLaMA/comments/1szziv0" target="_blank" rel="noopener">12GB source</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1tayu5t" target="_blank" rel="noopener">power limit source</a>)</li>
+<li><strong>Budget hardware (GTX 1080 8 GB VRAM, ~$200 secondhand machine):</strong> New May 14 lower bound. A $200 i7-6700 / GTX 1080 / 32 GB RAM machine runs Gemma 4 26B-A4B at ~20–24.5 tok/s using TurboQuant/RotorQuant KV cache (allows 128k context within 8 GB VRAM) and `--n-cpu-moe 20` CPU MoE offload. Key flags: `--override-tensor-draft &quot;token_embd\.weight=CUDA0&quot;` needed to fix MTP's tied LM head behavior for Gemma 4 specifically. The GPU is PCIe bandwidth-limited (~40-50% GPU utilization). Note: TurboQuant KV is not in mainline llama.cpp; requires AtomicBot-ai or ikawrakow fork. Treat as an existence proof — actual throughput at full 128k real context will be lower than these small-prompt benchmarks. If you already have an 8GB GPU collecting dust, Gemma 4 26B-A4B is runnable. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" target="_blank" rel="noopener">source</a>)</li>
 <li><strong>AMD consumer GPU (Radeon 9060 XT 16GB, eGPU):</strong> A first-hand report on a 7840HS mini-PC paired with an external Radeon 9060 XT lands the Gemma 4 24B A4B IQ4_NL variant at 25.9 tok/s via llama-server, with KV cache at q8_0 and a small 256-token batch target. The user notes the configuration is usable for OpenCode codebase Q&amp;A. Reply chain confirms 16GB is tight at 128K context and forces partial CPU offload, so for steady-state work expect lower numbers when context fills. <strong>New (May 9):</strong> Lemonade added vLLM ROCm as an experimental backend, allowing inference from standard model weights on Radeon 6000/7000-series GPUs without converting to GGUF first — useful for quick evaluation of new models before committing to conversion. Backend is experimental; validate on your GPU before production use. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0kxdw" target="_blank" rel="noopener">llama-server source</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t7g70j" target="_blank" rel="noopener">vLLM ROCm Lemonade</a>)</li>
 <li><strong>CPU-only (no GPU, DDR4/DDR5):</strong> Gemma 4 26B-A4B MoE is now confirmed to run at 9.25 t/s generation speed on an i5-8500 with 32GB DDR4 RAM — practical for interactive use. The reason: MoE only activates ~4B parameters per token despite 26B total. This makes it comparable to running a true 4B dense model on CPU. Qwen 3.6 27B Dense activates all 27B parameters per token and is ~8x slower on the same hardware — avoid for CPU-only setups. Recommended quant: Q4_K_M to fit comfortably in 32GB. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t4e046" target="_blank" rel="noopener">source</a>)</li>
 <li><strong>Apple Silicon (32-64 GB unified):</strong> The viral Pacman test ran Gemma 4 31B at 27 tok/s on M5 Max 64GB, confirming strong Apple Silicon inference. MTP is now confirmed working for Gemma 4 via the omlx runtime: a first-hand M1 Max 64GB report (May 7) measured 11 → 20+ tok/s — roughly doubling decode speed. Standard MLX MTP support is still pending. MTPLX (a separate patched MLX fork) shows 2.24x speedup on Qwen 3.6 27B and claims compatibility with any MTP model. Recommended quant for 31B on 64GB: Q8 or Q6_K. <strong>Supply chain note (May 9):</strong> Apple has removed the M3 Ultra 256GB Mac Studio from its store, likely ahead of an M5 Mac Studio launch. If you were planning a 256GB Apple Silicon build for BF16 Gemma 4 31B, that window has closed for now — wait for M5 Ultra availability and pricing before committing. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0epei" target="_blank" rel="noopener">sources</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t6iy5s" target="_blank" rel="noopener">omlx MTP</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t3zuvy" target="_blank" rel="noopener">MTPLX</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t8f33t" target="_blank" rel="noopener">Apple store note</a>)</li>
@@ -1179,13 +1316,13 @@
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1tax6hj" target="_blank" rel="noopener">Models and Quants quality test results — the chessboard svg</a> (May 12, 2026, 46 score, 19 comments — Gemma 4 26B Q4_K_L does &quot;very good job&quot; on visual geometry tasks; strong spatial reasoning at Q4 quant)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ta7ce9" target="_blank" rel="noopener">Strix Halo or DGX Spark for a home LLM server?</a> (May 11, 2026, 21 score, 91 comments — owner of both confirms Spark faster prompt processing and better long-context scaling; Strix Halo more repurposable; community split on inference-specialization vs. longevity)</li>
 </ul>
-<p>The full set of 131 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
-<p><em>Last updated: 2026-05-13 (May 13 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
+<p>The full set of 136 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
+<p><em>Last updated: 2026-05-14 (May 14 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
       <div class="community-section" id="community">
-      <h3>Community Reports (131 from r/LocalLLaMA)</h3>
+      <h3>Community Reports (136 from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>
       <div class="search-bar"><input type="text" id="community-search" placeholder="Search community reports..." autocomplete="off"></div>
-      <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (24)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (17)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (8)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (4)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (8)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (92)</button><button class="cat-filter-btn" data-cat="general">Other (32)</button></div>
+      <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (24)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (18)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (8)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (4)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (8)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (95)</button><button class="cat-filter-btn" data-cat="general">Other (34)</button></div>
 <div id="community-cards"><div class="cr-card" data-search="gemma 4 has been released [ quantization agents anthropic google gemma google is going to show what open weights is about. happy easter everyone. gemma-4 has native thinking, tool calling and is multimodal! use temperature = 1.0, top_p = and after a week maybe : &quot;gemma 4 26b heretic uncensored ablated claude opus 4.6 reasoning distlled" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -2393,6 +2530,23 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/danish334 (+13)</span><span class="cr-comment-text">Nice. I too noticed the acceptance rate of dflash wasn't as good as mtp but zlab do mention lossless inference. You should benchmark their claim.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/MrLlamaGnome (+8)</span><span class="cr-comment-text">Nice writeup! As a GTX 1050 3GB potato enjoyer, I wonder how this comparison would change on more constrained hardware... Is one method more compute or I/O dependent in practice than the other?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+8)</span><span class="cr-comment-text">DFlash uses diffusion to generate a larger batch of tokens. MTP is autoregressive, one token at a time, and it usually isn't worth generating more than 2 or 3 tokens with MTP. For the same cost, you c...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tb160j" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
+<div class="cr-card" data-search="is using vllm actually worth it if you aren't serving the model to other people? so, as most of us here are, i'm a llama.cpp loyalist. easy to understand, great configuration, relatively stable, etc. but i’ve been increasingly tempted by vllm, especially since amd just added it as a built-in inference engine to lemonade, and i happen to have an amd gpu. the thing is, i've never actually used vllm directly, but i've heard good things about how it performs compared to llama.cpp… hardware inference" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tbftlt" target="_blank" rel="noopener">Is using vLLM actually worth it if you aren't serving the model to other people?</a></h4>
+      <span class="cr-score cr-score-mid">+75</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/ayylmaonade</span>
+      <span class="cr-date">2026-05-12</span>
+      <span class="cr-flair">Question | Help</span>
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">So, as most of us here are, I'm a llama.cpp loyalist. Easy to understand, great configuration, relatively stable, etc. But I’ve been increasingly tempted by vLLM, especially since AMD just added it as a built-in inference engine to Lemonade, and I ha...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ttkciar (+66)</span><span class="cr-comment-text">If you do any batched inference at all, vLLM is going to scale better and more easily, since it allocates VRAM per-batch as needed as context grows and as more concurrent queries arrive, while llama.c...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Farmadupe (+24)</span><span class="cr-comment-text">It's totally ironic that llama.cpp is built for people without VRAM but (practically) needs to pre-allocate all possible KV VRAM at launch time. If llama.cpp ever gets a mature paging/preempting KV ca...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Klutzy-Snow8016 (+19)</span><span class="cr-comment-text">It usually gets new models before llama.cpp. The same goes for features. For example, MTP is already supported for Qwen3.6 and Gemma 4. vLLM can be much faster if you can use tensor parallelism. It do...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1tbftlt" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
 <div class="cr-card" data-search="speculative decoding question, 665% speed increase im using these settings in llama.cpp: --spec-type ngram-map-k --spec-ngram-size-n 24 --draft-min 12 --draft-max 48 whats the real reason for lets say the prompt is for &quot;minor changes in code&quot;, whats differing between models: gemma 4 31b: doubles in tks gen so 100% qwen 3.6: only 40% more speed devstrall small: 665% increase in speed (what?) edit: added --repeat-penalty 1.0 and --spec-type ngram-m… inference meta-llama qwen gemma specul" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -2545,6 +2699,23 @@
   <p class="cr-summary">I wrote up this little python app to cycle through a bunch of prompts like this: |Single HTML file using three.js from CDN. A central rotating MeshNormalMaterial torus knot. Place a bright Sprite (AdditiveBlending, soft circular canvas texture) at a ...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ambient_temp_xeno (+13)</span><span class="cr-comment-text">I wonder if gemma knows these effects so well because of youtube videos of them.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/DifficultDog8435 (+8)</span><span class="cr-comment-text">That’s sick honestly. I like the idea of treating the prompts like a little generative demo reel instead of manually cherry-picking one good output.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/itsappleseason (+7)</span><span class="cr-comment-text">of course not.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t9cle9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="llama.cpp docker images to run mtp models this is follow up from previous post: there have been many improvements to the mtp pull request and the llama.cpp main branch, such as image support and various bug fixes. i recently made a new build for my local machine, but keeping guides up to date is an issue, so i built docker images to make running them easier. if you are already using l… hardware quantization inference meta-llama qwen gemma the hero we don't deserve. thanks havenoammo! you've done" data-cats="high-gpu quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tc132c" target="_blank" rel="noopener">llama.cpp docker images to run MTP models</a></h4>
+      <span class="cr-score cr-score-mid">+63</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/havenoammo</span>
+      <span class="cr-date">2026-05-13</span>
+      <span class="cr-flair">Resources</span>
+      <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">This is follow up from previous post: There have been many improvements to the MTP pull request and the llama.cpp main branch, such as image support and various bug fixes. I recently made a new build for my local machine, but keeping guides up to dat...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/metmelo (+13)</span><span class="cr-comment-text">The hero we don't deserve.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/grumd (+12)</span><span class="cr-comment-text">Thanks havenoammo! You've done a lot to push MTP with Qwen recently! I'd recommend adding --min-p 0.0 to the command, default is 0.1</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Prudence-0 (+5)</span><span class="cr-comment-text">Il grand merci, j'ai gagné +34% de perf sur ma RTX 3090</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1tc132c" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="introducing laguna xs.2 and laguna m.1 link post. the discussion is mostly in the comments. target: hardware quantization benchmarking good to see one more 30b range moe model. that seems honest benchmark(check the graph) xs.2 is currently out. 33ba3b ( m.1 still not open. 225b always cool to see more open weight models!" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
@@ -2834,6 +3005,23 @@
   <p class="cr-summary">I have run two tests on each LLM with OpenCode to check their basic readiness and convenience: \- Create IndexNow CLI in Golang (Easy Task) and \- Create Migration Map for a website following SiteStructure Strategy. (Complex Task) Tested Qwen 3.5, &amp;a...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pulse77 (+15)</span><span class="cr-comment-text">For complex coding tasks where precision matters the 3-bit quantization is &quot;gambling&quot;...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/InternationalNebula7 (+13)</span><span class="cr-comment-text">Please run with Qwen3.6:27B when unsloth releases the quants. Look forward to seeing the results!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Designer_Reaction551 (+7)</span><span class="cr-comment-text">Qwen3 Coder Next beating the larger 3.5/3.6 general models tracks with what I've seen on agentic coding tasks on similar hardware. Task-tuned models hold structure better at 25-50k context than bigger...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="24+ tok/s from ~30b moe models on an old gtx 1080 (8 gb vram, 128k context) i got qwen 3.6 35b-a3b and gemma 4 26b-a4b running on a $200 secondhand machine (i7-6700 / gtx 1080 / 32 gb ram) using llama.cpp (the turboquant/rotorquant kv cache quantisation allows 128k context within the 8 gb vram). results (q4\k\m models, 128k context): |model|tok/s|key flags| |:-|:-|:-| |qwen 3.6 35b-a3b|\~24| \--n-cpu-moe 30, k=turbo4 v=turbo3| |gemma 4 26b-a4b (no mtp) |\~2… hardware quantization inference rag g" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" target="_blank" rel="noopener">24+ tok/s from ~30B MoE models on an old GTX 1080 (8 GB VRAM, 128k context)</a></h4>
+      <span class="cr-score ">+45</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/mdda</span>
+      <span class="cr-date">2026-05-13</span>
+      <span class="cr-flair">Tutorial | Guide</span>
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">I got Qwen 3.6 35B-A3B and Gemma 4 26B-A4B running on a $200 secondhand machine (i7-6700 / GTX 1080 / 32 GB RAM) using llama.cpp (the TurboQuant/RotorQuant KV cache quantisation allows 128k context within the 8 GB VRAM). Results (Q4\K\M models, 128k ...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/OldEffective9726 (+7)</span><span class="cr-comment-text">That's a steal for only $200!!!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/julp (+4)</span><span class="cr-comment-text">That's interesting about needing to force the MTP onto GPU. Seems like an odd design decision on Google's end.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/rm_rf_all_files (+3)</span><span class="cr-comment-text">32gb ram machine, crazy cheap</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="i tested 9 local models on the same flight sim prompt, all q8, different q providers, mlx i gave 9 local models the same flight combat sim prompt. the results broke a few of my assumptions about quant providers and parameter count. *all 8-bit mlx, m3 max 128gb, served via omlx, prompted through claude code. same prompt every time — single-file html, three selectable planes (jet, prop, wildcard of the model's choice), dynamic enemies, tracers, damage, crash spiral on loss. counted… hardware quant" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
@@ -3225,6 +3413,40 @@
   <p class="cr-summary">I have been using local LLM for coding quite a lot as well as some other tasks (like data extraction from images) and I had quite a good success with Qwen3.6 models. It's obviously not Sonnet/Opus, but I am able to get quite a lot of work done. Latel...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/swagonflyyyy (+26)</span><span class="cr-comment-text">Gemma4-26b and up seems to be good as an everything but code model. Like, its so goddamn intuitive and good at chatting too, but its fails hard at code.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/[deleted] (+16)</span><span class="cr-comment-text">[removed]</span></div><div class="cr-comment"><span class="cr-comment-meta">u/false79 (+9)</span><span class="cr-comment-text">I dont use pi. I use cline --tui on windows and it gets the tool calls 100% of the time But qwen 3.6 27B gets out better answers faster. No issues with calls But I strictly use it for coding. Sometime...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t7rco2" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="gemma 4 e4b is great for short transcriptions yes, for material that is an hour long, there is no getting around tools like whisper - or something even better. however, for transcribing short snippets, gemma works very quickly and reliably- even in foreign languages. do you use it as well? google gemma true, but sadly it can't process audio files directly. google only supports that with the e2b and e4 tbh., i think gemma 4 e4b reached the &quot;good enough&quot; stage for me - not entirely sure " data-cats="general">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tavuru" target="_blank" rel="noopener">Gemma 4 E4B is great for short transcriptions</a></h4>
+      <span class="cr-score ">+22</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/PromptInjection_</span>
+      <span class="cr-date">2026-05-12</span>
+      <span class="cr-flair">Discussion</span>
+      <span class="cr-cat-badge">General</span>
+    </div>
+  </div>
+  <p class="cr-summary">Yes, for material that is an hour long, there is no getting around tools like Whisper - or something even better. However, for transcribing short snippets, Gemma works very quickly and reliably- even in foreign languages. Do you use it as well?</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PromptInjection_ (+8)</span><span class="cr-comment-text">True, but sadly it can't process audio files directly. Google only supports that with the E2B and E4B.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/dev_dan_2 (+7)</span><span class="cr-comment-text">tbh., I think Gemma 4 E4B reached the &quot;good enough&quot; stage for me - not entirely sure yet, but in my usage so far, it looks quite like that! Of course, I still hope for 6-12 months more of even better ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/monrow_io (+4)</span><span class="cr-comment-text">Yeah I’ve seen people do that split setup. Whisper (or similar) for long, noisy audio, and smaller models like Gemma for quick short clips where latency matters more. I don’t really use tools directly...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1tavuru" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="does thinking mode significantly improve translation? between a solid model from qwen or gemma 4, when translating a text, does &quot;thinking mode&quot; significantly boost the quality of the translation, or is the difference negligible? qwen gemma i have been using gemma 4 for translation processing on some personal projects and i found that havi i have a custom harness and i've generally done: 1. pass one, no thinking. direct translation. 2. se thinking pays off for idioms, jargon, and long-f" data-cats="general">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tbt8xl" target="_blank" rel="noopener">Does THINKING MODE significantly improve translation?</a></h4>
+      <span class="cr-score ">+22</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/Sostrene_Blue</span>
+      <span class="cr-date">2026-05-13</span>
+      <span class="cr-flair">Question | Help</span>
+      <span class="cr-cat-badge">General</span>
+    </div>
+  </div>
+  <p class="cr-summary">Between a solid model from Qwen or Gemma 4, when translating a text, does &quot;thinking mode&quot; significantly boost the quality of the translation, or is the difference negligible?</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/UnWiseSageVibe (+17)</span><span class="cr-comment-text">I have been using Gemma 4 for translation processing on some personal projects and I found that having it off is better. It wastes a lot of context thinking about it and also ends up overthinking it.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Temporary-Mix8022 (+10)</span><span class="cr-comment-text">I have a custom harness and I've generally done: 1. Pass one, no thinking. Direct translation. 2. Second pass, consider whether translation are appropriate, flag why/why not. This has a much larger co...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/MindPsychological140 (+5)</span><span class="cr-comment-text">Thinking pays off for idioms, jargon, and long-form consistency. For straight prose it's mostly latency overhead. A dedicated translation tune (Qwen3-Translation, Tower) usually beats generalist + thi...</span></div></div>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1tbt8xl" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="best local llm for web search which llm with under 10b params has the best ability to do web searches is there any benchmark for this where i could see how certain models perform i've checked out gemma e4b it, is it any good for web searching compared to other alternatives at the same size. does the web searching get way better when going to better models like qwen 3.6 35b or gemma 4 31b benchmarking google qwen gemma any decent model will do solid web search if you provide it with the right too" data-cats="quantization">
   <div class="cr-card-header">

--- a/site/community.html
+++ b/site/community.html
@@ -353,30 +353,6 @@
       color: var(--fg);
       font-variant-numeric: tabular-nums;
     }
-    .suite-quality-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 0.75rem;
-      margin: 0 0 1.25rem;
-    }
-    .suite-quality-grid div {
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      background: var(--bg);
-      padding: 0.85rem;
-    }
-    .suite-quality-grid strong {
-      display: block;
-      margin-bottom: 0.35rem;
-      color: var(--fg);
-      font-size: 0.92rem;
-    }
-    .suite-quality-grid span {
-      display: block;
-      color: var(--fg-soft);
-      font-size: 0.86rem;
-      line-height: 1.45;
-    }
     .suite-pill-row {
       display: flex;
       flex-wrap: wrap;
@@ -500,56 +476,6 @@
       font-family: 'SF Mono', Menlo, Consolas, monospace;
       font-size: 0.82rem;
     }
-    .template-full-setup,
-    .variation-full-setup {
-      margin: 0 1rem 1rem;
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      background: var(--bg);
-    }
-    .template-full-setup summary,
-    .variation-full-setup summary {
-      padding: 0.65rem 0.8rem;
-      color: var(--fg);
-      font-weight: 600;
-      cursor: pointer;
-    }
-    .template-full-setup dl {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 0.6rem;
-      margin: 0;
-      padding: 0 0.8rem 0.8rem;
-    }
-    .template-full-setup dt {
-      color: var(--muted);
-      font-size: 0.74rem;
-    }
-    .template-full-setup dd {
-      margin: 0.15rem 0 0;
-      color: var(--fg-soft);
-      overflow-wrap: anywhere;
-    }
-    .template-full-setup h4 {
-      margin: 0.75rem 0.8rem 0.35rem;
-      color: var(--fg);
-      font-size: 0.9rem;
-    }
-    .template-full-setup pre,
-    .variation-full-setup pre {
-      margin: 0 0.8rem 0.8rem;
-      max-height: 360px;
-      overflow: auto;
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      background: var(--bg-elev);
-      color: var(--fg-soft);
-      padding: 0.75rem;
-      font-size: 0.78rem;
-      line-height: 1.5;
-    }
     .variation-list {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -573,62 +499,6 @@
     .variation-chip:hover {
       border-color: var(--accent);
       color: var(--accent);
-    }
-    .variation-chip[aria-current="true"] {
-      border-color: var(--accent);
-      background: var(--accent-soft);
-      color: var(--fg);
-    }
-    .variation-detail {
-      margin: 0 1rem 1rem;
-      border: 1px solid var(--accent);
-      border-radius: 8px;
-      background: var(--bg);
-      padding: 1rem;
-      scroll-margin-top: 96px;
-    }
-    .variation-detail-header {
-      display: flex;
-      align-items: baseline;
-      justify-content: space-between;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-      margin-bottom: 0.8rem;
-    }
-    .variation-detail-header span {
-      color: var(--muted);
-      font-size: 0.78rem;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-    }
-    .variation-detail-header strong {
-      color: var(--fg);
-      font-family: 'SF Mono', Menlo, Consolas, monospace;
-      font-size: 0.9rem;
-    }
-    .variation-detail dl {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 0.7rem 1rem;
-      margin: 0;
-    }
-    .variation-detail dl div {
-      min-width: 0;
-    }
-    .variation-detail dt {
-      color: var(--muted);
-      font-size: 0.75rem;
-      margin-bottom: 0.18rem;
-    }
-    .variation-detail dd {
-      margin: 0;
-      color: var(--fg-soft);
-      font-size: 0.9rem;
-      overflow-wrap: anywhere;
-    }
-    .variation-detail code {
-      white-space: normal;
-      overflow-wrap: anywhere;
     }
 
     /* Search */
@@ -1131,14 +1001,8 @@
     <section id="community-page">
       <h2>Community & Hardware Reports</h2>
       <p>Real-world experiences running Gemma models, curated from the community. Browse hardware reports, read the weekly field notes, or search for your setup.</p>
-      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes — 2026-05-14</h2>
-<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (15 new or updated since 2026-05-13, 136 total) and their top comment threads. Confidence is <strong>medium</strong> unless noted, since this is community signal rather than a controlled benchmark.</p>
-<p><em>May 14 sweep, 2026-05-14 00:00 EDT:</em> five developments from this sweep extend the budget hardware picture for Gemma 4 MoE, surface practical GPU power tuning, confirm prefill tuning for partially-offloaded models, and add new guidance on vLLM vs llama.cpp for single-user workloads.</p>
-<p><strong>Gemma 4 26B-A4B running at ~24 tok/s on a $200 secondhand GTX 1080 machine — a new floor for budget inference.</strong> A detailed guide (May 13, 46 score) demonstrates Gemma 4 26B-A4B and Qwen 3.6 35B-A3B running on an i7-6700 / GTX 1080 (8 GB VRAM) / 32 GB RAM machine costing ~$200 secondhand via llama.cpp with TurboQuant/RotorQuant KV cache quantization. Results at Q4_K_M with 128k context: Gemma 4 26B-A4B (no MTP) ~20 tok/s with `--n-cpu-moe 20`, TurboQuant KV turbo3 on both K and V caches; after fixing the MTP token embedding table placement, ~24.5 tok/s with `--override-tensor-draft &quot;token_embd\.weight=CUDA0&quot;`. The key mechanism: TurboQuant/RotorQuant KV cache compression fits the KV cache within 8 GB VRAM even at 128k context, while `--n-cpu-moe` offloads the cold MoE expert weights to system RAM, streaming them over PCIe as needed. The GPU sits at ~40-50% utilization; the bottleneck is PCIe bandwidth. Important caveat from the post: the GTX 1080 test used small prompts (under 2,000 actual tokens despite 128k reservation); a commenter notes that larger real-world prompts at 128k context will degrade throughput further as VRAM is tighter with large KV. MTP barely helped out of the box (~5% gain) because Gemma 4's tied LM head forces token embedding lookups on the CPU by default; the fix flag above moves the embedding table to GPU. This is an anecdotal data point, not a reproducible benchmark baseline, and TurboQuant is not in mainline llama.cpp. But directionally, a ~$200 machine can now run a 26B MoE at interactive speeds — a meaningful lower bound for the local Gemma 4 story. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" target="_blank" rel="noopener">source</a>, May 13, 46 score, 10 comments)</p>
-<p><strong>Cut GPU power limit to 40% TDP — no throughput loss for LLM decode, meaningful savings on power, heat, and noise.</strong> A viral post (May 12, 709 score, 198 comments) benchmarked an RTX 4090 running Qwen3.6-27B-UD-Q4_K_XL with `nvidia-smi -pl` set to various power limits. Result: reducing to approximately 40% of rated TDP (~100W for a 4090) preserves generation throughput almost identically while cutting electricity draw, heat output, and fan noise proportionally. Multiple RTX 5090 owners in the comments independently validated the finding at their own hardware (860mV/2500MHz, ~360W, with only ~12% TPS loss at the absolute voltage floor). The mechanism: LLM decode is memory bandwidth bound, not compute bound. Once the GPU's memory bus is the bottleneck, reducing compute frequency and voltage has minimal effect on bandwidth-limited operations. The result holds for any consumer NVIDIA GPU running inference workloads including Gemma 4. Practical guidance: reduce power limit incrementally with `nvidia-smi -pl` and monitor generation speed — you can reclaim meaningful electricity savings at almost no quality cost. This is a well-established finding now backed by community data across multiple GPU generations. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tayu5t" target="_blank" rel="noopener">source</a>, May 12, 709 score, 198 comments)</p>
-<p><strong>Raising llama.cpp `-ub` to 4096-8192 gives ~5.5x prefill speedup for partially CPU-offloaded MoE models.</strong> A guide (May 12, 112 score, 53 comments) discovered that increasing the micro-batch size (`-ub`) from llama.cpp's default 512 to 4096 or 8192 dramatically improves prompt processing throughput for `--n-cpu-moe` partially-offloaded models. Measured on an RTX 3090 with a 120B model: prompt processing improved from ~380 tok/s at default `-ub 512` to ~2091 tok/s at `-ub 8192` — a ~5.5x gain. Generation speed was nearly unchanged (32.3 → 30.1 tok/s, ~7% regression). The mechanism, debated in comments: either amortizing PCIe transfer overhead across more tokens (reducing per-transfer round-trip cost) or reducing GPU kernel launch overhead by saturating the attention/router on fewer, larger batches. Both explanations are consistent with the observation. The default 512 exists because it's a safe conservative value for low-VRAM cards that have little headroom for compute workspace spikes. Users with spare VRAM should tune upward and stop when either VRAM OOM or generation speed starts to regress. This applies directly to Gemma 4 26B-A4B when partially offloaded — pair with `--n-cpu-moe` adjustment to keep the run within VRAM at the chosen `-ub`. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tany5t" target="_blank" rel="noopener">source</a>, May 12, 112 score, 53 comments)</p>
-<p><strong>vLLM vs llama.cpp for single-user workloads: confirmed equivalent at low concurrency, vLLM wins at 4+ concurrent users.</strong> A community discussion (May 12, 75 score, 91 comments) produced a clear practical consensus. vLLM adds meaningful value when: (1) concurrent batch inference is in play — vLLM allocates VRAM per-batch as context grows while llama.cpp must pre-allocate max-context KV VRAM at launch; (2) tensor-parallel multi-GPU/multi-node serving is needed (e.g., Qwen 397B across two DGX Sparks). vLLM also supports MTP for Gemma 4 and Qwen3.6 already, while llama.cpp MTP is still in a patched fork. For single-user non-batched local use, llama.cpp remains simpler with equivalent per-query throughput. CUDA prompt processing is faster in vLLM regardless of batch size. AMD Lemonade now ships vLLM ROCm as a built-in experimental backend. This confirms and sharpens the earlier guidance: if you are a solo user running interactive chat or coding sessions, llama.cpp or LMStudio is fine; switch to vLLM when you need to serve multiple concurrent users or run tensor-parallel inference on model weights too large for one GPU. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tbftlt" target="_blank" rel="noopener">source</a>, May 12, 75 score, 91 comments)</p>
-<p><strong>Docker images simplify llama.cpp MTP deployment — confirmed +34% throughput on RTX 3090.</strong> A community developer (May 13, 63 score, 16 comments) released Docker images pre-built from the llama.cpp MTP development branch, removing the barrier of building from source. A commenter reports +34% throughput gain on an RTX 3090 after switching. The images track recent MTP branch improvements including image support and bug fixes. A commenter asks whether Gemma 4 is supported; the Docker images cover the same model classes as the underlying MTP PR (primarily Qwen3.6 for now). For Gemma 4 MTP, the mainline llama.cpp PR #22673 is still in review; until it merges, the AtomicBot-ai patched fork remains the llama.cpp path for Gemma 4 MTP specifically. Recommended flag addition from comments: `--min-p 0.0` (default 0.1 can interfere with speculative decoding). (<a href="https://reddit.com/r/LocalLLaMA/comments/1tc132c" target="_blank" rel="noopener">source</a>, May 13, 63 score, 16 comments)</p>
+      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes — 2026-05-13</h2>
+<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (17 new or updated since 2026-05-12, 131 total) and their top comment threads. Confidence is <strong>medium</strong> unless noted, since this is community signal rather than a controlled benchmark.</p>
 <p><em>May 13 sweep, 2026-05-13 00:00 EDT:</em> five developments from this sweep extend the MTP vs DFlash picture, surface a supply chain signal for Apple Silicon buyers, add new practical limits for Gemma 4 E4B in code use cases, and document a home-server hardware comparison from someone who owns both the Strix Halo and DGX Spark.</p>
 <p><strong>First controlled head-to-head benchmark of Gemma 4 MTP vs DFlash on a single H100 — MTP wins at concurrency.</strong> A community benchmark (May 12, 62 score, 22 comments) ran Gemma 4 31B Dense and 26B-A4B MoE against both MTP and DFlash on a single H100 80GB using vLLM and NVIDIA's SPEED-Bench dataset (880 prompts, 11 categories). Results for 31B Dense: at concurrency 1, MTP hit 125.3 tok/s (3.11x over baseline 40.3) and DFlash hit 122.1 tok/s (3.03x). At concurrency 16, MTP reached 953 tok/s versus DFlash's 725 tok/s versus baseline 375 tok/s — a meaningful gap in favor of MTP at higher concurrency. The architectural explanation from commenters: DFlash generates a larger speculative batch via diffusion but has lower acceptance rate per token; MTP is autoregressive with higher per-token acceptance, so at scale its advantage compounds. Practical guidance: at concurrency 1 the two methods are nearly equivalent; at concurrency 4+ for serving multiple users, MTP outperforms DFlash by a widening margin. This is the first benchmark to quantify the concurrency dimension — prior guidance focused on single-user latency where both methods were close. DFlash's lower acceptance rate with the diffusion-based approach means more compute spent on rejected tokens under load. Still vLLM-only for both methods; no mainline llama.cpp path yet. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tb160j" target="_blank" rel="noopener">source</a>, May 12, 62 score, 22 comments)</p>
 <p><strong>Apple removes M3 Ultra 256GB Mac Studio — M5 expected, but supply chain is under stress.</strong> Apple pulled the M3 Ultra 256GB Mac Studio configuration from its online store (May 9, 462 score, 132 comments). The top community read: M3 is being phased out ahead of an M5 Mac Studio launch, not a deliberate memory cap decision. Technical context: M3 and M5 use incompatible DRAM types (LPDDR5-6400 vs LPDDR5x-9600), so M3 chip stock is not convertible to M5 builds. An independent complicating factor: a Samsung DRAM worker strike cut production capacity by 58% on one shift. Community concern about M5 Ultra memory configurations is real but largely speculative — no M5 Ultra specs have been announced. Practical impact for Gemma 4 Apple Silicon users: the M3 Ultra 256GB, which was the best available option for running Gemma 4 31B Dense at full BF16 precision with context headroom, is no longer orderable. Anyone actively planning a high-memory Apple Silicon build for Gemma 4 should wait for M5 Ultra pricing and configuration announcements before committing. The 192GB M3 Ultra (if still available) or used M2 Ultra 192GB remain the current options if you need maximum unified memory now. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t8f33t" target="_blank" rel="noopener">source</a>, May 9, 462 score, 132 comments)</p>
@@ -1195,8 +1059,7 @@
 <ul class="setup-list">
 <li><strong>RTX 5xxx (Blackwell consumer):</strong> Gemma 4 26B MoE now has an official <a href="https://huggingface.co/nvidia/Gemma-4-26B-A4B-NVFP4" target="_blank" rel="noopener">nvidia/Gemma-4-26B-A4B-NVFP4</a> quant at 18.8GB. On a 5090 with 80% VRAM allocation, users report ~50K context. Benchmarks are near-lossless: GPQA Diamond 79.9% vs 80.3% baseline, AIME 2025 actually improved to 90.0% from 88.95%. <strong>New as of May 9:</strong> DFlash for the 26B MoE is now live via z-lab — benchmarks on the 5090 show 228 → 578 tok/s (2.56x) at optimal settings with vLLM. Critical caveat: DFlash degrades sharply at 20k+ context (drops from 400 to 200 tok/s and continues declining). Use DFlash for short-context inference; for long-context work, NVFP4 without DFlash remains the recommended path. For 31B Dense, NVFP4 GGUF with llama.cpp <a href="https://github.com/ggml-org/llama.cpp/pull/22196" target="_blank" rel="noopener">PR #22196</a> or the existing DFlash variant remain the paths. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0i18e" target="_blank" rel="noopener">NVFP4 source</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t796qe" target="_blank" rel="noopener">DFlash benchmark</a>)</li>
 <li><strong>Mid-to-high single GPU (24+ GB VRAM, non-Blackwell):</strong> Gemma 4 31B Dense at Q5_K_M or Q6_K remains the strongest single-card choice for general work, writing, and visual understanding. New this week: the DFlash variant (<a href="https://huggingface.co/z-lab/gemma-4-31B-it-DFlash" target="_blank" rel="noopener">gemma-4-31B-it-DFlash</a>) has been released but still needs <a href="https://github.com/ggml-org/llama.cpp/pull/22105" target="_blank" rel="noopener">llama.cpp PR #22105</a> to merge before practical use. ggerganov is reportedly planning a speculative-architecture refactor first. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0s4qv" target="_blank" rel="noopener">source</a>)</li>
-<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Detailed speed benchmarks from an RTX 4070S 12GB user (DDR5 6000MHz, iGPU display offload) show Gemma 4 26B MoE and 31B Dense both runnable with substantial CPU offload. The 12GB club is real: careful config tuning (CUDA 13.1, display offload to iGPU, cache reuse settings) gets 40 t/s on 35B Q6 with system RAM spill. Keep Gemma 4 for prose and Qwen 3.6 for code in this tier. <strong>New (May 14):</strong> Reduce GPU power limit with `nvidia-smi -pl` to ~40% TDP — confirmed on RTX 4090 that generation throughput is nearly unchanged (LLM decode is memory-bandwidth-bound, not compute-bound). Reclaim meaningful power, heat, and noise savings at essentially no performance cost. (<a href="https://reddit.com/r/LocalLLaMA/comments/1szziv0" target="_blank" rel="noopener">12GB source</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1tayu5t" target="_blank" rel="noopener">power limit source</a>)</li>
-<li><strong>Budget hardware (GTX 1080 8 GB VRAM, ~$200 secondhand machine):</strong> New May 14 lower bound. A $200 i7-6700 / GTX 1080 / 32 GB RAM machine runs Gemma 4 26B-A4B at ~20–24.5 tok/s using TurboQuant/RotorQuant KV cache (allows 128k context within 8 GB VRAM) and `--n-cpu-moe 20` CPU MoE offload. Key flags: `--override-tensor-draft &quot;token_embd\.weight=CUDA0&quot;` needed to fix MTP's tied LM head behavior for Gemma 4 specifically. The GPU is PCIe bandwidth-limited (~40-50% GPU utilization). Note: TurboQuant KV is not in mainline llama.cpp; requires AtomicBot-ai or ikawrakow fork. Treat as an existence proof — actual throughput at full 128k real context will be lower than these small-prompt benchmarks. If you already have an 8GB GPU collecting dust, Gemma 4 26B-A4B is runnable. (<a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" target="_blank" rel="noopener">source</a>)</li>
+<li><strong>Constrained GPU (8-16 GB VRAM):</strong> Detailed speed benchmarks from an RTX 4070S 12GB user (DDR5 6000MHz, iGPU display offload) show Gemma 4 26B MoE and 31B Dense both runnable with substantial CPU offload. The 12GB club is real: careful config tuning (CUDA 13.1, display offload to iGPU, cache reuse settings) gets 40 t/s on 35B Q6 with system RAM spill. Keep Gemma 4 for prose and Qwen 3.6 for code in this tier. (<a href="https://reddit.com/r/LocalLLaMA/comments/1szziv0" target="_blank" rel="noopener">source</a>)</li>
 <li><strong>AMD consumer GPU (Radeon 9060 XT 16GB, eGPU):</strong> A first-hand report on a 7840HS mini-PC paired with an external Radeon 9060 XT lands the Gemma 4 24B A4B IQ4_NL variant at 25.9 tok/s via llama-server, with KV cache at q8_0 and a small 256-token batch target. The user notes the configuration is usable for OpenCode codebase Q&amp;A. Reply chain confirms 16GB is tight at 128K context and forces partial CPU offload, so for steady-state work expect lower numbers when context fills. <strong>New (May 9):</strong> Lemonade added vLLM ROCm as an experimental backend, allowing inference from standard model weights on Radeon 6000/7000-series GPUs without converting to GGUF first — useful for quick evaluation of new models before committing to conversion. Backend is experimental; validate on your GPU before production use. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0kxdw" target="_blank" rel="noopener">llama-server source</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t7g70j" target="_blank" rel="noopener">vLLM ROCm Lemonade</a>)</li>
 <li><strong>CPU-only (no GPU, DDR4/DDR5):</strong> Gemma 4 26B-A4B MoE is now confirmed to run at 9.25 t/s generation speed on an i5-8500 with 32GB DDR4 RAM — practical for interactive use. The reason: MoE only activates ~4B parameters per token despite 26B total. This makes it comparable to running a true 4B dense model on CPU. Qwen 3.6 27B Dense activates all 27B parameters per token and is ~8x slower on the same hardware — avoid for CPU-only setups. Recommended quant: Q4_K_M to fit comfortably in 32GB. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t4e046" target="_blank" rel="noopener">source</a>)</li>
 <li><strong>Apple Silicon (32-64 GB unified):</strong> The viral Pacman test ran Gemma 4 31B at 27 tok/s on M5 Max 64GB, confirming strong Apple Silicon inference. MTP is now confirmed working for Gemma 4 via the omlx runtime: a first-hand M1 Max 64GB report (May 7) measured 11 → 20+ tok/s — roughly doubling decode speed. Standard MLX MTP support is still pending. MTPLX (a separate patched MLX fork) shows 2.24x speedup on Qwen 3.6 27B and claims compatibility with any MTP model. Recommended quant for 31B on 64GB: Q8 or Q6_K. <strong>Supply chain note (May 9):</strong> Apple has removed the M3 Ultra 256GB Mac Studio from its store, likely ahead of an M5 Mac Studio launch. If you were planning a 256GB Apple Silicon build for BF16 Gemma 4 31B, that window has closed for now — wait for M5 Ultra availability and pricing before committing. (<a href="https://reddit.com/r/LocalLLaMA/comments/1t0epei" target="_blank" rel="noopener">sources</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t6iy5s" target="_blank" rel="noopener">omlx MTP</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t3zuvy" target="_blank" rel="noopener">MTPLX</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1t8f33t" target="_blank" rel="noopener">Apple store note</a>)</li>
@@ -1316,13 +1179,13 @@
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1tax6hj" target="_blank" rel="noopener">Models and Quants quality test results — the chessboard svg</a> (May 12, 2026, 46 score, 19 comments — Gemma 4 26B Q4_K_L does &quot;very good job&quot; on visual geometry tasks; strong spatial reasoning at Q4 quant)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ta7ce9" target="_blank" rel="noopener">Strix Halo or DGX Spark for a home LLM server?</a> (May 11, 2026, 21 score, 91 comments — owner of both confirms Spark faster prompt processing and better long-context scaling; Strix Halo more repurposable; community split on inference-specialization vs. longevity)</li>
 </ul>
-<p>The full set of 136 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
-<p><em>Last updated: 2026-05-14 (May 14 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
+<p>The full set of 131 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
+<p><em>Last updated: 2026-05-13 (May 13 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
       <div class="community-section" id="community">
-      <h3>Community Reports (136 from r/LocalLLaMA)</h3>
+      <h3>Community Reports (131 from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>
       <div class="search-bar"><input type="text" id="community-search" placeholder="Search community reports..." autocomplete="off"></div>
-      <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (24)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (18)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (8)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (4)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (8)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (95)</button><button class="cat-filter-btn" data-cat="general">Other (34)</button></div>
+      <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (24)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (17)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (8)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (4)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (8)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (92)</button><button class="cat-filter-btn" data-cat="general">Other (32)</button></div>
 <div id="community-cards"><div class="cr-card" data-search="gemma 4 has been released [ quantization agents anthropic google gemma google is going to show what open weights is about. happy easter everyone. gemma-4 has native thinking, tool calling and is multimodal! use temperature = 1.0, top_p = and after a week maybe : &quot;gemma 4 26b heretic uncensored ablated claude opus 4.6 reasoning distlled" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -2530,23 +2393,6 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/danish334 (+13)</span><span class="cr-comment-text">Nice. I too noticed the acceptance rate of dflash wasn't as good as mtp but zlab do mention lossless inference. You should benchmark their claim.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/MrLlamaGnome (+8)</span><span class="cr-comment-text">Nice writeup! As a GTX 1050 3GB potato enjoyer, I wonder how this comparison would change on more constrained hardware... Is one method more compute or I/O dependent in practice than the other?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+8)</span><span class="cr-comment-text">DFlash uses diffusion to generate a larger batch of tokens. MTP is autoregressive, one token at a time, and it usually isn't worth generating more than 2 or 3 tokens with MTP. For the same cost, you c...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tb160j" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="is using vllm actually worth it if you aren't serving the model to other people? so, as most of us here are, i'm a llama.cpp loyalist. easy to understand, great configuration, relatively stable, etc. but i’ve been increasingly tempted by vllm, especially since amd just added it as a built-in inference engine to lemonade, and i happen to have an amd gpu. the thing is, i've never actually used vllm directly, but i've heard good things about how it performs compared to llama.cpp… hardware inference" data-cats="quantization">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tbftlt" target="_blank" rel="noopener">Is using vLLM actually worth it if you aren't serving the model to other people?</a></h4>
-      <span class="cr-score cr-score-mid">+75</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/ayylmaonade</span>
-      <span class="cr-date">2026-05-12</span>
-      <span class="cr-flair">Question | Help</span>
-      <span class="cr-cat-badge">Quantization &amp; Backends</span>
-    </div>
-  </div>
-  <p class="cr-summary">So, as most of us here are, I'm a llama.cpp loyalist. Easy to understand, great configuration, relatively stable, etc. But I’ve been increasingly tempted by vLLM, especially since AMD just added it as a built-in inference engine to Lemonade, and I ha...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ttkciar (+66)</span><span class="cr-comment-text">If you do any batched inference at all, vLLM is going to scale better and more easily, since it allocates VRAM per-batch as needed as context grows and as more concurrent queries arrive, while llama.c...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Farmadupe (+24)</span><span class="cr-comment-text">It's totally ironic that llama.cpp is built for people without VRAM but (practically) needs to pre-allocate all possible KV VRAM at launch time. If llama.cpp ever gets a mature paging/preempting KV ca...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Klutzy-Snow8016 (+19)</span><span class="cr-comment-text">It usually gets new models before llama.cpp. The same goes for features. For example, MTP is already supported for Qwen3.6 and Gemma 4. vLLM can be much faster if you can use tensor parallelism. It do...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1tbftlt" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
 <div class="cr-card" data-search="speculative decoding question, 665% speed increase im using these settings in llama.cpp: --spec-type ngram-map-k --spec-ngram-size-n 24 --draft-min 12 --draft-max 48 whats the real reason for lets say the prompt is for &quot;minor changes in code&quot;, whats differing between models: gemma 4 31b: doubles in tks gen so 100% qwen 3.6: only 40% more speed devstrall small: 665% increase in speed (what?) edit: added --repeat-penalty 1.0 and --spec-type ngram-m… inference meta-llama qwen gemma specul" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -2699,23 +2545,6 @@
   <p class="cr-summary">I wrote up this little python app to cycle through a bunch of prompts like this: |Single HTML file using three.js from CDN. A central rotating MeshNormalMaterial torus knot. Place a bright Sprite (AdditiveBlending, soft circular canvas texture) at a ...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ambient_temp_xeno (+13)</span><span class="cr-comment-text">I wonder if gemma knows these effects so well because of youtube videos of them.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/DifficultDog8435 (+8)</span><span class="cr-comment-text">That’s sick honestly. I like the idea of treating the prompts like a little generative demo reel instead of manually cherry-picking one good output.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/itsappleseason (+7)</span><span class="cr-comment-text">of course not.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t9cle9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
-<div class="cr-card" data-search="llama.cpp docker images to run mtp models this is follow up from previous post: there have been many improvements to the mtp pull request and the llama.cpp main branch, such as image support and various bug fixes. i recently made a new build for my local machine, but keeping guides up to date is an issue, so i built docker images to make running them easier. if you are already using l… hardware quantization inference meta-llama qwen gemma the hero we don't deserve. thanks havenoammo! you've done" data-cats="high-gpu quantization">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tc132c" target="_blank" rel="noopener">llama.cpp docker images to run MTP models</a></h4>
-      <span class="cr-score cr-score-mid">+63</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/havenoammo</span>
-      <span class="cr-date">2026-05-13</span>
-      <span class="cr-flair">Resources</span>
-      <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
-    </div>
-  </div>
-  <p class="cr-summary">This is follow up from previous post: There have been many improvements to the MTP pull request and the llama.cpp main branch, such as image support and various bug fixes. I recently made a new build for my local machine, but keeping guides up to dat...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/metmelo (+13)</span><span class="cr-comment-text">The hero we don't deserve.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/grumd (+12)</span><span class="cr-comment-text">Thanks havenoammo! You've done a lot to push MTP with Qwen recently! I'd recommend adding --min-p 0.0 to the command, default is 0.1</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Prudence-0 (+5)</span><span class="cr-comment-text">Il grand merci, j'ai gagné +34% de perf sur ma RTX 3090</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1tc132c" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="introducing laguna xs.2 and laguna m.1 link post. the discussion is mostly in the comments. target: hardware quantization benchmarking good to see one more 30b range moe model. that seems honest benchmark(check the graph) xs.2 is currently out. 33ba3b ( m.1 still not open. 225b always cool to see more open weight models!" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
@@ -3005,23 +2834,6 @@
   <p class="cr-summary">I have run two tests on each LLM with OpenCode to check their basic readiness and convenience: \- Create IndexNow CLI in Golang (Easy Task) and \- Create Migration Map for a website following SiteStructure Strategy. (Complex Task) Tested Qwen 3.5, &amp;a...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pulse77 (+15)</span><span class="cr-comment-text">For complex coding tasks where precision matters the 3-bit quantization is &quot;gambling&quot;...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/InternationalNebula7 (+13)</span><span class="cr-comment-text">Please run with Qwen3.6:27B when unsloth releases the quants. Look forward to seeing the results!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Designer_Reaction551 (+7)</span><span class="cr-comment-text">Qwen3 Coder Next beating the larger 3.5/3.6 general models tracks with what I've seen on agentic coding tasks on similar hardware. Task-tuned models hold structure better at 25-50k context than bigger...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
-<div class="cr-card" data-search="24+ tok/s from ~30b moe models on an old gtx 1080 (8 gb vram, 128k context) i got qwen 3.6 35b-a3b and gemma 4 26b-a4b running on a $200 secondhand machine (i7-6700 / gtx 1080 / 32 gb ram) using llama.cpp (the turboquant/rotorquant kv cache quantisation allows 128k context within the 8 gb vram). results (q4\k\m models, 128k context): |model|tok/s|key flags| |:-|:-|:-| |qwen 3.6 35b-a3b|\~24| \--n-cpu-moe 30, k=turbo4 v=turbo3| |gemma 4 26b-a4b (no mtp) |\~2… hardware quantization inference rag g" data-cats="quantization">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" target="_blank" rel="noopener">24+ tok/s from ~30B MoE models on an old GTX 1080 (8 GB VRAM, 128k context)</a></h4>
-      <span class="cr-score ">+46</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/mdda</span>
-      <span class="cr-date">2026-05-13</span>
-      <span class="cr-flair">Tutorial | Guide</span>
-      <span class="cr-cat-badge">Quantization &amp; Backends</span>
-    </div>
-  </div>
-  <p class="cr-summary">I got Qwen 3.6 35B-A3B and Gemma 4 26B-A4B running on a $200 secondhand machine (i7-6700 / GTX 1080 / 32 GB RAM) using llama.cpp (the TurboQuant/RotorQuant KV cache quantisation allows 128k context within the 8 GB VRAM). Results (Q4\K\M models, 128k ...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/OldEffective9726 (+5)</span><span class="cr-comment-text">That's a steal for only $200!!!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/julp (+3)</span><span class="cr-comment-text">That's interesting about needing to force the MTP onto GPU. Seems like an odd design decision on Google's end.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Client_Hello (+3)</span><span class="cr-comment-text">Your tests are all with small context, usually under 2000 total tokens. While you reserved 128k, you didn't actually use it. Reserving the larger context reserved VRAM, causing more layers to offload ...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1tcc7h5" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="i tested 9 local models on the same flight sim prompt, all q8, different q providers, mlx i gave 9 local models the same flight combat sim prompt. the results broke a few of my assumptions about quant providers and parameter count. *all 8-bit mlx, m3 max 128gb, served via omlx, prompted through claude code. same prompt every time — single-file html, three selectable planes (jet, prop, wildcard of the model's choice), dynamic enemies, tracers, damage, crash spiral on loss. counted… hardware quant" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
@@ -3414,23 +3226,6 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/swagonflyyyy (+26)</span><span class="cr-comment-text">Gemma4-26b and up seems to be good as an everything but code model. Like, its so goddamn intuitive and good at chatting too, but its fails hard at code.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/[deleted] (+16)</span><span class="cr-comment-text">[removed]</span></div><div class="cr-comment"><span class="cr-comment-meta">u/false79 (+9)</span><span class="cr-comment-text">I dont use pi. I use cline --tui on windows and it gets the tool calls 100% of the time But qwen 3.6 27B gets out better answers faster. No issues with calls But I strictly use it for coding. Sometime...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t7rco2" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 e4b is great for short transcriptions yes, for material that is an hour long, there is no getting around tools like whisper - or something even better. however, for transcribing short snippets, gemma works very quickly and reliably- even in foreign languages. do you use it as well? google gemma true, but sadly it can't process audio files directly. google only supports that with the e2b and e4 tbh., i think gemma 4 e4b reached the &quot;good enough&quot; stage for me - not entirely sure " data-cats="general">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tavuru" target="_blank" rel="noopener">Gemma 4 E4B is great for short transcriptions</a></h4>
-      <span class="cr-score ">+22</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/PromptInjection_</span>
-      <span class="cr-date">2026-05-12</span>
-      <span class="cr-flair">Discussion</span>
-      <span class="cr-cat-badge">General</span>
-    </div>
-  </div>
-  <p class="cr-summary">Yes, for material that is an hour long, there is no getting around tools like Whisper - or something even better. However, for transcribing short snippets, Gemma works very quickly and reliably- even in foreign languages. Do you use it as well?</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PromptInjection_ (+8)</span><span class="cr-comment-text">True, but sadly it can't process audio files directly. Google only supports that with the E2B and E4B.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/dev_dan_2 (+7)</span><span class="cr-comment-text">tbh., I think Gemma 4 E4B reached the &quot;good enough&quot; stage for me - not entirely sure yet, but in my usage so far, it looks quite like that! Of course, I still hope for 6-12 months more of even better ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/monrow_io (+4)</span><span class="cr-comment-text">Yeah I’ve seen people do that split setup. Whisper (or similar) for long, noisy audio, and smaller models like Gemma for quick short clips where latency matters more. I don’t really use tools directly...</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1tavuru" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
 <div class="cr-card" data-search="best local llm for web search which llm with under 10b params has the best ability to do web searches is there any benchmark for this where i could see how certain models perform i've checked out gemma e4b it, is it any good for web searching compared to other alternatives at the same size. does the web searching get way better when going to better models like qwen 3.6 35b or gemma 4 31b benchmarking google qwen gemma any decent model will do solid web search if you provide it with the right too" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -3532,23 +3327,6 @@
   <p class="cr-summary">I’m currently stuck deciding between AMD Strix Halo (128 GB AMD Ryzen AI Max+ 395 Framework Desktop) and an Nvidia DGX Spark (Asus Ascent GX10) for a home LLM server that can be accessed over the local network with a ChatGPT like interface in a web b...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/abnormal_human (+51)</span><span class="cr-comment-text">If you're just doing LLM inference on it, Spark all the way. If you also want a gaming PC (or whatever), Strix Halo.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tomekrs (+41)</span><span class="cr-comment-text">Definitely Ryzen 395, as it's a standard x86/amd64 machine that can always be repurposed and will never lose drivers or compatibility with new operating systems. Nvidia on the other hand has a history...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Eugr (+33)</span><span class="cr-comment-text">Spark has much faster GPU which results in faster prompt processing speeds. Also, the performance degrades less on Spark as context grows (I have both).</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ta7ce9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
-</div>
-<div class="cr-card" data-search="does thinking mode significantly improve translation? between a solid model from qwen or gemma 4, when translating a text, does &quot;thinking mode&quot; significantly boost the quality of the translation, or is the difference negligible? qwen gemma i have been using gemma 4 for translation processing on some personal projects and i found that havi i have a custom harness and i've generally done: 1. pass one, no thinking. direct translation. 2. se translation should be a relatively easy task and" data-cats="general">
-  <div class="cr-card-header">
-    <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tbt8xl" target="_blank" rel="noopener">Does THINKING MODE significantly improve translation?</a></h4>
-      <span class="cr-score ">+20</span>
-    </div>
-    <div class="cr-meta">
-      <span class="cr-author">u/Sostrene_Blue</span>
-      <span class="cr-date">2026-05-13</span>
-      <span class="cr-flair">Question | Help</span>
-      <span class="cr-cat-badge">General</span>
-    </div>
-  </div>
-  <p class="cr-summary">Between a solid model from Qwen or Gemma 4, when translating a text, does &quot;thinking mode&quot; significantly boost the quality of the translation, or is the difference negligible?</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/UnWiseSageVibe (+17)</span><span class="cr-comment-text">I have been using Gemma 4 for translation processing on some personal projects and I found that having it off is better. It wastes a lot of context thinking about it and also ends up overthinking it.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Temporary-Mix8022 (+11)</span><span class="cr-comment-text">I have a custom harness and I've generally done: 1. Pass one, no thinking. Direct translation. 2. Second pass, consider whether translation are appropriate, flag why/why not. This has a much larger co...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LagOps91 (+5)</span><span class="cr-comment-text">translation should be a relatively easy task and no thinking should be required. be sure that you don't have any repetition penalty set and use low temperature.</span></div></div>
-  <a href="https://reddit.com/r/LocalLLaMA/comments/1tbt8xl" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="anyone tried +- 100b models locally with foreign languages? community discussion comparing gemma 4 31b, qwen 3.6 27b, and glm 4.7 30b on non-english (primarily european) languages. original poster reports gemma 4 31b as the best at czech, noting it &quot;blows their mind&quot; at 18gb. key community finding: gemma 4 31b (16-bit) is reported as &quot;extremely good in hungarian&quot; while the 26b 8-bit variant shows some &quot;slightly chinese&quot; output contamination. expert commenter conclud" data-cats="high-gpu quantization">
   <div class="cr-card-header">

--- a/src/gemmaclaw/benchmark/agent-runner.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.ts
@@ -742,7 +742,9 @@ export function resolveAgentPluginAllowIds(backend: AgentBackendType): string[] 
     return ["google"];
   }
   if (backend === "openai-codex") {
-    return ["codex"];
+    // The "openai" plugin (not "codex") registers the "openai-codex" provider.
+    // The "codex" plugin registers under provider id "codex" only.
+    return ["openai"];
   }
   if (backend === "llama-cpp") {
     return ["openai"];
@@ -834,6 +836,25 @@ export function readOpenAICodexAuthProfilesFromStore(storePath: string): AuthPro
   return profiles;
 }
 
+function decodeJwtExpiresMs(token: string): number | undefined {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) {
+      return undefined;
+    }
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as {
+      exp?: unknown;
+    };
+    const exp = payload.exp;
+    if (typeof exp === "number" && Number.isFinite(exp) && exp > 0) {
+      return Math.trunc(exp) * 1000;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function readOpenAICodexProfilesFromCodexHome(codexHome: string): AuthProfiles {
   const authPath = path.join(codexHome, "auth.json");
   if (!fs.existsSync(authPath)) {
@@ -856,12 +877,21 @@ function readOpenAICodexProfilesFromCodexHome(codexHome: string): AuthProfiles {
   ) {
     return {};
   }
+  // OAuthCredential requires `expires` (ms since epoch). Without it,
+  // hasUsableOAuthCredential returns false → triggers a proactive token
+  // refresh that fails if the refresh_token was already rotated by a
+  // prior container run. Decode the JWT exp from the access_token so
+  // OpenClaw can use it directly when it is still valid.
+  const expiresMs = decodeJwtExpiresMs(tokens.access_token);
   return {
     "openai-codex:default": {
       type: "oauth",
       provider: "openai-codex",
       access: tokens.access_token,
       refresh: tokens.refresh_token,
+      // Fall back to 1 hour from now if JWT decode fails so the caller
+      // can still attempt the access token rather than forcing a refresh.
+      expires: expiresMs ?? Date.now() + 60 * 60 * 1000,
       ...(typeof tokens.id_token === "string" ? { idToken: tokens.id_token } : {}),
       ...(typeof tokens.account_id === "string" ? { accountId: tokens.account_id } : {}),
     },
@@ -1901,7 +1931,11 @@ export async function dispatchTask(
           },
         },
       };
-    } else if (!isOpenAICodex) {
+    } else if (isOpenAICodex) {
+      // Empty providers so the config loader doesn't fall back to a default
+      // that lacks the openai-codex provider; the plugin handles model resolution.
+      benchConfigData.models = { providers: {} };
+    } else {
       benchConfigData.models = {
         providers: {
           ollama: {


### PR DESCRIPTION
## Summary

- Fix four bugs in the benchmark harness that prevented GPT-5.5 / openai-codex runs inside the Docker container
- Run GPT-5.5 end-to-end reference pass on the expanded suite (12/12 tasks passed with fake-gog isolation)
- Update site to reflect expanded suite reference validation status

## Harness fixes

**Plugin routing** — `resolveAgentPluginAllowIds` was returning `["codex"]` for the `openai-codex` backend. The `"codex"` plugin only registers `provider id = "codex"`; the `"openai"` plugin registers `"openai-codex"`. Changed to return `["openai"]`.

**Per-task model config** — `dispatchTask()` had no branch for `isOpenAICodex`, so the generated per-task `openclaw.json` had no `models.providers` key. The config loader fell through to an Ollama default. Added `benchConfigData.models = { providers: {} }` for the openai-codex case.

**OAuth token expiry** — `readOpenAICodexProfilesFromCodexHome()` was creating an `OAuthCredential` without an `expires` field. `hasUsableOAuthCredential()` returns false when `expires` is undefined, triggering a proactive refresh that fails on rotated refresh tokens. Now decodes `exp` from the JWT access_token and sets `expires = exp * 1000`.

**Entrypoint auth profile** — `benchmark-docker-entrypoint.sh` was writing an Ollama dummy auth profile and generic `openclaw.json` when `BENCHMARK_BACKEND=openai-codex`. Added an openai-codex branch that writes the correct OAuth profile and `models.providers: {}` config.

## Reference pass results

12/12 representative expanded suite tasks: all `completionStatus: completed`, 0 real-account markers, 0 credential leakage, fake-gog isolated.

| Task | Category | Turns | Tools | Time |
|------|----------|-------|-------|------|
| expanded_sanity | productivity | 2 | 0 | 22.6s |
| expanded_calendar | productivity | 4 | 1 | 38.6s |
| expanded_email | writing | 4 | 1 | 24.6s |
| expanded_email_reply_drafting | writing | 8 | 3 | 50.6s |
| expanded_email_search | analysis | 10 | 4 | 106.7s |
| expanded_email_triage | productivity | 10 | 4 | 90.7s |
| expanded_csv_stock_trend | csv_analysis | 23 | 11 | 212.8s |
| expanded_log_apache_client_issues | log_analysis | 26 | 12 | 188.9s |
| expanded_log_nginx_errors | log_analysis | 83 | 32 | 542.0s |
| expanded_memory | memory | 8 | 3 | 32.6s |
| expanded_second_brain | memory | 6 | 2 | 30.6s |
| expanded_weather | coding | 14 | 6 | 100.7s |

## Site change

`generate-site.py` — Expanded Agent Coverage Suite status updated from "Imported internally, reference validation pending" to "Reference validated — 12/12 tasks passed (e2e, 2026-05-14)" with updated description.