### PR TITLE
Wait full compaction window before retry fallback

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.compaction-retry-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.compaction-retry-timeout.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  getHoisted,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+
+describe("runEmbeddedAttempt compaction retry timeout", () => {
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+    vi.restoreAllMocks();
+  });
+
+  it("uses the configured compaction safety timeout for compaction retry waits", async () => {
+    const { assemble } = createContextEngineBootstrapAndAssemble();
+
+    await createContextEngineAttemptRunner({
+      contextEngine: { assemble },
+      attemptOverrides: {
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                timeoutSeconds: 123,
+              },
+            },
+          },
+        },
+      },
+      sessionKey: "agent:main:explicit:test-compaction-retry-timeout",
+      tempPaths,
+    });
+
+    expect(hoisted.waitForCompactionRetryWithAggregateTimeoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aggregateTimeoutMs: 123_000,
+      }),
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -25,6 +25,8 @@ type SubscribeEmbeddedPiSessionFn =
   typeof import("../../pi-embedded-subscribe.js").subscribeEmbeddedPiSession;
 type AcquireSessionWriteLockFn =
   typeof import("../../session-write-lock.js").acquireSessionWriteLock;
+type WaitForCompactionRetryWithAggregateTimeoutFn =
+  typeof import("./compaction-retry-aggregate-timeout.js").waitForCompactionRetryWithAggregateTimeout;
 
 type SubscriptionMock = ReturnType<SubscribeEmbeddedPiSessionFn>;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
@@ -61,6 +63,8 @@ type AttemptSpawnWorkspaceHoisted = {
   installToolResultContextGuardMock: UnknownMock;
   flushPendingToolResultsAfterIdleMock: AsyncUnknownMock;
   releaseWsSessionMock: UnknownMock;
+  resolveCompactionTimeoutMsMock: Mock<(config?: unknown) => number>;
+  waitForCompactionRetryWithAggregateTimeoutMock: Mock<WaitForCompactionRetryWithAggregateTimeoutFn>;
   resolveBootstrapContextForRunMock: Mock<() => Promise<BootstrapContext>>;
   isWorkspaceBootstrapPendingMock: Mock<(workspaceDir: string) => Promise<boolean>>;
   resolveContextInjectionModeMock: Mock<() => "always" | "continuation-skip">;
@@ -113,6 +117,19 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const installToolResultContextGuardMock = vi.fn(() => () => {});
   const flushPendingToolResultsAfterIdleMock = vi.fn(async () => {});
   const releaseWsSessionMock = vi.fn(() => {});
+  const resolveCompactionTimeoutMsMock = vi.fn((config?: unknown) => {
+    const raw = (
+      config as { agents?: { defaults?: { compaction?: { timeoutSeconds?: unknown } } } }
+    )?.agents?.defaults?.compaction?.timeoutSeconds;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+      return Math.floor(raw) * 1000;
+    }
+    return 900_000;
+  });
+  const waitForCompactionRetryWithAggregateTimeoutMock =
+    vi.fn<WaitForCompactionRetryWithAggregateTimeoutFn>(async () => ({
+      timedOut: false,
+    }));
   const subscribeEmbeddedPiSessionMock = vi.fn<SubscribeEmbeddedPiSessionFn>(() =>
     createSubscriptionMock(),
   );
@@ -162,6 +179,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     installToolResultContextGuardMock,
     flushPendingToolResultsAfterIdleMock,
     releaseWsSessionMock,
+    resolveCompactionTimeoutMsMock,
+    waitForCompactionRetryWithAggregateTimeoutMock,
     resolveBootstrapContextForRunMock,
     isWorkspaceBootstrapPendingMock,
     resolveContextInjectionModeMock,
