### PR TITLE
site: stack mobile community toc pills

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -4772,15 +4772,21 @@ CSS = """
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/benchmark-results/functiongemma-270m-high.html
+++ b/site/benchmark-results/functiongemma-270m-high.html
@@ -1090,15 +1090,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/benchmark-results/gemma4-26b-q4-high.html
+++ b/site/benchmark-results/gemma4-26b-q4-high.html
@@ -1090,15 +1090,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/benchmark-results/gemma4-31b-q4-high.html
+++ b/site/benchmark-results/gemma4-31b-q4-high.html
@@ -1090,15 +1090,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/benchmark-results/gemma4-e4b-q4-high.html
+++ b/site/benchmark-results/gemma4-e4b-q4-high.html
@@ -1090,15 +1090,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/benchmarking.html
+++ b/site/benchmarking.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/community.html
+++ b/site/community.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/enhancements.html
+++ b/site/enhancements.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/goals.html
+++ b/site/goals.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/index.html
+++ b/site/index.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/self-hosting.html
+++ b/site/self-hosting.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;

--- a/site/setup.html
+++ b/site/setup.html
@@ -1099,15 +1099,21 @@
         padding: 0.55rem;
         border-radius: 10px;
       }
+      .page-toc > span {
+        white-space: normal;
+      }
       .page-toc div {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr);
         gap: 0.35rem;
+        min-width: 0;
       }
       .page-toc a {
         min-height: 2rem;
         padding: 0.35rem 0.5rem;
         font-size: 0.76rem;
+        white-space: normal;
+        word-break: break-word;
       }
       .benchmark-jump-nav {
         top: 54px;


### PR DESCRIPTION
## Summary
- stack the mobile page TOC pills into a single column instead of forcing two equal-width columns
- allow the TOC label and pills to wrap on narrow viewports
- regenerate the static site pages so the emitted HTML stays in sync

## Verification
- pnpm check:changed
- pnpm test:changed
- mobile DOM width probe on community.html reports scrollWidth == viewport width after regeneration
