### PR TITLE
fix(site): correct benchmark pass counts and 26B class

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -203,11 +203,23 @@ def normalize_agentic_benchmark_result(data, run_id):
         ordered = sorted(speed_values)
         median_speed = ordered[len(ordered) // 2]
 
+    passed_count = sum(1 for task in normalized_tasks if task.get("passed"))
+    quant = (
+        metadata.get("quant")
+        or config.get("quant")
+        or infer_quant_label(" ".join([
+            str(metadata.get("model") or ""),
+            str(config.get("model") or ""),
+            run_id,
+        ]))
+        or ""
+    )
+
     return {
         "model": metadata.get("model") or config.get("model") or "unknown",
         "backend": config.get("backend", "ollama"),
         "timestamp": metadata.get("startedAt", ""),
-        "quant": metadata.get("quant") or config.get("quant") or "",
+        "quant": quant,
         "thinkingLevel": metadata.get("thinkingLevel") or config.get("thinkingLevel") or "",
         "runId": run_id,
         "hardware": {
@@ -217,8 +229,9 @@ def normalize_agentic_benchmark_result(data, run_id):
         },
         "summary": {
             "percentage": round((total_score / total_max) * 100) if total_max else 0,
-            "passedCount": completed,
-            "failedCount": max(0, len(normalized_tasks) - completed),
+            "passedCount": passed_count,
+            "failedCount": max(0, len(normalized_tasks) - passed_count),
+            "completedCount": completed,
             "medianTokensPerSecond": median_speed,
             "medianTokensPerSecondSource": summarize_speed_source(normalized_tasks),
             "totalTimeMs": total_time,
@@ -400,14 +413,27 @@ def format_time(ms):
     return f"{m:.1f}m"
 
 
+def infer_quant_label(text):
+    text = text.lower().replace("-", "_")
+    if re.search(r"q6_?k", text):
+        return "Q6_K"
+    if re.search(r"q5_?k_?m|q5km", text):
+        return "Q5_K_M"
+    if re.search(r"q4_?k_?m|q4km", text):
+        return "Q4_K_M"
+    if re.search(r"(?:^|_)q4(?:_|$)", text):
+        return "Q4_K_M"
+    return ""
+
+
 SIZE_CLASSES = {
     "Small (4B)": {
         "models": ["gemma3:4b", "gemma4-e4b", "gemma4:e4b"],
         "hw_rec": "Runs on 8GB RAM laptops or any machine with 4GB+ VRAM. Fast inference, good for quick tasks.",
         "icon": "&#128187;",
     },
-    "Medium (27B MoE)": {
-        "models": ["gemma4-26b-moe", "gemma4:26b-moe", "gemma4-27b"],
+    "Medium (26B MoE)": {
+        "models": ["gemma-4-26b", "gemma4-26b", "gemma4:26b", "gemma4-26b-moe", "gemma4:26b-moe", "gemma4-27b"],
         "hw_rec": "Needs 16GB+ RAM or a GPU with 12GB+ VRAM. MoE architecture activates only part of the model per token, so it runs faster than its size suggests.",
         "icon": "&#9889;",
     },
@@ -421,16 +447,16 @@ SIZE_CLASSES = {
 
 def classify_model_size(model_name):
     name_lower = model_name.lower().replace(":", "-").replace("__", "-")
+    if "26b" in name_lower or "27b" in name_lower or "moe" in name_lower:
+        return "Medium (26B MoE)"
+    if "31b" in name_lower or "dense" in name_lower:
+        return "Large (31B Dense)"
     for cls_name, cls_info in SIZE_CLASSES.items():
         for pattern in cls_info["models"]:
             if pattern.lower().replace(":", "-") in name_lower:
                 return cls_name
-    if "4b" in name_lower or "e4b" in name_lower:
+    if re.search(r"(^|[-_:])e?4b($|[-_:])", name_lower):
         return "Small (4B)"
-    if "26b" in name_lower or "27b" in name_lower or "moe" in name_lower:
-        return "Medium (27B MoE)"
-    if "31b" in name_lower or "dense" in name_lower:
-        return "Large (31B Dense)"
     return "Other"
 
 

--- a/site/benchmark-results/functiongemma-270m-high.html
+++ b/site/benchmark-results/functiongemma-270m-high.html
@@ -1213,7 +1213,7 @@
   <div class="detail-tags"><span class="tag tag-accent">Other</span><span class="tag">Unknown</span><span class="tag">Thinking: high</span><span class="tag">2026-05-13</span></div>
   <div class="score-hero">
     <span class="score-big bad">0%</span>
-    <span class="score-label">2/2 tasks passed</span>
+    <span class="score-label">0/2 tasks passed</span>
   </div>
   <div class="meta-grid">
     <span><strong>Model class:</strong> Other</span>

--- a/site/benchmark-results/gemma4-26b-q4-high.html
+++ b/site/benchmark-results/gemma4-26b-q4-high.html
@@ -1210,15 +1210,15 @@
   <div class="wrap">
     <section class="detail-hero">
   <h1>gemma-4-26B-A4B-it-Q4_K_M <small style="font-weight:400;font-size:1rem;color:var(--muted)">(llama-cpp)</small></h1>
-  <div class="detail-tags"><span class="tag tag-accent">Small (4B)</span><span class="tag">MoE</span><span class="tag">Thinking: high</span><span class="tag">2026-05-15</span></div>
+  <div class="detail-tags"><span class="tag tag-accent">Medium (26B MoE)</span><span class="tag">MoE</span><span class="tag">Q4_K_M</span><span class="tag">Thinking: high</span><span class="tag">2026-05-15</span></div>
   <div class="score-hero">
     <span class="score-big bad">73%</span>
-    <span class="score-label">43/47 tasks passed</span>
+    <span class="score-label">40/47 tasks passed</span>
   </div>
   <div class="meta-grid">
-    <span><strong>Model class:</strong> Small (4B)</span>
+    <span><strong>Model class:</strong> Medium (26B MoE)</span>
     <span><strong>Architecture:</strong> MoE</span>
-    <span><strong>Quantization:</strong> unquantized / not reported</span>
+    <span><strong>Quantization:</strong> Q4_K_M</span>
     <span><strong>Thinking:</strong> high</span>
     <span><strong>Backend:</strong> llama-cpp</span>
     <span><strong>GPU:</strong> CPU only</span>

--- a/site/benchmark-results/gemma4-31b-q4-high.html
+++ b/site/benchmark-results/gemma4-31b-q4-high.html
@@ -1213,7 +1213,7 @@
   <div class="detail-tags"><span class="tag tag-accent">Large (31B Dense)</span><span class="tag">Dense</span><span class="tag">Q4_K_M</span><span class="tag">Thinking: high</span><span class="tag">2026-05-12</span></div>
   <div class="score-hero">
     <span class="score-big ">88%</span>
-    <span class="score-label">46/47 tasks passed</span>
+    <span class="score-label">44/47 tasks passed</span>
   </div>
   <div class="meta-grid">
     <span><strong>Model class:</strong> Large (31B Dense)</span>

--- a/site/benchmark-results/gemma4-e4b-q4-high.html
+++ b/site/benchmark-results/gemma4-e4b-q4-high.html
@@ -1210,15 +1210,15 @@
   <div class="wrap">
     <section class="detail-hero">
   <h1>gemma4:e4b <small style="font-weight:400;font-size:1rem;color:var(--muted)">(ollama)</small></h1>
-  <div class="detail-tags"><span class="tag tag-accent">Small (4B)</span><span class="tag">Dense</span><span class="tag">Thinking: high</span><span class="tag">2026-05-15</span></div>
+  <div class="detail-tags"><span class="tag tag-accent">Small (4B)</span><span class="tag">Dense</span><span class="tag">Q4_K_M</span><span class="tag">Thinking: high</span><span class="tag">2026-05-15</span></div>
   <div class="score-hero">
     <span class="score-big bad">5%</span>
-    <span class="score-label">47/47 tasks passed</span>
+    <span class="score-label">11/47 tasks passed</span>
   </div>
   <div class="meta-grid">
     <span><strong>Model class:</strong> Small (4B)</span>
     <span><strong>Architecture:</strong> Dense</span>
-    <span><strong>Quantization:</strong> unquantized / not reported</span>
+    <span><strong>Quantization:</strong> Q4_K_M</span>
     <span><strong>Thinking:</strong> high</span>
     <span><strong>Backend:</strong> ollama</span>
     <span><strong>GPU:</strong> NVIDIA GeForce RTX 3090</span>


### PR DESCRIPTION
Fixes two benchmark page display issues:

- Counts tasks passed from judge pass/fail instead of raw task completion, so E4B shows 11/47 rather than 47/47.
- Classifies 26B MoE before any 4B fallback so gemma-4-26B-A4B-it-Q4_K_M appears under Medium (26B MoE), not Small (4B).
- Infers Q4_K_M from model/run ids when result metadata omitted quant.

Validation:
- python3 scripts/site/generate-site.py
- bash scripts/site/check-site-quality.sh
- pnpm check:changed
- Chrome MCP local UI check on /benchmarks.html confirmed E4B 11/47 and 26B Medium 40/47.