### PR TITLE
Limit pre-compaction memory flush duration

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -149,10 +149,12 @@ describe("runMemoryFlushIfNeeded", () => {
       prompt?: string;
       memoryFlushWritePath?: string;
       silentExpected?: boolean;
+      timeoutMs?: number;
     };
     expect(flushCall.prompt).toContain("Pre-compaction memory flush.");
     expect(flushCall.memoryFlushWritePath).toMatch(/^memory\/\d{4}-\d{2}-\d{2}\.md$/);
     expect(flushCall.silentExpected).toBe(true);
+    expect(flushCall.timeoutMs).toBe(1_000);
     expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
       key: sessionKey,
       previousSessionId: "session",
@@ -167,6 +169,42 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(persisted.main.compactionCount).toBe(2);
     expect(persisted.main.memoryFlushCompactionCount).toBe(2);
     expect(persisted.main.memoryFlushAt).toBe(1_700_000_000_000);
+  });
+
+  it("caps memory flush turns below the normal interactive timeout", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+
+    await runMemoryFlushIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {},
+            },
+          },
+        },
+      },
+      followupRun: createTestFollowupRun({ timeoutMs: 7_200_000 }),
+      sessionCtx: { Provider: "telegram" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    const flushCall = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as {
+      timeoutMs?: number;
+    };
+    expect(flushCall.timeoutMs).toBe(120_000);
   });
 
   it("skips memory flush for CLI providers", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -81,6 +81,8 @@ const memoryDeps = {
   now: () => Date.now(),
 };
 
+const MEMORY_FLUSH_TURN_TIMEOUT_MS = 120_000;
+
 export function setAgentRunnerMemoryTestDeps(overrides?: Partial<typeof memoryDeps>): void {
   Object.assign(memoryDeps, {
     runWithModelFallback,
@@ -765,6 +767,10 @@ export async function runMemoryFlushIfNeeded(params: {
           ...embeddedContext,
           ...senderContext,
           ...runBaseParams,
+          timeoutMs: Math.min(
+            runBaseParams.timeoutMs ?? MEMORY_FLUSH_TURN_TIMEOUT_MS,
+            MEMORY_FLUSH_TURN_TIMEOUT_MS,
+          ),
           sandboxSessionKey: params.runtimePolicySessionKey,
           allowGatewaySubagentBinding: true,
           silentExpected: true,


### PR DESCRIPTION
## Summary
- cap pre-compaction memory flush embedded turns at 120 seconds while preserving shorter caller timeouts
- add regression coverage for the cap so memory flush cannot consume a full interactive turn

## Why
Jake lost Frank's local TTS voice-sample request because a silent memory flush inherited the live task, ran for too long, and ended with `assistantTexts: []`, producing the generic incomplete-response banner.

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/auto-reply/reply/agent-runner-memory.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`

## Scope
Gemmaclaw runtime only. No OpenClaw docs sync or openclaw/docs target.