### PR TITLE
feat(benchmark): port QwenClaw 3.6 benchmark workflow into Gemmaclaw

### DIFF
--- a/docs/cli/benchmark.md
+++ b/docs/cli/benchmark.md
@@ -214,3 +214,95 @@ Results are written to the output directory in three formats:
 
 The summary printed to the terminal includes total score, pass rate, average
 tokens per second, and file paths for each output format.
+
+## QwenClaw 3.6 benchmark port
+
+The QwenClaw 3.6 benchmark port brings the original Jake / Pi benchmark
+workflow for Qwen 3.6 into the Gemmaclaw benchmark system. The port is
+defined in `src/gemmaclaw/benchmark/qwenclaw-models.ts` and
+`src/gemmaclaw/benchmark/jake-manifest-validator.ts`.
+
+### Provenance
+
+The original workflow ran on the Raspberry Pi 5 (frankpi) via the Jake
+OpenClaw gateway, with Ollama serving models on the Desktop PC RTX 3090. The
+two canonical model targets were:
+
+| Jake / Ollama model ID   | Role  | Status  |
+| ------------------------ | ----- | ------- |
+| `qwen3.6:35b`            | Dense | Blocked |
+| `qwen3.6:35b-a3b-q4_K_M` | MoE   | Ready   |
+
+**Dense blocker:** The unsloth GGUF for the dense model has empty tensor names
+and crashes on llama.cpp b9190. The froggeric GGUF resolves this, but its
+throughput (63-65 tok/s) is not competitive with the MoE (133-135 tok/s) at
+comparable VRAM. Use the froggeric GGUF only as a smoke target. See
+`knowledge/infra/gemmaclaw-benchmark-backends.md` for details.
+
+### Running the MoE target
+
+The Qwen 3.6 MoE model (`Qwen3.6-35B-A3B-UD-IQ4_XS.gguf`) is the primary
+benchmark target. Serve it with the Desktop llama.cpp instance and run via
+the Gemmaclaw benchmark CLI:
+
+```bash
+# Serve the model (llama.cpp on Desktop RTX 3090)
+llama-server \
+  -m /home/frank/models/gguf/qwen3.6-hf/Qwen3.6-35B-A3B-UD-IQ4_XS.gguf \
+  --alias qwen3.6-35b-a3b \
+  --host 0.0.0.0 --port 8080 \
+  --n-gpu-layers 99 --ctx-size 65536 --parallel 1 \
+  --cache-type-k q8_0 --cache-type-v q8_0 \
+  --flash-attn on --threads 8 --jinja --no-webui
+
+# Run the benchmark (from gemmaclaw repo)
+pnpm benchmark agent \
+  --backend llama-cpp \
+  --llama-cpp-url http://100.69.102.71:8080 \
+  --model qwen3.6-35b-a3b \
+  --quant IQ4_XS \
+  --thinking high \
+  --run-id qwenclaw-36-moe-high
+```
+
+### Running the dense target (smoke only)
+
+Use the froggeric GGUF as a smaller smoke target:
+
+```bash
+pnpm benchmark agent \
+  --backend llama-cpp \
+  --llama-cpp-url http://100.69.102.71:8080 \
+  --model qwen3.6-27b-dense \
+  --quant Q4_K_M \
+  --thinking high \
+  --run-id qwenclaw-36-dense-smoke
+```
+
+### Container isolation and credentials
+
+All real benchmark agent runs must execute inside the Gemmaclaw Docker
+container (`Dockerfile.benchmark`) with `GEMMACLAW_BENCHMARK_CONTAINER=1`
+and the fake-gog shim active. Do not run publishable benchmarks in host mode.
+
+This benchmark does not use `OPENAI_API_KEY`. The llama.cpp backend uses a
+dummy auth token. Any semantic judging must go through an OAuth-backed
+path (CC ACP or Claude Code), not a raw API key.
+
+### Validating historical Jake run manifests
+
+Use `validateJakeManifest` from `jake-manifest-validator.ts` to check
+whether a historical Pi run meets the original completion criteria:
+
+```typescript
+import { validateJakeManifest } from "./src/gemmaclaw/benchmark/jake-manifest-validator.js";
+
+const result = validateJakeManifest(manifest);
+if (result.valid) {
+  // manifest.finished is non-empty and tasks_run >= 22
+} else {
+  console.error(result.reason);
+}
+```
+
+A run is complete when `manifest.finished` is non-empty and `manifest.tasks_run >= 22`.