@@ -560,7 +579,7 @@ vi.mock("../compaction-runtime-context.js", () => ({
 }));
 
 vi.mock("../compaction-safety-timeout.js", () => ({
-  resolveCompactionTimeoutMs: () => undefined,
+  resolveCompactionTimeoutMs: (config?: unknown) => hoisted.resolveCompactionTimeoutMsMock(config),
 }));
 
 vi.mock("../history.js", () => ({
@@ -617,10 +636,9 @@ vi.mock("../utils.js", () => ({
 }));
 
 vi.mock("./compaction-retry-aggregate-timeout.js", () => ({
-  waitForCompactionRetryWithAggregateTimeout: async () => ({
-    timedOut: false,
-    aborted: false,
-  }),
+  waitForCompactionRetryWithAggregateTimeout: (
+    params: Parameters<WaitForCompactionRetryWithAggregateTimeoutFn>[0],
+  ) => hoisted.waitForCompactionRetryWithAggregateTimeoutMock(params),
 }));
 
 vi.mock("./compaction-timeout.js", () => ({
@@ -721,6 +739,18 @@ export function resetEmbeddedAttemptHarness(
   hoisted.installToolResultContextGuardMock.mockReset().mockReturnValue(() => {});
   hoisted.flushPendingToolResultsAfterIdleMock.mockReset().mockResolvedValue(undefined);
   hoisted.releaseWsSessionMock.mockReset().mockReturnValue(undefined);
+  hoisted.resolveCompactionTimeoutMsMock.mockReset().mockImplementation((config?: unknown) => {
+    const raw = (
+      config as { agents?: { defaults?: { compaction?: { timeoutSeconds?: unknown } } } }
+    )?.agents?.defaults?.compaction?.timeoutSeconds;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+      return Math.floor(raw) * 1000;
+    }
+    return 900_000;
+  });
+  hoisted.waitForCompactionRetryWithAggregateTimeoutMock
+    .mockReset()
+    .mockResolvedValue({ timedOut: false });
   hoisted.resolveBootstrapContextForRunMock.mockReset().mockResolvedValue({
     bootstrapFiles: [],
     contextFiles: [],

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2346,7 +2346,10 @@ export async function runEmbeddedAttempt(
         // Only trust snapshot if compaction wasn't running before or after capture
         const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
         const preCompactionSessionId = activeSession.sessionId;
-        const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000;
+        // Use the same configured safety window as compaction itself. Slow Pi
+        // runs can legitimately need more than one minute after context
+        // overflow, while the abort timer still bounds the total wait.
+        const compactionRetryAggregateTimeoutMs = compactionTimeoutMs;
 
         try {
           // Flush buffered block replies before waiting for compaction so the
@@ -2364,14 +2367,14 @@ export async function runEmbeddedAttempt(
             : await waitForCompactionRetryWithAggregateTimeout({
                 waitForCompactionRetry,
                 abortable,
-                aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
+                aggregateTimeoutMs: compactionRetryAggregateTimeoutMs,
                 isCompactionStillInFlight: isCompactionInFlight,
               });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;
             if (!isProbeSession) {
               log.warn(
-                `compaction retry aggregate timeout (${COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS}ms): ` +
+                `compaction retry aggregate timeout (${compactionRetryAggregateTimeoutMs}ms): ` +
                   `proceeding with pre-compaction state runId=${params.runId} sessionId=${params.sessionId}`,
               );
             }

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
@@ -1,6 +1,7 @@
 /**
- * Wait for compaction retry completion with an aggregate timeout to avoid
- * holding a session lane indefinitely when retry resolution is lost.
+ * Wait for compaction retry completion with the caller's configured safety
+ * timeout to avoid holding a session lane indefinitely when retry resolution
+ * is lost.
  */
 export async function waitForCompactionRetryWithAggregateTimeout(params: {
   waitForCompactionRetry: () => Promise<void>;


### PR DESCRIPTION
## Objective

Fix the Gemmaclaw/Jake compaction retry path that still had a hard 60s aggregate timeout after PR #215. In the live Jake trace, that cap could fire before slow Pi compaction finished, causing the visible user turn to fall back to pre-compaction state and surface the incomplete-turn warning instead of the refreshed answer.

## Change Summary

- Replaced the hardcoded `60_000` compaction retry aggregate timeout in `attempt.ts` with the configured compaction safety timeout.
- Kept the fallback bounded by the existing compaction safety window, defaulting to 900s.
- Updated the compaction retry helper comment so it describes the caller-configured safety timeout.
- Extended the attempt test harness to expose the compaction timeout resolver and retry wait mock.
- Added `attempt.compaction-retry-timeout.test.ts` to assert a configured `timeoutSeconds: 123` becomes a `123_000ms` retry wait.

## Non-Goals

- No changes to compaction execution itself.
- No unbounded waits.
- No model, prompt, benchmark, setup, or site behavior changes.
- No Jake-only config patch.

## Baseline Evidence

The interrupted `/iterate_gemma` investigation reconstructed the current failure from Jake logs and source state:

- Expected behavior: after forced compaction, the visible user turn waits for refreshed post-compaction context and returns a normal answer.
- Observed behavior: PR #215 removed one bad timeout path, but the visible turn could still hit `compaction retry aggregate timeout (60000ms)` and proceed with pre-compaction state.
- Code evidence: `src/agents/pi-embedded-runner/run/attempt.ts` still defined `COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000` and passed it into `waitForCompactionRetryWithAggregateTimeout`.

## Acceptance Criteria

- The compaction retry wait uses the configured compaction safety timeout, not a fixed 60s cap.
- Slow Pi/Jake compaction can continue for the configured window before fallback.
- Lost or stuck compaction retry resolution still falls back after a bounded safety timeout.
- Tests prove the configured timeout is passed to the retry wait path.

## Verification Map

- Requirement: remove premature 60s fallback.
  Code path: `runEmbeddedAttempt` in `attempt.ts`.
  Test: `attempt.compaction-retry-timeout.test.ts` asserts `aggregateTimeoutMs: 123_000`.

- Requirement: preserve bounded failure behavior.
  Code path: `waitForCompactionRetryWithAggregateTimeout` still receives a finite aggregate timeout from `resolveCompactionTimeoutMs`.
  Existing coverage: `compaction-retry-aggregate-timeout.test.ts` covers timeout and abort behavior.

- Requirement: avoid regressions in touched runtime paths.
  Checks run: targeted compaction tests plus `pnpm check:changed`.

## Consequence Check

Does this solve the original failure? Yes. The known premature fallback came from the remaining fixed `60_000ms` retry cap. This change removes that cap and uses the same configured compaction safety window used by the rest of the embedded run timeout handling.

Slow dependency behavior: slow-but-valid Pi compaction now has the configured safety window, default 900s, to complete instead of being cut off after one minute.

Partial or failing dependency behavior: if compaction retry resolution is lost or compaction remains in flight past the safety window, the existing timeout path still logs and falls back. This does not turn the wait into an unbounded hang.

Edge cases introduced: a genuinely stuck compaction can hold the session lane longer than before, up to the configured safety timeout. That is the intended tradeoff because the previous 60s bound dropped valid slow completions and left sessions near the context cliff.

## Diagrams

```mermaid
sequenceDiagram
  participant UserTurn as Visible user turn
  participant Attempt as runEmbeddedAttempt
  participant Compact as Compaction retry
  participant Timeout as Safety timeout

  UserTurn->>Attempt: Needs compaction retry
  Attempt->>Timeout: resolveCompactionTimeoutMs(config)
  Attempt->>Compact: waitForCompactionRetryWithAggregateTimeout(timeout)
  alt retry completes inside configured window
    Compact-->>Attempt: refreshed post-compaction state ready
    Attempt-->>UserTurn: continue visible answer
  else retry exceeds configured window
    Timeout-->>Attempt: bounded timeout
    Attempt-->>UserTurn: fallback with explicit warning path
  end
```

```mermaid
flowchart TD
  A[Compaction retry needed] --> B[Resolve configured compaction safety timeout]
  B --> C[Wait for retry with configured aggregate timeout]
  C -->|Completes| D[Use refreshed post-compaction context]
  C -->|Times out| E[Log bounded timeout and fall back]
  D --> F[Visible reply resumes]
  E --> G[No indefinite lane hold]
```

## Checks Run

```bash
source ~/.nvm/nvm.sh && nvm use 22 && OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/agents/pi-embedded-runner/run/attempt.compaction-retry-timeout.test.ts src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts && OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
```

Results:

- Targeted compaction tests: 2 files passed, 8 tests passed.
- `pnpm check:changed`: passed, 17 test files passed, 237 tests passed.