### PR TITLE
Fix Telegram media final preview flush

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -768,6 +768,13 @@ export const dispatchTelegramMessage = async ({
       stopDraftLane: async (lane) => {
         await lane.stream?.stop();
       },
+      discardDraftLane: async (lane) => {
+        if (typeof lane.stream?.discard === "function") {
+          await lane.stream.discard();
+          return;
+        }
+        await lane.stream?.stop();
+      },
       editPreview: async ({ messageId, text, previewButtons }) => {
         if (isDispatchSuperseded()) {
           return;

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -76,6 +76,7 @@ type CreateLaneTextDelivererParams = {
   sendPayload: (payload: ReplyPayload) => Promise<boolean>;
   flushDraftLane: (lane: DraftLaneState) => Promise<void>;
   stopDraftLane: (lane: DraftLaneState) => Promise<void>;
+  discardDraftLane: (lane: DraftLaneState) => Promise<void>;
   editPreview: (params: {
     laneName: LaneName;
     messageId: number;
@@ -567,7 +568,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: preview final too long for edit (${text.length} > ${params.draftMaxChars}); falling back to standard send`,
         );
       }
-      await params.stopDraftLane(lane);
+      if (hasMedia) {
+        await params.discardDraftLane(lane);
+      } else {
+        await params.stopDraftLane(lane);
+      }
       const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
       return delivered ? result("sent") : result("skipped");
     }

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -45,6 +45,9 @@ function createHarness(params?: {
     }
     await lane.stream?.stop();
   });
+  const discardDraftLane = vi.fn().mockImplementation(async (lane: DraftLaneState) => {
+    await lane.stream?.discard?.();
+  });
   const editPreview = vi.fn().mockResolvedValue(undefined);
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
@@ -67,6 +70,7 @@ function createHarness(params?: {
     sendPayload,
     flushDraftLane,
     stopDraftLane,
+    discardDraftLane,
     editPreview,
     deletePreviewMessage,
     log,
@@ -83,6 +87,7 @@ function createHarness(params?: {
     sendPayload,
     flushDraftLane,
     stopDraftLane,
+    discardDraftLane,
     editPreview,
     deletePreviewMessage,
     log,
@@ -189,6 +194,30 @@ describe("createLaneTextDeliverer", () => {
       }),
     );
     expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
+  it("does not flush text previews before final media delivery", async () => {
+    const harness = createHarness({ answerHasStreamedMessage: true });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Here is the cougar",
+      payload: {
+        text: "Here is the cougar",
+        mediaUrl: "/home/frank/.gemmaclaw/workspace/cougar.jpg",
+      },
+      infoKind: "final",
+    });
+
+    expect(result.kind).toBe("sent");
+    expect(harness.discardDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.stopDraftLane).not.toHaveBeenCalled();
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Here is the cougar",
+        mediaUrl: "/home/frank/.gemmaclaw/workspace/cougar.jpg",
+      }),
+    );
   });
 
   it("keeps stop-created preview when follow-up final edit fails", async () => {


### PR DESCRIPTION
## Summary
- discard stale Telegram draft previews before final replies with media
- keep MEDIA directive final replies on the sendPhoto path instead of flushing raw MEDIA text as a draft/text message
- add regression coverage for media finals with existing draft previews

## Verification
- OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/lane-delivery.test.ts -t 'does not flush text previews before final media delivery'
- OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts -t 'delivers media when a final answer contains both text and media'
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
- Jake live Pi build/restart and controlled dispatcher smoke: MEDIA final discarded draft preview and called sendPhoto with cougar.jpg