--- a/src/gemmaclaw/benchmark/jake-manifest-validator.test.ts
+++ b/src/gemmaclaw/benchmark/jake-manifest-validator.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for jake-manifest-validator.ts — QwenClaw 3.6 port.
+ *
+ * These are pure-unit / fixture-backed tests. No model inference, no Docker,
+ * no network. They verify that the manifest validator correctly applies the
+ * historical Jake completion criteria (finished non-empty, tasks_run >= 22)
+ * and that model preset metadata is accurate.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  JAKE_MANIFEST_MIN_TASKS,
+  describeManifestValidation,
+  validateJakeManifest,
+  validateQwenClawJakeRuns,
+} from "./jake-manifest-validator.js";
+import {
+  QWEN36_DENSE_BLOCKED,
+  QWEN36_JAKE_MODEL_IDS,
+  QWEN36_LLAMACPP_MAPPING,
+  QWEN36_MOE_PRESET,
+  QWENCLAW_PORT_DESCRIPTION,
+  isJakeManifestComplete,
+} from "./qwenclaw-models.js";
+
+// ── Fixture manifests ───────────────────────────────────────────────────────
+
+const COMPLETE_MANIFEST = {
+  finished: "2026-04-10T14:23:00Z",
+  tasks_run: 22,
+  model: "qwen3.6:35b-a3b-q4_K_M",
+  thinking: "high",
+};
+
+const COMPLETE_MANIFEST_LARGE = {
+  finished: "2026-04-11T08:00:00Z",
+  tasks_run: 24,
+  model: "qwen3.6:35b",
+  thinking: "high",
+};
+
+const PARTIAL_MANIFEST_LOW_TASKS = {
+  finished: "2026-04-10T09:00:00Z",
+  tasks_run: 10,
+  model: "qwen3.6:35b",
+  thinking: "high",
+};
+
+const INCOMPLETE_MANIFEST_NO_FINISHED = {
+  finished: "",
+  tasks_run: 22,
+  model: "qwen3.6:35b",
+};
+
+const INCOMPLETE_MANIFEST_MISSING_FINISHED = {
+  tasks_run: 22,
+  model: "qwen3.6:35b",
+};
+
+const MALFORMED_MANIFEST = "not an object";
+const NULL_MANIFEST = null;
+
+// ── isJakeManifestComplete (qwenclaw-models.ts) ─────────────────────────────
+
+describe("isJakeManifestComplete", () => {
+  it("returns true for a complete manifest with exactly 22 tasks", () => {
+    expect(isJakeManifestComplete(COMPLETE_MANIFEST)).toBe(true);
+  });
+
+  it("returns true for a complete manifest with more than 22 tasks", () => {
+    expect(isJakeManifestComplete(COMPLETE_MANIFEST_LARGE)).toBe(true);
+  });
+
+  it("returns false when tasks_run is below 22", () => {
+    expect(isJakeManifestComplete(PARTIAL_MANIFEST_LOW_TASKS)).toBe(false);
+  });
+
+  it("returns false when finished is an empty string", () => {
+    expect(isJakeManifestComplete(INCOMPLETE_MANIFEST_NO_FINISHED)).toBe(false);
+  });
+
+  it("returns false when finished is missing", () => {
+    expect(isJakeManifestComplete(INCOMPLETE_MANIFEST_MISSING_FINISHED)).toBe(false);
+  });
+
+  it("returns false for null input", () => {
+    expect(isJakeManifestComplete(null)).toBe(false);
+  });
+
+  it("returns false for non-object input", () => {
+    expect(isJakeManifestComplete("not an object")).toBe(false);
+  });
+});
+
+// ── validateJakeManifest ────────────────────────────────────────────────────
+
+describe("validateJakeManifest", () => {
+  it("validates a complete manifest", () => {
+    const result = validateJakeManifest(COMPLETE_MANIFEST);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.manifest.tasks_run).toBe(22);
+    }
+  });
+
+  it("returns invalid for missing finished", () => {
+    const result = validateJakeManifest(INCOMPLETE_MANIFEST_MISSING_FINISHED);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("finished");
+    }
+  });
+
+  it("returns invalid for empty finished", () => {
+    const result = validateJakeManifest(INCOMPLETE_MANIFEST_NO_FINISHED);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("finished");
+    }
+  });
+
+  it("returns invalid for low task count", () => {
+    const result = validateJakeManifest(PARTIAL_MANIFEST_LOW_TASKS);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("tasks_run");
+      expect(result.reason).toContain(String(JAKE_MANIFEST_MIN_TASKS));
+    }
+  });
+
+  it("returns invalid for null manifest", () => {
+    const result = validateJakeManifest(NULL_MANIFEST);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for malformed manifest", () => {
+    const result = validateJakeManifest(MALFORMED_MANIFEST);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ── describeManifestValidation ──────────────────────────────────────────────
+
+describe("describeManifestValidation", () => {
+  it("returns COMPLETE string for valid manifest", () => {
+    const desc = describeManifestValidation(COMPLETE_MANIFEST);
+    expect(desc).toMatch(/^COMPLETE:/);
+    expect(desc).toContain("tasks_run=22");
+  });
+
+  it("returns INCOMPLETE string for invalid manifest", () => {
+    const desc = describeManifestValidation(PARTIAL_MANIFEST_LOW_TASKS);
+    expect(desc).toMatch(/^INCOMPLETE:/);
+  });
+});
+
+// ── validateQwenClawJakeRuns ────────────────────────────────────────────────
+
+describe("validateQwenClawJakeRuns", () => {
+  it("reports bothComplete=true when both manifests are complete", () => {
+    const result = validateQwenClawJakeRuns({
+      dense: COMPLETE_MANIFEST_LARGE,
+      moe: COMPLETE_MANIFEST,
+    });
+    expect(result.bothComplete).toBe(true);
+    expect(result.dense.valid).toBe(true);
+    expect(result.moe.valid).toBe(true);
+  });
+
+  it("reports bothComplete=false when dense is missing", () => {
+    const result = validateQwenClawJakeRuns({ moe: COMPLETE_MANIFEST });
+    expect(result.bothComplete).toBe(false);
+    expect(result.dense.valid).toBe(false);
+  });
+
+  it("reports bothComplete=false when moe is incomplete", () => {
+    const result = validateQwenClawJakeRuns({
+      dense: COMPLETE_MANIFEST_LARGE,
+      moe: PARTIAL_MANIFEST_LOW_TASKS,
+    });
+    expect(result.bothComplete).toBe(false);
+    expect(result.moe.valid).toBe(false);
+  });
+
+  it("reports bothComplete=false when both are undefined", () => {
+    const result = validateQwenClawJakeRuns({});
+    expect(result.bothComplete).toBe(false);
+  });
+});
+
+// ── Model preset metadata (provenance checks) ───────────────────────────────
+
+describe("QWEN36 model preset metadata", () => {
+  it("has both Jake model IDs defined", () => {
+    expect(QWEN36_JAKE_MODEL_IDS.DENSE).toBe("qwen3.6:35b");
+    expect(QWEN36_JAKE_MODEL_IDS.MOE).toBe("qwen3.6:35b-a3b-q4_K_M");
+  });
+
+  it("marks dense model as blocked", () => {
+    expect(QWEN36_DENSE_BLOCKED).toBe(true);
+    expect(QWEN36_LLAMACPP_MAPPING["qwen3.6:35b"].status).toBe("blocked");
+  });
+
+  it("marks MoE model as ready", () => {
+    expect(QWEN36_LLAMACPP_MAPPING["qwen3.6:35b-a3b-q4_K_M"].status).toBe("ready");
+  });
+
+  it("MoE preset uses llama-cpp backend", () => {
+    expect(QWEN36_MOE_PRESET.backend).toBe("llama-cpp");
+    expect(QWEN36_MOE_PRESET.thinkingLevel).toBe("high");
+    expect(QWEN36_MOE_PRESET.quant).toBe("IQ4_XS");
+  });
+
+  it("JAKE_MANIFEST_MIN_TASKS is 22 (historical QwenClaw criterion)", () => {
+    expect(JAKE_MANIFEST_MIN_TASKS).toBe(22);
+  });
+
+  it("port description includes both model entries", () => {
+    expect(QWENCLAW_PORT_DESCRIPTION.models).toHaveLength(2);
+    const jakeIds = QWENCLAW_PORT_DESCRIPTION.models.map((m) => m.jakeId);
+    expect(jakeIds).toContain("qwen3.6:35b");
+    expect(jakeIds).toContain("qwen3.6:35b-a3b-q4_K_M");
+  });
+
+  it("port description has benchmark commands for both models", () => {
+    for (const m of QWENCLAW_PORT_DESCRIPTION.models) {
+      expect(m.benchmarkCommand).toContain("pnpm benchmark agent");
+      expect(m.benchmarkCommand).toContain("--backend llama-cpp");
+    }
+  });
+});

--- a/src/gemmaclaw/benchmark/jake-manifest-validator.ts
+++ b/src/gemmaclaw/benchmark/jake-manifest-validator.ts
@@ -1,0 +1,107 @@
+/**
+ * Jake run manifest validator.
+ *
+ * Validates historical Jake benchmark run manifests using the original
+ * QwenClaw completion criteria. Used by the Gemmaclaw benchmark port to
+ * verify that a Jake run is complete before consuming its artifacts.
+ *
+ * PROVENANCE: Historical Jake runs live at:
+ *   ~/.openclaw/workspace/skills/jake-benchmark/runs/<model>__<ts>/manifest.json
+ *   on the Pi (100.108.252.124).
+ *
+ * Historical completion rule (from cron/jake-benchmark-qwen36-run-until-done.md):
+ *   manifest.finished is non-empty AND manifest.tasks_run >= 22
+ */
+
+import { isJakeManifestComplete, JAKE_MANIFEST_MIN_TASKS } from "./qwenclaw-models.js";
+
+export type JakeManifest = {
+  /** ISO timestamp when the run finished. Non-empty = complete. */
+  finished?: string;
+  /** Number of tasks executed in this run. */
+  tasks_run?: number;
+  /** Model that was benchmarked. */
+  model?: string;
+  /** Thinking level used (e.g. "high"). */
+  thinking?: string;
+  /** Run directory name. */
+  run_dir?: string;
+  /** Any additional fields from the manifest. */
+  [key: string]: unknown;
+};
+
+export type ManifestValidationResult =
+  | { valid: true; manifest: JakeManifest; reason?: never }
+  | { valid: false; manifest?: JakeManifest; reason: string };
+
+/**
+ * Validate a Jake run manifest object against the historical QwenClaw
+ * completion criteria.
+ *
+ * Returns { valid: true } when:
+ *   - manifest is a non-null object
+ *   - manifest.finished is a non-empty string
+ *   - manifest.tasks_run >= JAKE_MANIFEST_MIN_TASKS (22)
+ */
+export function validateJakeManifest(raw: unknown): ManifestValidationResult {
+  if (typeof raw !== "object" || raw === null) {
+    return { valid: false, reason: "manifest is not an object" };
+  }
+  const manifest = raw as JakeManifest;
+  const finished = manifest.finished;
+  if (finished == null || finished.trim() === "") {
+    return {
+      valid: false,
+      manifest,
+      reason: "manifest.finished is missing or empty — run not complete",
+    };
+  }
+  const tasksRun =
+    typeof manifest.tasks_run === "number" ? manifest.tasks_run : Number(manifest.tasks_run) || 0;
+  if (tasksRun < JAKE_MANIFEST_MIN_TASKS) {
+    return {
+      valid: false,
+      manifest,
+      reason: `manifest.tasks_run is ${tasksRun}, need >= ${JAKE_MANIFEST_MIN_TASKS}`,
+    };
+  }
+  return { valid: true, manifest };
+}
+
+/**
+ * Validate a synthetic or loaded fixture manifest and return a human-readable
+ * summary string.
+ */
+export function describeManifestValidation(raw: unknown): string {
+  const result = validateJakeManifest(raw);
+  if (result.valid) {
+    const m = result.manifest;
+    return (
+      `COMPLETE: model=${m.model ?? "unknown"} finished=${m.finished} ` +
+      `tasks_run=${m.tasks_run ?? "?"}`
+    );
+  }
+  return `INCOMPLETE: ${result.reason}`;
+}
+
+/**
+ * Validate a set of Jake manifest objects for both QwenClaw targets.
+ *
+ * Returns a summary object with per-model results.
+ */
+export function validateQwenClawJakeRuns(manifests: { dense?: unknown; moe?: unknown }): {
+  dense: ManifestValidationResult;
+  moe: ManifestValidationResult;
+  bothComplete: boolean;
+} {
+  const dense = validateJakeManifest(manifests.dense);
+  const moe = validateJakeManifest(manifests.moe);
+  return {
+    dense,
+    moe,
+    bothComplete: dense.valid && moe.valid,
+  };
+}
+
+// Re-export for convenience
+export { isJakeManifestComplete, JAKE_MANIFEST_MIN_TASKS };

--- a/src/gemmaclaw/benchmark/qwenclaw-models.ts
+++ b/src/gemmaclaw/benchmark/qwenclaw-models.ts
@@ -1,0 +1,182 @@
+/**
+ * QwenClaw 3.6 benchmark port — model presets and provenance.
+ *
+ * PROVENANCE: This file ports the QwenClaw / Qwen 3.6 Jake benchmark workflow
+ * into the Gemmaclaw benchmark system. The original workflow ran on the Raspberry
+ * Pi 5 (frankpi / 100.108.252.124) via the Jake OpenClaw gateway with Ollama on
+ * the Desktop PC RTX 3090. Sources:
+ *   - scripts/qwen36-jake-orchestrator.sh
+ *   - cron/jake-benchmark-qwen36-run-until-done.md
+ *   - cron/jake-benchmark-qwen36-run-and-grade-until-done.md
+ *   - cron/jake-benchmark-qwen36-grade-and-update.md
+ *   - skills/jake-benchmark/SKILL.md
+ *
+ * OLD COMMANDS (Jake / Pi):
+ *   bash skills/jake-benchmark/scripts/run-model-benchmark.sh 'qwen3.6:35b' high
+ *   bash skills/jake-benchmark/scripts/run-model-benchmark.sh 'qwen3.6:35b-a3b-q4_K_M' high
+ *
+ * OLD COMPLETION CRITERIA (Jake runs):
+ *   manifest.finished is non-empty AND tasks_run >= 22
+ *   Run dirs: ~/.openclaw/workspace/skills/jake-benchmark/runs/<model>__<ts>/manifest.json
+ *
+ * NEW COMMANDS (Gemmaclaw / llama.cpp on Desktop RTX 3090):
+ *   pnpm benchmark agent --backend llama-cpp --llama-cpp-url http://100.69.102.71:8080 \
+ *     --model qwen3.6-35b-a3b --quant IQ4_XS --thinking high \
+ *     --run-id qwenclaw-36-moe-high
+ *   (Dense model is blocked — see QWEN36_DENSE_BLOCKED below.)
+ */
+
+import type { AgentBenchmarkConfig } from "./agent-runner.js";
+
+// ── Canonical Qwen 3.6 target identifiers ──────────────────────────────────
+
+/**
+ * The two Qwen 3.6 Jake benchmark targets, using the original Ollama model IDs
+ * as the canonical identifiers for provenance.
+ */
+export const QWEN36_JAKE_MODEL_IDS = {
+  /** Dense 27B-class model. Was pulled as "qwen3.6:35b" from Ollama. */
+  DENSE: "qwen3.6:35b" as const,
+  /** MoE 35B-A3B model. Was pulled as "qwen3.6:35b-a3b-q4_K_M" from Ollama. */
+  MOE: "qwen3.6:35b-a3b-q4_K_M" as const,
+} as const;
+
+export type QwenClawModelId = (typeof QWEN36_JAKE_MODEL_IDS)[keyof typeof QWEN36_JAKE_MODEL_IDS];
+
+// ── Current llama.cpp model mappings ───────────────────────────────────────
+
+/**
+ * Mapping from Jake/Ollama model IDs to current llama.cpp GGUF identifiers.
+ * Updated 2026-05-21 from knowledge/infra/gemmaclaw-benchmark-backends.md.
+ */
+export const QWEN36_LLAMACPP_MAPPING: Record<
+  QwenClawModelId,
+  { alias: string; gguf: string; vram: string; genToks: string; status: "ready" | "blocked" }
+> = {
+  "qwen3.6:35b": {
+    alias: "qwen3.6-27b-dense",
+    // froggeric GGUF resolves unsloth empty-tensor issue; alias matches --alias arg
+    gguf: "froggeric/Qwen3.6-27B-GGUF → Qwen3.6-27B-Q4_K_M.gguf",
+    vram: "~19600 MiB at ctx=65536",
+    genToks: "63-65 tok/s with MTP, 76-85% acceptance",
+    // BLOCKED: unsloth GGUF (original) has empty tensor names on llama.cpp b9190.
+    // froggeric GGUF works but is not competitive vs MoE (133 tok/s). Use as
+    // smaller smoke target only. See knowledge/infra/gemmaclaw-benchmark-backends.md
+    // "Qwen 3.6 27B dense (unsloth GGUF — BLOCKED)" section.
+    status: "blocked",
+  },
+  "qwen3.6:35b-a3b-q4_K_M": {
+    alias: "qwen3.6-35b-a3b",
+    gguf: "unsloth/Qwen3.6-35B-A3B-GGUF → Qwen3.6-35B-A3B-UD-IQ4_XS.gguf",
+    vram: "~19100 MiB at ctx=65536",
+    genToks: "133-135 tok/s",
+    status: "ready",
+  },
+};
+
+/** True if dense model can be used in a real benchmark run on current hardware. */
+export const QWEN36_DENSE_BLOCKED = QWEN36_LLAMACPP_MAPPING["qwen3.6:35b"].status === "blocked";
+
+// ── Default llama.cpp server endpoint ──────────────────────────────────────
+
+/** Desktop PC llama.cpp OpenAI-compatible endpoint (Tailscale). */
+export const QWEN36_DEFAULT_LLAMACPP_URL = "http://100.69.102.71:8080";
+
+// ── Gemmaclaw benchmark config presets ─────────────────────────────────────
+
+/**
+ * Gemmaclaw benchmark config preset for the Qwen 3.6 MoE model.
+ * Run with: pnpm benchmark agent --backend llama-cpp
+ *           --llama-cpp-url http://100.69.102.71:8080
+ *           --model qwen3.6-35b-a3b --quant IQ4_XS --thinking high
+ *           --run-id qwenclaw-36-moe-high
+ */
+export const QWEN36_MOE_PRESET: Partial<AgentBenchmarkConfig> = {
+  backend: "llama-cpp",
+  llamaCppUrl: QWEN36_DEFAULT_LLAMACPP_URL,
+  // Alias served by llamacpp-qwen36-35b-a3b-server.service (or custom launch).
+  model: QWEN36_LLAMACPP_MAPPING["qwen3.6:35b-a3b-q4_K_M"].alias,
+  quant: "IQ4_XS",
+  thinkingLevel: "high",
+};
+
+/**
+ * Gemmaclaw benchmark config preset for the Qwen 3.6 dense model.
+ * NOTE: The unsloth GGUF is blocked. Use froggeric GGUF as smoke target.
+ * Not competitive vs MoE — use for provenance smoke only.
+ */
+export const QWEN36_DENSE_PRESET: Partial<AgentBenchmarkConfig> = {
+  backend: "llama-cpp",
+  llamaCppUrl: QWEN36_DEFAULT_LLAMACPP_URL,
+  // Uses froggeric GGUF alias. See QWEN36_LLAMACPP_MAPPING for blocker details.
+  model: QWEN36_LLAMACPP_MAPPING["qwen3.6:35b"].alias,
+  quant: "Q4_K_M",
+  thinkingLevel: "high",
+};
+
+// ── Historical Jake run completion criteria ────────────────────────────────
+
+/** Minimum task count for a Jake run manifest to be considered complete. */
+export const JAKE_MANIFEST_MIN_TASKS = 22;
+
+/**
+ * Check whether a raw Jake run manifest object meets the historical
+ * QwenClaw completion criteria:
+ *   - manifest.finished is non-empty (string)
+ *   - manifest.tasks_run >= JAKE_MANIFEST_MIN_TASKS (22)
+ */
+export function isJakeManifestComplete(manifest: unknown): boolean {
+  if (typeof manifest !== "object" || manifest === null) {
+    return false;
+  }
+  const m = manifest as Record<string, unknown>;
+  const finished = m["finished"];
+  const tasksRun = m["tasks_run"];
+  if (finished == null || typeof finished !== "string" || finished.trim() === "") {
+    return false;
+  }
+  const count = typeof tasksRun === "number" ? tasksRun : Number(tasksRun) || 0;
+  return count >= JAKE_MANIFEST_MIN_TASKS;
+}
+
+/**
+ * Human-readable description of what the QwenClaw port adds to Gemmaclaw.
+ * Shown in `pnpm benchmark agent list --suite qwenclaw` or docs.
+ */
+export const QWENCLAW_PORT_DESCRIPTION = {
+  name: "QwenClaw 3.6 Benchmark Port",
+  version: "1.0.0",
+  portedFrom: "Jake benchmark (Pi) — scripts/qwen36-jake-orchestrator.sh",
+  portedOn: "2026-05-21",
+  models: [
+    {
+      jakeId: QWEN36_JAKE_MODEL_IDS.MOE,
+      llamaCppAlias: QWEN36_LLAMACPP_MAPPING["qwen3.6:35b-a3b-q4_K_M"].alias,
+      gguf: QWEN36_LLAMACPP_MAPPING["qwen3.6:35b-a3b-q4_K_M"].gguf,
+      status: "ready",
+      benchmarkCommand:
+        "pnpm benchmark agent --backend llama-cpp --llama-cpp-url http://100.69.102.71:8080 " +
+        "--model qwen3.6-35b-a3b --quant IQ4_XS --thinking high --run-id qwenclaw-36-moe-high",
+    },
+    {
+      jakeId: QWEN36_JAKE_MODEL_IDS.DENSE,
+      llamaCppAlias: QWEN36_LLAMACPP_MAPPING["qwen3.6:35b"].alias,
+      gguf: QWEN36_LLAMACPP_MAPPING["qwen3.6:35b"].gguf,
+      status: "blocked",
+      blockerNote:
+        "Unsloth GGUF has empty tensor names on llama.cpp b9190. " +
+        "Froggeric GGUF works but is not competitive (63-65 tok/s vs 133 for MoE). " +
+        "Use as smoke target only. See knowledge/infra/gemmaclaw-benchmark-backends.md.",
+      benchmarkCommand:
+        "pnpm benchmark agent --backend llama-cpp --llama-cpp-url http://100.69.102.71:8080 " +
+        "--model qwen3.6-27b-dense --quant Q4_K_M --thinking high --run-id qwenclaw-36-dense-smoke",
+    },
+  ],
+  jakeCompletionCriteria: {
+    minTasksRun: JAKE_MANIFEST_MIN_TASKS,
+    finishedFieldRequired: true,
+    description:
+      "A Jake run is complete when manifest.json exists, manifest.finished is non-empty, " +
+      `and manifest.tasks_run >= ${JAKE_MANIFEST_MIN_TASKS}.`,
+  },
+};


### PR DESCRIPTION
## Summary

Ports the old Jake/Pi QwenClaw 3.6 benchmark workflow (scattered across `scripts/qwen36-jake-orchestrator.sh` and 3 cron markdown files) into the Gemmaclaw benchmark system.

Changes:
- `qwenclaw-models.ts`: canonical model IDs, llama.cpp GGUF mappings, `AgentBenchmarkConfig` presets, `isJakeManifestComplete()`, `QWENCLAW_PORT_DESCRIPTION` with full provenance
- `jake-manifest-validator.ts`: `validateJakeManifest()` and `validateQwenClawJakeRuns()` for checking Pi run manifests against the original completion rule (finished non-empty and tasks_run >= 22)
- `jake-manifest-validator.test.ts`: 26 fixture-backed unit tests covering all manifest states and model preset metadata
- `docs/cli/benchmark.md`: QwenClaw 3.6 port section with provenance, run commands, isolation rules, API example

## Context

The original QwenClaw benchmark ran on the Pi via Jake with Ollama. This PR registers the two Qwen 3.6 targets as known Gemmaclaw benchmark configs discoverable via `pnpm benchmark agent --backend llama-cpp`.

Dense model blocker: unsloth GGUF has empty tensor names on llama.cpp b9190. Froggeric GGUF is the smoke target. MoE (`Qwen3.6-35B-A3B-UD-IQ4_XS.gguf`) is the primary ready target at 133-135 tok/s.

Credential rule: no `OPENAI_API_KEY`. llama-cpp backend uses dummy token. Any semantic judging must go through OAuth-backed CC ACP path.

## Test plan

- [x] `pnpm check:changed`: 0 lint errors, typecheck ok, cycles ok, all guards pass
- [x] `pnpm test`: 160/160 tests pass (26 new)
- [ ] Real MoE run (requires llama.cpp at 100.69.102.71:8080 with IQ4_XS GGUF, tracked as follow-up subtask)