### PR TITLE
Fix Telegram MEDIA directive delivery

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2528,6 +2528,46 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers media when a final answer contains both text and media", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "Here is the tiger\n\nMEDIA:tiger.jpg" },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        route: { agentId: "main", accountId: "default" },
+      } as Partial<TelegramMessageContext>),
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true }],
+          defaults: { workspace: "/tmp/jake-main-workspace" },
+        },
+      } as OpenClawConfig,
+      streamMode: "block",
+    });
+
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ mediaUrl: expect.stringMatching(/tiger\.jpg$/) })],
+      }),
+    );
+    const mediaReply = deliverReplies.mock.calls.find((call) => {
+      const replies = call[0]?.replies;
+      return Array.isArray(replies) && String(replies[0]?.mediaUrl ?? "").endsWith("tiger.jpg");
+    })?.[0]?.replies?.[0];
+    expect(mediaReply?.text).toBe("Here is the tiger");
+    expect(mediaReply?.text).not.toContain("MEDIA:");
+    expect(mediaReply?.mediaUrl).toContain("/workspace/tiger.jpg");
+    expect(mediaReply?.mediaUrl).not.toContain("/sandboxes/");
+  });
+
   it("clears stale preview when response is NO_REPLY", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Bot } from "grammy";
 import {
   DEFAULT_TIMING,
@@ -79,9 +80,80 @@ import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
+const MEDIA_DIRECTIVE_RE = /^\s*MEDIA:\s*(.+?)\s*$/i;
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
+
+function isPathInsideRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function stripMediaSourceQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === `"` && last === `"`) || (first === `'` && last === `'`)) {
+      return trimmed.slice(1, -1).trim();
+    }
+  }
+  return trimmed;
+}
+
+function resolveTelegramMediaDirectiveSource(source: string, mediaLocalRoots: readonly string[]) {
+  const trimmed = stripMediaSourceQuotes(source);
+  if (!trimmed || SCHEME_RE.test(trimmed) || path.isAbsolute(trimmed) || trimmed.startsWith("~")) {
+    return trimmed;
+  }
+  const workspaceRoots = mediaLocalRoots.filter((root) => {
+    const normalized = path.resolve(root);
+    return (
+      path.basename(normalized) === "workspace" ||
+      path.basename(path.dirname(normalized)) === "workspaces"
+    );
+  });
+  const preferredRoots =
+    workspaceRoots.length > 0 ? workspaceRoots.toReversed() : mediaLocalRoots.toReversed();
+  for (const root of preferredRoots) {
+    const resolved = path.resolve(root, trimmed);
+    if (isPathInsideRoot(resolved, root)) {
+      return resolved;
+    }
+  }
+  return trimmed;
+}
+
+function normalizeTelegramMediaDirectives(
+  payload: ReplyPayload,
+  mediaLocalRoots: readonly string[],
+): ReplyPayload {
+  if (typeof payload.text !== "string" || !/^\s*MEDIA:/im.test(payload.text)) {
+    return payload;
+  }
+  const mediaUrls = [...(payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []))];
+  const textLines: string[] = [];
+  for (const line of payload.text.split(/\r?\n/)) {
+    const match = MEDIA_DIRECTIVE_RE.exec(line);
+    if (!match) {
+      textLines.push(line);
+      continue;
+    }
+    const resolved = resolveTelegramMediaDirectiveSource(match[1] ?? "", mediaLocalRoots);
+    if (resolved) {
+      mediaUrls.push(resolved);
+    }
+  }
+  const text = textLines.join("\n").trim() || undefined;
+  return {
+    ...payload,
+    text,
+    mediaUrl: mediaUrls[0],
+    mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+  };
+}
 
 async function resolveStickerVisionSupport(cfg: OpenClawConfig, agentId: string) {
   try {
@@ -774,12 +846,13 @@ export const dispatchTelegramMessage = async ({
             if (isDispatchSuperseded()) {
               return;
             }
+            const payloadForDelivery = normalizeTelegramMediaDirectives(payload, mediaLocalRoots);
             const clearPendingCompactionReplayBoundaryOnVisibleBoundary = (didDeliver: boolean) => {
               if (didDeliver && info.kind !== "final") {
                 pendingCompactionReplayBoundary = false;
               }
             };
-            if (payload.isError === true) {
+            if (payloadForDelivery.isError === true) {
               hadErrorReplyFailureOrSkip = true;
             }
             if (info.kind === "final") {
@@ -789,18 +862,20 @@ export const dispatchTelegramMessage = async ({
               shouldSuppressLocalTelegramExecApprovalPrompt({
                 cfg,
                 accountId: route.accountId,
-                payload,
+                payload: payloadForDelivery,
               })
             ) {
               queuedFinal = true;
               return;
             }
             const previewButtons = (
-              payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
+              payloadForDelivery.channelData?.telegram as
+                | { buttons?: TelegramInlineButtons }
+                | undefined
             )?.buttons;
-            const split = splitTextIntoLaneSegments(payload.text);
+            const split = splitTextIntoLaneSegments(payloadForDelivery.text);
             const segments = split.segments;
-            const reply = resolveSendableOutboundReplyParts(payload);
+            const reply = resolveSendableOutboundReplyParts(payloadForDelivery);
             const _hasMedia = reply.hasMedia;
 
             const flushBufferedFinalAnswer = async () => {
@@ -830,7 +905,7 @@ export const dispatchTelegramMessage = async ({
                 reasoningStepState.shouldBufferFinalAnswer()
               ) {
                 reasoningStepState.bufferFinalAnswer({
-                  payload,
+                  payload: payloadForDelivery,
                   text: segment.text,
                 });
                 continue;
@@ -841,7 +916,7 @@ export const dispatchTelegramMessage = async ({
               const result = await deliverLaneText({
                 laneName: segment.lane,
                 text: segment.text,
-                payload,
+                payload: payloadForDelivery,
                 infoKind: info.kind,
                 previewButtons,
                 allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
@@ -866,6 +941,7 @@ export const dispatchTelegramMessage = async ({
             }
             if (segments.length > 0) {
               if (info.kind === "final") {
+                await flushBufferedFinalAnswer();
                 pendingCompactionReplayBoundary = false;
               }
               return;
@@ -873,7 +949,9 @@ export const dispatchTelegramMessage = async ({
             if (split.suppressedReasoningOnly) {
               if (reply.hasMedia) {
                 const payloadWithoutSuppressedReasoning =
-                  typeof payload.text === "string" ? { ...payload, text: "" } : payload;
+                  typeof payloadForDelivery.text === "string"
+                    ? { ...payloadForDelivery, text: "" }
+                    : payloadForDelivery;
                 clearPendingCompactionReplayBoundaryOnVisibleBoundary(
                   await sendPayload(payloadWithoutSuppressedReasoning),
                 );
@@ -898,7 +976,9 @@ export const dispatchTelegramMessage = async ({
               }
               return;
             }
-            clearPendingCompactionReplayBoundaryOnVisibleBoundary(await sendPayload(payload));
+            clearPendingCompactionReplayBoundaryOnVisibleBoundary(
+              await sendPayload(payloadForDelivery),
+            );
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
               pendingCompactionReplayBoundary = false;


### PR DESCRIPTION
## Summary
- Parse inline MEDIA: directives in Telegram dispatch before lane delivery.
- Resolve relative media against the agent workspace instead of the sandbox root.
- Add regression coverage for Jake-style final replies like `Here is the tiger\n\nMEDIA:tiger.jpg`.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`
- Pi: focused Telegram dispatch regression passed.
- Pi: rebuilt and restarted `openclaw-gateway.service`.
- Pi: controlled synthetic Telegram dispatch with `MEDIA:tiger.jpg` completed without LocalMediaAccessError after deploy.