### PR TITLE
Fix media directive delivery failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -74,7 +74,7 @@ describe("buildReplyPayloads media filter integration", () => {
     });
   });
 
-  it("drops only invalid media when reply media normalization fails", async () => {
+  it("surfaces an error when reply media normalization fails", async () => {
     const normalizeMediaPaths = async (payload: { mediaUrl?: string }) => {
       if (payload.mediaUrl === "./bad.png") {
         throw new Error("Path escapes sandbox root");
@@ -93,10 +93,8 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(2);
     expect(replyPayloads[0]).toMatchObject({
-      text: "keep text",
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-      audioAsVoice: false,
+      text: expect.stringContaining("couldn't prepare the file"),
+      isError: true,
     });
     expect(replyPayloads[1]).toMatchObject({
       text: "keep second",
@@ -233,6 +231,43 @@ describe("buildReplyPayloads media filter integration", () => {
       mediaUrl: "./fox.jpg",
       mediaUrls: ["./fox.jpg"],
       replyToId: "post-123",
+    });
+  });
+
+  it("surfaces final media delivery errors after block pipeline streamed text", async () => {
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => false,
+      hasSentPayload: () => false,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+    };
+    const normalizeMediaPaths = async (payload: { mediaUrls?: string[] }) => ({
+      ...payload,
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      replyToMode: "all",
+      payloads: [
+        {
+          text: "Got 'em.\n\nMEDIA:lessac_sample.wav\nMEDIA:amy_sample.wav\nMEDIA:ryan_sample.wav",
+          replyToId: "post-123",
+        },
+      ],
+      normalizeMediaPaths,
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({
+      isError: true,
+      text: expect.stringContaining("3 media attachments"),
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -29,21 +29,38 @@ async function normalizeReplyPayloadMedia(params: {
   payload: ReplyPayload;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
 }): Promise<ReplyPayload> {
-  if (!params.normalizeMediaPaths || !resolveSendableOutboundReplyParts(params.payload).hasMedia) {
+  const originalParts = resolveSendableOutboundReplyParts(params.payload);
+  if (!params.normalizeMediaPaths || !originalParts.hasMedia) {
     return params.payload;
   }
 
   try {
-    return await params.normalizeMediaPaths(params.payload);
+    const normalized = await params.normalizeMediaPaths(params.payload);
+    if (!resolveSendableOutboundReplyParts(normalized).hasMedia) {
+      return {
+        text: formatMediaDeliveryError(originalParts.mediaCount, "access"),
+        isError: true,
+      };
+    }
+    return normalized;
   } catch (err) {
     logVerbose(`reply payload media normalization failed: ${String(err)}`);
     return {
-      ...params.payload,
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-      audioAsVoice: false,
+      text: `${formatMediaDeliveryError(originalParts.mediaCount, "prepare")}: ${String(err)}`,
+      isError: true,
     };
   }
+}
+
+function formatMediaDeliveryError(mediaCount: number, failure: "access" | "prepare"): string {
+  const attachmentText =
+    mediaCount === 1 ? "a media attachment" : `${mediaCount} media attachments`;
+  const fileText = mediaCount === 1 ? "file" : "files";
+  const actionText = failure === "access" ? "access" : "prepare";
+  return (
+    `⚠️ I generated ${attachmentText}, but I couldn't ${actionText} the ${fileText}` +
+    " for delivery. Please retry and I'll regenerate them."
+  );
 }
 
 async function normalizeSentMediaUrlsForDedupe(params: {

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -103,4 +103,18 @@ describe("splitMediaFromOutput", () => {
       { type: "text", text: "```text\nMEDIA:https://example.com/ignored.png\n```\nAfter" },
     ]);
   });
+
+  it("returns media segments for bare filename directives", () => {
+    const result = splitMediaFromOutput(
+      "Got it.\nMEDIA:lessac_sample.wav\nMEDIA:amy_sample.wav\nMEDIA:ryan_sample.wav",
+    );
+
+    expect(result.mediaUrls).toEqual(["lessac_sample.wav", "amy_sample.wav", "ryan_sample.wav"]);
+    expect(result.segments).toEqual([
+      { type: "text", text: "Got it." },
+      { type: "media", url: "lessac_sample.wav" },
+      { type: "media", url: "amy_sample.wav" },
+      { type: "media", url: "ryan_sample.wav" },
+    ]);
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -264,6 +264,7 @@ export function splitMediaFromOutput(raw: string): {
           media.push(fallback);
           hasValidMedia = true;
           foundMediaToken = true;
+          validCount = 1;
           invalidParts.length = 0;
         }
       }


### PR DESCRIPTION
## Summary
- preserve media segments for bare filename MEDIA directives
- surface a visible error when reply media normalization drops every attachment
- cover post-stream media normalization failure so text-only success cannot mask missing files

## Tests
- OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/test-projects.mjs src/media/parse.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-media-paths.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
- pnpm build
- GEMMACLAW_LOCAL_AGENT_SMOKE_REQUIRED=1 pnpm test:docker:gemmaclaw-setup-live-smoke