### PR TITLE
fix(benchmark): disambiguate Qwen 3.6 local Jake port from upstream QwenClawBench

### DIFF
--- a/docs/cli/benchmark.md
+++ b/docs/cli/benchmark.md
@@ -218,18 +218,22 @@ Results are written to the output directory in three formats:
 The summary printed to the terminal includes total score, pass rate, average
 tokens per second, and file paths for each output format.
 
-## QwenClaw 3.6 benchmark port
+## Qwen 3.6 local Jake provenance
 
-The QwenClaw 3.6 benchmark port brings the original Jake / Pi benchmark
-workflow for Qwen 3.6 into the Gemmaclaw benchmark system. The port is
-defined in `src/gemmaclaw/benchmark/qwenclaw-models.ts` and
-`src/gemmaclaw/benchmark/jake-manifest-validator.ts`.
+This section documents the local Jake/Pi Qwen 3.6 runner that was brought
+into the Gemmaclaw benchmark system as model presets and a manifest
+validator. It is purely historical provenance for a workflow that
+predates Gemmaclaw and is **not** the Qwen team's QwenClawBench. The
+upstream QwenClawBench is covered in the next section.
+
+The port is defined in `src/gemmaclaw/benchmark/qwen36-jake-models.ts`
+and `src/gemmaclaw/benchmark/jake-manifest-validator.ts`.
 
 ### Provenance
 
-The original workflow ran on the Raspberry Pi 5 (frankpi) via the Jake
-OpenClaw gateway, with Ollama serving models on the Desktop PC RTX 3090. The
-two canonical model targets were:
+The original workflow ran on a Raspberry Pi 5 via a local OpenClaw gateway,
+with Ollama serving models on a workstation GPU. The two canonical model
+targets were:
 
 | Jake / Ollama model ID   | Role  | Status  |
 | ------------------------ | ----- | ------- |
@@ -239,19 +243,18 @@ two canonical model targets were:
 **Dense blocker:** The unsloth GGUF for the dense model has empty tensor names
 and crashes on llama.cpp b9190. The froggeric GGUF resolves this, but its
 throughput (63-65 tok/s) is not competitive with the MoE (133-135 tok/s) at
-comparable VRAM. Use the froggeric GGUF only as a smoke target. See
-`knowledge/infra/gemmaclaw-benchmark-backends.md` for details.
+comparable VRAM. Use the froggeric GGUF only as a smoke target.
 
 ### Running the MoE target
 
 The Qwen 3.6 MoE model (`Qwen3.6-35B-A3B-UD-IQ4_XS.gguf`) is the primary
-benchmark target. Serve it with the Desktop llama.cpp instance and run via
-the Gemmaclaw benchmark CLI:
+benchmark target. Serve it with a local llama.cpp instance and run via the
+Gemmaclaw benchmark CLI:
 
 ```bash
-# Serve the model (llama.cpp on Desktop RTX 3090)
+# Serve the model (llama.cpp on a workstation GPU)
 llama-server \
-  -m /home/frank/models/gguf/qwen3.6-hf/Qwen3.6-35B-A3B-UD-IQ4_XS.gguf \
+  -m /path/to/Qwen3.6-35B-A3B-UD-IQ4_XS.gguf \
   --alias qwen3.6-35b-a3b \
   --host 0.0.0.0 --port 8080 \
   --n-gpu-layers 99 --ctx-size 65536 --parallel 1 \
@@ -261,11 +264,11 @@ llama-server \
 # Run the benchmark (from gemmaclaw repo)
 pnpm benchmark agent \
   --backend llama-cpp \
-  --llama-cpp-url http://100.69.102.71:8080 \
+  --llama-cpp-url http://gateway-host:8080 \
   --model qwen3.6-35b-a3b \
   --quant IQ4_XS \
   --thinking high \
-  --run-id qwenclaw-36-moe-high
+  --run-id qwen36-jake-moe-high
 ```
 
 ### Running the dense target (smoke only)
@@ -275,11 +278,11 @@ Use the froggeric GGUF as a smaller smoke target:
 ```bash
 pnpm benchmark agent \
   --backend llama-cpp \
-  --llama-cpp-url http://100.69.102.71:8080 \
+  --llama-cpp-url http://gateway-host:8080 \
   --model qwen3.6-27b-dense \
   --quant Q4_K_M \
   --thinking high \
-  --run-id qwenclaw-36-dense-smoke
+  --run-id qwen36-jake-dense-smoke
 ```
 
 ### Container isolation and credentials
@@ -295,7 +298,7 @@ path (CC ACP or Claude Code), not a raw API key.
 ### Validating historical Jake run manifests
 
 Use `validateJakeManifest` from `jake-manifest-validator.ts` to check
-whether a historical Pi run meets the original completion criteria:
+whether a historical Jake run meets the original completion criteria:
 
 ```typescript
 import { validateJakeManifest } from "./src/gemmaclaw/benchmark/jake-manifest-validator.js";
@@ -309,3 +312,49 @@ if (result.valid) {
 ```
 
 A run is complete when `manifest.finished` is non-empty and `manifest.tasks_run >= 22`.
+
+## Upstream QwenClawBench (Qwen team, release-blocked)
+
+The Qwen team's **QwenClawBench** is a separate benchmark that has **not yet
+been open-sourced**. It is referenced in the official Qwen3.6 Hugging Face
+model cards as:
+
+> _QwenClawBench: An internal real-user-distribution Claw agent benchmark
+> (open-sourcing soon); temp=0.6, 256K ctx._
+
+Sources verified 2026-05-21:
+
+- [github.com/QwenLM/Qwen3.6](https://github.com/QwenLM/Qwen3.6) (no
+  QwenClawBench mention; no public dataset/repo)
+- [huggingface.co/Qwen/Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B)
+  (results table + footnote)
+- [huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8](https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8)
+  (same footnote)
+
+Gemmaclaw must not publish a benchmark under the QwenClawBench name until
+the Qwen team releases the official artifact. The release tracker lives in
+`src/gemmaclaw/benchmark/qwenclaw-bench-upstream.ts`:
+
+- `QWENCLAW_BENCH_UPSTREAM_STATUS` records the current release state.
+- `QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS` carries the upstream-documented
+  run settings (temperature 0.6, context length 256K).
+- `assessQwenClawBenchRelease()` is a pure helper a watcher can call with
+  fetched upstream text to detect when the "open-sourcing soon" language
+  changes.
+- `ensureQwenClawBenchImportAllowed()` throws while the status is still
+  internal; use it as a guard in any code path that wants to expose a
+  QwenClawBench-named artifact.
+- `QWENCLAW_BENCH_RELEASE_CHECKLIST` lists the manual steps a future
+  Gemmaclaw adapter must follow once the upstream artifact ships.
+
+When Qwen releases QwenClawBench:
+
+1. Confirm the public artifact lives under a Qwen-team-owned namespace
+   (`github.com/QwenLM`, `huggingface.co/Qwen`, or an officially linked
+   Qwen blog).
+2. Update `QWENCLAW_BENCH_UPSTREAM_STATUS` to `released` and set
+   `publicArtifactUrl`.
+3. Implement the Gemmaclaw adapter behind the same container/credential
+   guardrails listed above (no `OPENAI_API_KEY`, container-only,
+   OAuth-backed judging).
+4. Add an end-to-end smoke before any publishable run.

--- a/src/gemmaclaw/benchmark/jake-manifest-validator.test.ts
+++ b/src/gemmaclaw/benchmark/jake-manifest-validator.test.ts
@@ -1,10 +1,14 @@
 /**
- * Tests for jake-manifest-validator.ts — QwenClaw 3.6 port.
+ * Tests for jake-manifest-validator.ts — Qwen 3.6 local Jake provenance.
  *
  * These are pure-unit / fixture-backed tests. No model inference, no Docker,
  * no network. They verify that the manifest validator correctly applies the
  * historical Jake completion criteria (finished non-empty, tasks_run >= 22)
  * and that model preset metadata is accurate.
+ *
+ * SCOPE: validates Frank's local Jake/Pi runner artifacts. NOT a validator
+ * for the Qwen team's upstream QwenClawBench. See
+ * `qwenclaw-bench-upstream.test.ts` for upstream-fact tests.
  */
 
 import { describe, expect, it } from "vitest";
@@ -12,16 +16,16 @@ import {
   JAKE_MANIFEST_MIN_TASKS,
   describeManifestValidation,
   validateJakeManifest,
-  validateQwenClawJakeRuns,
+  validateQwen36JakeRuns,
 } from "./jake-manifest-validator.js";
 import {
   QWEN36_DENSE_BLOCKED,
   QWEN36_JAKE_MODEL_IDS,
+  QWEN36_JAKE_PROVENANCE,
   QWEN36_LLAMACPP_MAPPING,
   QWEN36_MOE_PRESET,
-  QWENCLAW_PORT_DESCRIPTION,
   isJakeManifestComplete,
-} from "./qwenclaw-models.js";
+} from "./qwen36-jake-models.js";
 
 // ── Fixture manifests ───────────────────────────────────────────────────────
 
@@ -60,7 +64,7 @@ const INCOMPLETE_MANIFEST_MISSING_FINISHED = {
 const MALFORMED_MANIFEST = "not an object";
 const NULL_MANIFEST = null;
 
-// ── isJakeManifestComplete (qwenclaw-models.ts) ─────────────────────────────
+// ── isJakeManifestComplete (qwen36-jake-models.ts) ──────────────────────────
 
 describe("isJakeManifestComplete", () => {
   it("returns true for a complete manifest with exactly 22 tasks", () => {
@@ -154,11 +158,11 @@ describe("describeManifestValidation", () => {
   });
 });
 
-// ── validateQwenClawJakeRuns ────────────────────────────────────────────────
+// ── validateQwen36JakeRuns ──────────────────────────────────────────────────
 
-describe("validateQwenClawJakeRuns", () => {
+describe("validateQwen36JakeRuns", () => {
   it("reports bothComplete=true when both manifests are complete", () => {
-    const result = validateQwenClawJakeRuns({
+    const result = validateQwen36JakeRuns({
       dense: COMPLETE_MANIFEST_LARGE,
       moe: COMPLETE_MANIFEST,
     });
@@ -168,13 +172,13 @@ describe("validateQwenClawJakeRuns", () => {
   });
 
   it("reports bothComplete=false when dense is missing", () => {
-    const result = validateQwenClawJakeRuns({ moe: COMPLETE_MANIFEST });
+    const result = validateQwen36JakeRuns({ moe: COMPLETE_MANIFEST });
     expect(result.bothComplete).toBe(false);
     expect(result.dense.valid).toBe(false);
   });
 
   it("reports bothComplete=false when moe is incomplete", () => {
-    const result = validateQwenClawJakeRuns({
+    const result = validateQwen36JakeRuns({
       dense: COMPLETE_MANIFEST_LARGE,
       moe: PARTIAL_MANIFEST_LOW_TASKS,
     });
@@ -183,7 +187,7 @@ describe("validateQwenClawJakeRuns", () => {
   });
 
   it("reports bothComplete=false when both are undefined", () => {
-    const result = validateQwenClawJakeRuns({});
+    const result = validateQwen36JakeRuns({});
     expect(result.bothComplete).toBe(false);
   });
 });
@@ -211,21 +215,26 @@ describe("QWEN36 model preset metadata", () => {
     expect(QWEN36_MOE_PRESET.quant).toBe("IQ4_XS");
   });
 
-  it("JAKE_MANIFEST_MIN_TASKS is 22 (historical QwenClaw criterion)", () => {
+  it("JAKE_MANIFEST_MIN_TASKS is 22 (historical Jake criterion)", () => {
     expect(JAKE_MANIFEST_MIN_TASKS).toBe(22);
   });
 
-  it("port description includes both model entries", () => {
-    expect(QWENCLAW_PORT_DESCRIPTION.models).toHaveLength(2);
-    const jakeIds = QWENCLAW_PORT_DESCRIPTION.models.map((m) => m.jakeId);
+  it("provenance includes both model entries", () => {
+    expect(QWEN36_JAKE_PROVENANCE.models).toHaveLength(2);
+    const jakeIds = QWEN36_JAKE_PROVENANCE.models.map((m) => m.jakeId);
     expect(jakeIds).toContain("qwen3.6:35b");
     expect(jakeIds).toContain("qwen3.6:35b-a3b-q4_K_M");
   });
 
-  it("port description has benchmark commands for both models", () => {
-    for (const m of QWENCLAW_PORT_DESCRIPTION.models) {
+  it("provenance has benchmark commands for both models", () => {
+    for (const m of QWEN36_JAKE_PROVENANCE.models) {
       expect(m.benchmarkCommand).toContain("pnpm benchmark agent");
       expect(m.benchmarkCommand).toContain("--backend llama-cpp");
     }
+  });
+
+  it("provenance explicitly distinguishes from upstream QwenClawBench", () => {
+    expect(QWEN36_JAKE_PROVENANCE.distinctFromUpstream).toMatch(/QwenClawBench/i);
+    expect(QWEN36_JAKE_PROVENANCE.distinctFromUpstream).toMatch(/NOT/);
   });
 });

--- a/src/gemmaclaw/benchmark/jake-manifest-validator.ts
+++ b/src/gemmaclaw/benchmark/jake-manifest-validator.ts
@@ -1,9 +1,13 @@
 /**
  * Jake run manifest validator.
  *
- * Validates historical Jake benchmark run manifests using the original
- * QwenClaw completion criteria. Used by the Gemmaclaw benchmark port to
+ * Validates historical Jake benchmark run manifests using the original Jake
+ * completion rule. Used by the Gemmaclaw Qwen 3.6 local-provenance port to
  * verify that a Jake run is complete before consuming its artifacts.
+ *
+ * SCOPE: This validator targets Frank's older local Jake/Pi runner. It is NOT
+ * a validator for the Qwen team's QwenClawBench (a separate, internal coding-
+ * agent benchmark; see `qwenclaw-bench-upstream.ts`).
  *
  * PROVENANCE: Historical Jake runs live at:
  *   ~/.openclaw/workspace/skills/jake-benchmark/runs/<model>__<ts>/manifest.json
@@ -13,7 +17,7 @@
  *   manifest.finished is non-empty AND manifest.tasks_run >= 22
  */
 
-import { isJakeManifestComplete, JAKE_MANIFEST_MIN_TASKS } from "./qwenclaw-models.js";
+import { isJakeManifestComplete, JAKE_MANIFEST_MIN_TASKS } from "./qwen36-jake-models.js";
 
 export type JakeManifest = {
   /** ISO timestamp when the run finished. Non-empty = complete. */
@@ -35,7 +39,7 @@ export type ManifestValidationResult =
   | { valid: false; manifest?: JakeManifest; reason: string };
 
 /**
- * Validate a Jake run manifest object against the historical QwenClaw
+ * Validate a Jake run manifest object against the historical Jake
  * completion criteria.
  *
  * Returns { valid: true } when:
@@ -85,11 +89,12 @@ export function describeManifestValidation(raw: unknown): string {
 }
 
 /**
- * Validate a set of Jake manifest objects for both QwenClaw targets.
+ * Validate a set of Jake manifest objects for both Qwen 3.6 Jake targets
+ * (dense + MoE).
  *
  * Returns a summary object with per-model results.
  */
-export function validateQwenClawJakeRuns(manifests: { dense?: unknown; moe?: unknown }): {
+export function validateQwen36JakeRuns(manifests: { dense?: unknown; moe?: unknown }): {
   dense: ManifestValidationResult;
   moe: ManifestValidationResult;
   bothComplete: boolean;

--- a/src/gemmaclaw/benchmark/qwen36-jake-models.ts
+++ b/src/gemmaclaw/benchmark/qwen36-jake-models.ts
@@ -1,10 +1,17 @@
 /**
- * QwenClaw 3.6 benchmark port — model presets and provenance.
+ * Qwen 3.6 local Jake-runner provenance — model presets and historical metadata.
  *
- * PROVENANCE: This file ports the QwenClaw / Qwen 3.6 Jake benchmark workflow
- * into the Gemmaclaw benchmark system. The original workflow ran on the Raspberry
- * Pi 5 (frankpi / 100.108.252.124) via the Jake OpenClaw gateway with Ollama on
- * the Desktop PC RTX 3090. Sources:
+ * NOT THE QWEN TEAM'S QWENCLAWBENCH. This file captures Frank's older local
+ * Jake/Pi runner that happened to target Qwen 3.6 models. The Qwen team's
+ * "QwenClawBench" is a separate internal coding-agent benchmark that is not
+ * yet public; see `qwenclaw-bench-upstream.ts` for the official upstream
+ * facts and release-tracking scaffold.
+ *
+ * PROVENANCE: This file documents the Qwen 3.6 Jake/Pi benchmark workflow
+ * and brings the model targets into the Gemmaclaw benchmark system as
+ * llama.cpp-backed presets. The original workflow ran on the Raspberry Pi 5
+ * (frankpi / 100.108.252.124) via the Jake OpenClaw gateway with Ollama on
+ * the Desktop PC RTX 3090. Sources (workspace, not this repo):
  *   - scripts/qwen36-jake-orchestrator.sh
  *   - cron/jake-benchmark-qwen36-run-until-done.md
  *   - cron/jake-benchmark-qwen36-run-and-grade-until-done.md
@@ -22,7 +29,7 @@
  * NEW COMMANDS (Gemmaclaw / llama.cpp on Desktop RTX 3090):
  *   pnpm benchmark agent --backend llama-cpp --llama-cpp-url http://100.69.102.71:8080 \
  *     --model qwen3.6-35b-a3b --quant IQ4_XS --thinking high \
- *     --run-id qwenclaw-36-moe-high
+ *     --run-id qwen36-jake-moe-high
  *   (Dense model is blocked — see QWEN36_DENSE_BLOCKED below.)
  */
 
@@ -41,7 +48,7 @@ export const QWEN36_JAKE_MODEL_IDS = {
   MOE: "qwen3.6:35b-a3b-q4_K_M" as const,
 } as const;
 
-export type QwenClawModelId = (typeof QWEN36_JAKE_MODEL_IDS)[keyof typeof QWEN36_JAKE_MODEL_IDS];
+export type Qwen36JakeModelId = (typeof QWEN36_JAKE_MODEL_IDS)[keyof typeof QWEN36_JAKE_MODEL_IDS];
 
 // ── Current llama.cpp model mappings ───────────────────────────────────────
 
@@ -50,13 +57,13 @@ export type QwenClawModelId = (typeof QWEN36_JAKE_MODEL_IDS)[keyof typeof QWEN36
  * Updated 2026-05-21 from knowledge/infra/gemmaclaw-benchmark-backends.md.
  */
 export const QWEN36_LLAMACPP_MAPPING: Record<
-  QwenClawModelId,
+  Qwen36JakeModelId,
   { alias: string; gguf: string; vram: string; genToks: string; status: "ready" | "blocked" }
 > = {
   "qwen3.6:35b": {
     alias: "qwen3.6-27b-dense",
     // froggeric GGUF resolves unsloth empty-tensor issue; alias matches --alias arg
-    gguf: "froggeric/Qwen3.6-27B-GGUF → Qwen3.6-27B-Q4_K_M.gguf",
+    gguf: "froggeric/Qwen3.6-27B-GGUF -> Qwen3.6-27B-Q4_K_M.gguf",
     vram: "~19600 MiB at ctx=65536",
     genToks: "63-65 tok/s with MTP, 76-85% acceptance",
     // BLOCKED: unsloth GGUF (original) has empty tensor names on llama.cpp b9190.
@@ -67,7 +74,7 @@ export const QWEN36_LLAMACPP_MAPPING: Record<
   },
   "qwen3.6:35b-a3b-q4_K_M": {
     alias: "qwen3.6-35b-a3b",
-    gguf: "unsloth/Qwen3.6-35B-A3B-GGUF → Qwen3.6-35B-A3B-UD-IQ4_XS.gguf",
+    gguf: "unsloth/Qwen3.6-35B-A3B-GGUF -> Qwen3.6-35B-A3B-UD-IQ4_XS.gguf",
     vram: "~19100 MiB at ctx=65536",
     genToks: "133-135 tok/s",
     status: "ready",
@@ -89,7 +96,7 @@ export const QWEN36_DEFAULT_LLAMACPP_URL = "http://100.69.102.71:8080";
  * Run with: pnpm benchmark agent --backend llama-cpp
  *           --llama-cpp-url http://100.69.102.71:8080
  *           --model qwen3.6-35b-a3b --quant IQ4_XS --thinking high
- *           --run-id qwenclaw-36-moe-high
+ *           --run-id qwen36-jake-moe-high
  */
 export const QWEN36_MOE_PRESET: Partial<AgentBenchmarkConfig> = {
   backend: "llama-cpp",
@@ -121,7 +128,7 @@ export const JAKE_MANIFEST_MIN_TASKS = 22;
 
 /**
  * Check whether a raw Jake run manifest object meets the historical
- * QwenClaw completion criteria:
+ * Jake completion criteria:
  *   - manifest.finished is non-empty (string)
  *   - manifest.tasks_run >= JAKE_MANIFEST_MIN_TASKS (22)
  */
@@ -140,14 +147,21 @@ export function isJakeManifestComplete(manifest: unknown): boolean {
 }
 
 /**
- * Human-readable description of what the QwenClaw port adds to Gemmaclaw.
- * Shown in `pnpm benchmark agent list --suite qwenclaw` or docs.
+ * Human-readable description of the Qwen 3.6 local Jake provenance brought
+ * into Gemmaclaw. This is NOT the Qwen team's QwenClawBench (see
+ * `qwenclaw-bench-upstream.ts`); it documents Frank's older Jake/Pi runner
+ * so that historical manifests can be validated and the same Qwen 3.6
+ * targets can be re-run from Gemmaclaw.
  */
-export const QWENCLAW_PORT_DESCRIPTION = {
-  name: "QwenClaw 3.6 Benchmark Port",
-  version: "1.0.0",
+export const QWEN36_JAKE_PROVENANCE = {
+  name: "Qwen 3.6 local Jake provenance",
+  version: "1.1.0",
   portedFrom: "Jake benchmark (Pi) — scripts/qwen36-jake-orchestrator.sh",
   portedOn: "2026-05-21",
+  distinctFromUpstream:
+    "This is Frank's local Jake/Pi runner for Qwen 3.6 models. " +
+    "It is NOT the Qwen team's QwenClawBench (open-sourcing soon). " +
+    "See `qwenclaw-bench-upstream.ts` for the upstream release scaffold.",
   models: [
     {
       jakeId: QWEN36_JAKE_MODEL_IDS.MOE,
@@ -156,7 +170,7 @@ export const QWENCLAW_PORT_DESCRIPTION = {
       status: "ready",
       benchmarkCommand:
         "pnpm benchmark agent --backend llama-cpp --llama-cpp-url http://100.69.102.71:8080 " +
-        "--model qwen3.6-35b-a3b --quant IQ4_XS --thinking high --run-id qwenclaw-36-moe-high",
+        "--model qwen3.6-35b-a3b --quant IQ4_XS --thinking high --run-id qwen36-jake-moe-high",
     },
     {
       jakeId: QWEN36_JAKE_MODEL_IDS.DENSE,
@@ -169,7 +183,7 @@ export const QWENCLAW_PORT_DESCRIPTION = {
         "Use as smoke target only. See knowledge/infra/gemmaclaw-benchmark-backends.md.",
       benchmarkCommand:
         "pnpm benchmark agent --backend llama-cpp --llama-cpp-url http://100.69.102.71:8080 " +
-        "--model qwen3.6-27b-dense --quant Q4_K_M --thinking high --run-id qwenclaw-36-dense-smoke",
+        "--model qwen3.6-27b-dense --quant Q4_K_M --thinking high --run-id qwen36-jake-dense-smoke",
     },
   ],
   jakeCompletionCriteria: {

--- a/src/gemmaclaw/benchmark/qwenclaw-bench-upstream.test.ts
+++ b/src/gemmaclaw/benchmark/qwenclaw-bench-upstream.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for qwenclaw-bench-upstream.ts.
+ *
+ * Pure-unit tests. They verify that the public-fact constants stay anchored
+ * to the Qwen-team sources, the release-watcher heuristic correctly handles
+ * the three input shapes (no mention, "open-sourcing soon" present, mention
+ * without the phrase), and the import-guard refuses while upstream is
+ * still internal.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  QWENCLAW_BENCH_RELEASE_CHECKLIST,
+  QWENCLAW_BENCH_UPSTREAM_FOOTNOTE,
+  QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS,
+  QWENCLAW_BENCH_UPSTREAM_SOURCES,
+  QWENCLAW_BENCH_UPSTREAM_STATUS,
+  QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT,
+  assessQwenClawBenchRelease,
+  ensureQwenClawBenchImportAllowed,
+} from "./qwenclaw-bench-upstream.js";
+
+describe("QWENCLAW_BENCH_UPSTREAM_SOURCES", () => {
+  it("only references Qwen-team-owned URLs", () => {
+    for (const url of Object.values(QWENCLAW_BENCH_UPSTREAM_SOURCES)) {
+      expect(url).toMatch(/^https:\/\/(github\.com\/QwenLM|huggingface\.co\/Qwen)/);
+    }
+  });
+
+  it("includes both MoE and FP8 model cards", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_SOURCES.hfQwen36MoE).toContain("Qwen3.6-35B-A3B");
+    expect(QWENCLAW_BENCH_UPSTREAM_SOURCES.hfQwen36MoEFp8).toContain("FP8");
+  });
+});
+
+describe("QWENCLAW_BENCH_UPSTREAM_FOOTNOTE", () => {
+  it("preserves the verbatim Qwen-team footnote", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_FOOTNOTE).toContain("internal real-user-distribution");
+    expect(QWENCLAW_BENCH_UPSTREAM_FOOTNOTE).toContain("Claw agent benchmark");
+    expect(QWENCLAW_BENCH_UPSTREAM_FOOTNOTE).toContain("open-sourcing soon");
+    expect(QWENCLAW_BENCH_UPSTREAM_FOOTNOTE).toContain("temp=0.6");
+    expect(QWENCLAW_BENCH_UPSTREAM_FOOTNOTE).toContain("256K ctx");
+  });
+});
+
+describe("QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS", () => {
+  it("uses the upstream-documented temperature 0.6", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS.temperature).toBe(0.6);
+  });
+
+  it("uses the upstream-documented 256K context length", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS.contextLengthTokens).toBe(262144);
+    expect(QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS.contextLengthLabel).toBe("256K");
+  });
+});
+
+describe("QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT", () => {
+  it("matches the published model-card numbers", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT.scores["Qwen3.6-35BA3B"]).toBe(52.6);
+    expect(QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT.scores["Qwen3.5-27B"]).toBe(52.2);
+    expect(QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT.scores["Gemma4-31B"]).toBe(41.7);
+  });
+
+  it("cites a Qwen-team source", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT.source).toContain("Qwen/Qwen3.6");
+  });
+});
+
+describe("QWENCLAW_BENCH_UPSTREAM_STATUS", () => {
+  it("starts in the internal-open-sourcing-soon state", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_STATUS.status).toBe("internal-open-sourcing-soon");
+  });
+
+  it("has no public artifact URL while internal", () => {
+    expect(QWENCLAW_BENCH_UPSTREAM_STATUS.publicArtifactUrl).toBeNull();
+  });
+});
+
+describe("assessQwenClawBenchRelease", () => {
+  it("returns unknown when no sources are provided", () => {
+    const r = assessQwenClawBenchRelease([]);
+    expect(r.status).toBe("unknown");
+    expect(r.blockedOnUpstream).toBe(true);
+    expect(r.releaseSignalDetected).toBe(false);
+  });
+
+  it("returns unknown when QwenClawBench is not mentioned", () => {
+    const r = assessQwenClawBenchRelease([
+      { url: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B", text: "Qwen3.6 release notes." },
+    ]);
+    expect(r.status).toBe("unknown");
+    expect(r.blockedOnUpstream).toBe(true);
+    expect(r.releaseSignalDetected).toBe(false);
+  });
+
+  it("returns internal-open-sourcing-soon when the upstream still gates the bench", () => {
+    const r = assessQwenClawBenchRelease([
+      {
+        url: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
+        text:
+          "QwenClawBench: An internal real-user-distribution Claw agent " +
+          "benchmark (open-sourcing soon); temp=0.6, 256K ctx.",
+      },
+    ]);
+    expect(r.status).toBe("internal-open-sourcing-soon");
+    expect(r.blockedOnUpstream).toBe(true);
+    expect(r.releaseSignalDetected).toBe(false);
+  });
+
+  it("flags a release signal when the bench is mentioned without the 'open-sourcing soon' phrase", () => {
+    const r = assessQwenClawBenchRelease([
+      {
+        url: "https://github.com/QwenLM/Qwen3.6",
+        text: "See QwenClawBench at https://github.com/QwenLM/QwenClawBench for run instructions.",
+      },
+    ]);
+    expect(r.status).toBe("unknown");
+    expect(r.blockedOnUpstream).toBe(true);
+    expect(r.releaseSignalDetected).toBe(true);
+    expect(r.reason).toContain("Manual follow-up");
+  });
+});
+
+describe("ensureQwenClawBenchImportAllowed", () => {
+  it("throws while upstream is still internal", () => {
+    expect(() => ensureQwenClawBenchImportAllowed()).toThrowError(/not released yet/);
+  });
+});
+
+describe("QWENCLAW_BENCH_RELEASE_CHECKLIST", () => {
+  it("includes the Qwen-team source-ownership check", () => {
+    const all = QWENCLAW_BENCH_RELEASE_CHECKLIST.join(" ");
+    expect(all).toMatch(/Qwen-team-owned/);
+  });
+
+  it("includes the container/credential guard reminders", () => {
+    const all = QWENCLAW_BENCH_RELEASE_CHECKLIST.join(" ");
+    expect(all).toMatch(/GEMMACLAW_BENCHMARK_CONTAINER/);
+    expect(all).toMatch(/fake-gog/);
+    expect(all).toMatch(/OPENAI_API_KEY/);
+  });
+
+  it("ends with a published-status update step", () => {
+    const last = QWENCLAW_BENCH_RELEASE_CHECKLIST[QWENCLAW_BENCH_RELEASE_CHECKLIST.length - 2];
+    expect(last).toMatch(/QWENCLAW_BENCH_UPSTREAM_STATUS/);
+  });
+});

--- a/src/gemmaclaw/benchmark/qwenclaw-bench-upstream.ts
+++ b/src/gemmaclaw/benchmark/qwenclaw-bench-upstream.ts
@@ -1,0 +1,230 @@
+/**
+ * Upstream Qwen-team QwenClawBench facts and release-tracking scaffold.
+ *
+ * This module records what the Qwen team has publicly stated about
+ * QwenClawBench. It is NOT a runner for the benchmark. The benchmark has
+ * not been open-sourced yet (per Qwen Hugging Face model cards, as of
+ * 2026-05-21), so there is no artifact for Gemmaclaw to import.
+ *
+ * If Qwen releases QwenClawBench, this module is where the public facts
+ * land: dataset/repo URLs, schema, scoring code, and a documented adapter
+ * path. Until then the constants here serve two purposes:
+ *
+ *   1. Guard rails: anyone implementing a Gemmaclaw "QwenClawBench" suite
+ *      must reference this module so that a synthetic substitute does not
+ *      get published under the QwenClawBench name.
+ *
+ *   2. Watcher inputs: `assessQwenClawBenchRelease()` can be called from a
+ *      release-watcher script that fetches the upstream model cards and
+ *      verifies whether the "open-sourcing soon" language is still present.
+ *
+ * Distinct from `qwen36-jake-models.ts`, which captures Frank's older
+ * local Jake/Pi runner targeting Qwen 3.6 models. That port is purely
+ * historical and unrelated to the Qwen team's internal benchmark.
+ */
+
+// ── Public facts (verified against official Qwen sources, 2026-05-21) ─────
+
+/**
+ * Stable URLs for the Qwen-team sources used to anchor the upstream
+ * QwenClawBench facts. Only Qwen-Team-owned namespaces are listed.
+ */
+export const QWENCLAW_BENCH_UPSTREAM_SOURCES = {
+  github: "https://github.com/QwenLM/Qwen3.6",
+  hfQwen36MoE: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B",
+  hfQwen36MoEFp8: "https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8",
+} as const;
+
+/**
+ * Verbatim footnote text from the Qwen-team Hugging Face model cards.
+ * Used by the watcher to detect when the language changes (the benchmark
+ * is published, or settings are updated). Keep verbatim, do not paraphrase.
+ */
+export const QWENCLAW_BENCH_UPSTREAM_FOOTNOTE =
+  "QwenClawBench: An internal real-user-distribution Claw agent benchmark " +
+  "(open-sourcing soon); temp=0.6, 256K ctx.";
+
+/**
+ * Publicly stated run settings for QwenClawBench. Pulled from the Qwen-team
+ * model card footnote. Use these as the canonical settings once the
+ * benchmark itself is released.
+ */
+export const QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS = {
+  temperature: 0.6,
+  contextLengthTokens: 262144,
+  contextLengthLabel: "256K",
+  description: "Real-user-distribution Claw agent benchmark (internal at Qwen).",
+} as const;
+
+/**
+ * Snapshot of the QwenClawBench results table from the Qwen-team model card
+ * (Qwen3.6-35B-A3B). Used so the watcher and tests can verify the upstream
+ * table has not silently changed. Not consumed as benchmark output.
+ */
+export const QWENCLAW_BENCH_UPSTREAM_TABLE_SNAPSHOT = {
+  capturedAt: "2026-05-21",
+  source: "huggingface.co/Qwen/Qwen3.6-35B-A3B",
+  scores: {
+    "Qwen3.5-27B": 52.2,
+    "Gemma4-31B": 41.7,
+    "Qwen3.5-35BA3B": 47.7,
+    "Gemma4-26BA4B": 38.7,
+    "Qwen3.6-35BA3B": 52.6,
+  },
+} as const;
+
+/**
+ * Possible release statuses for the upstream QwenClawBench.
+ */
+export type QwenClawBenchReleaseStatus = "internal-open-sourcing-soon" | "released" | "unknown";
+
+/**
+ * Current best knowledge about the upstream release status. Updated when
+ * the watcher (`assessQwenClawBenchRelease`) detects a change, or by hand
+ * after confirming the Qwen-team blog/repo.
+ */
+export const QWENCLAW_BENCH_UPSTREAM_STATUS: {
+  status: QwenClawBenchReleaseStatus;
+  asOf: string;
+  evidence: string;
+  publicArtifactUrl: string | null;
+} = {
+  status: "internal-open-sourcing-soon",
+  asOf: "2026-05-21",
+  evidence:
+    "Hugging Face model cards for Qwen3.6-35B-A3B and Qwen3.6-35B-A3B-FP8 " +
+    "describe QwenClawBench as an internal real-user-distribution Claw agent " +
+    "benchmark with the note '(open-sourcing soon); temp=0.6, 256K ctx'. " +
+    "The QwenLM/Qwen3.6 GitHub README does not mention QwenClawBench or " +
+    "expose any benchmark dataset/repo.",
+  publicArtifactUrl: null,
+};
+
+// ── Release-watcher logic ─────────────────────────────────────────────────
+
+/**
+ * Output of `assessQwenClawBenchRelease`. The watcher fetches the upstream
+ * model card text(s) elsewhere and passes the strings in; this function is
+ * pure so it can be tested without network access.
+ */
+export type QwenClawBenchReleaseAssessment = {
+  status: QwenClawBenchReleaseStatus;
+  /** Human-readable explanation suitable for a watcher log line. */
+  reason: string;
+  /** True when the watcher should NOT yet treat QwenClawBench as importable. */
+  blockedOnUpstream: boolean;
+  /** True when the watcher detected a release signal that needs follow-up. */
+  releaseSignalDetected: boolean;
+};
+
+/**
+ * Heuristic check on upstream model-card text. If any input contains the
+ * phrase "open-sourcing soon" near "QwenClawBench", the benchmark is still
+ * internal. If a card mentions QwenClawBench but no longer carries the
+ * "open-sourcing soon" language, treat that as a release signal that needs
+ * manual follow-up.
+ *
+ * Pure function: takes strings, returns a verdict. Network/IO lives in the
+ * watcher script that calls this helper.
+ */
+export function assessQwenClawBenchRelease(
+  sources: { url: string; text: string }[],
+): QwenClawBenchReleaseAssessment {
+  if (sources.length === 0) {
+    return {
+      status: "unknown",
+      reason: "no upstream sources provided to watcher",
+      blockedOnUpstream: true,
+      releaseSignalDetected: false,
+    };
+  }
+
+  let sawBenchMention = false;
+  let sawOpenSourcingSoon = false;
+  const mentionsWithoutSoon: string[] = [];
+
+  for (const source of sources) {
+    const lower = source.text.toLowerCase();
+    const hasName = lower.includes("qwenclawbench");
+    const hasSoon = lower.includes("open-sourcing soon");
+    if (hasName) {
+      sawBenchMention = true;
+      if (hasSoon) {
+        sawOpenSourcingSoon = true;
+      } else {
+        mentionsWithoutSoon.push(source.url);
+      }
+    }
+  }
+
+  if (!sawBenchMention) {
+    return {
+      status: "unknown",
+      reason: "no QwenClawBench mention found in upstream sources",
+      blockedOnUpstream: true,
+      releaseSignalDetected: false,
+    };
+  }
+
+  if (sawOpenSourcingSoon) {
+    return {
+      status: "internal-open-sourcing-soon",
+      reason:
+        "upstream sources still describe QwenClawBench as 'open-sourcing soon' " +
+        "(internal Qwen-team benchmark); do not import or substitute",
+      blockedOnUpstream: true,
+      releaseSignalDetected: false,
+    };
+  }
+
+  return {
+    status: "unknown",
+    reason:
+      "QwenClawBench is mentioned in upstream sources WITHOUT the 'open-sourcing soon' " +
+      `language: ${mentionsWithoutSoon.join(", ")}. Manual follow-up required to ` +
+      "confirm whether the benchmark has been published.",
+    blockedOnUpstream: true,
+    releaseSignalDetected: true,
+  };
+}
+
+/**
+ * Hard rule: until QwenClawBench is publicly released by the Qwen team,
+ * Gemmaclaw must not publish or label any internal/synthetic suite as
+ * "QwenClawBench". Use this guard in any code path that wants to expose a
+ * QwenClawBench-named artifact.
+ */
+export function ensureQwenClawBenchImportAllowed(): void {
+  if (QWENCLAW_BENCH_UPSTREAM_STATUS.status !== "released") {
+    throw new Error(
+      "QwenClawBench upstream is not released yet " +
+        `(status=${QWENCLAW_BENCH_UPSTREAM_STATUS.status}, asOf=${QWENCLAW_BENCH_UPSTREAM_STATUS.asOf}). ` +
+        "Do not publish a Gemmaclaw artifact under the QwenClawBench name. " +
+        "Update QWENCLAW_BENCH_UPSTREAM_STATUS after confirming the Qwen-team release.",
+    );
+  }
+}
+
+// ── Watcher checklist (consumed by docs + release script) ─────────────────
+
+/**
+ * Steps the release watcher / human follow-up should perform when the
+ * upstream model cards stop saying "open-sourcing soon". Kept here so
+ * docs and any future automation use the same checklist.
+ */
+export const QWENCLAW_BENCH_RELEASE_CHECKLIST: readonly string[] = [
+  "Confirm the new public artifact URL is in a Qwen-team-owned namespace " +
+    "(github.com/QwenLM, huggingface.co/Qwen, or an officially linked Qwen blog).",
+  "Read the released README/scoring docs end to end before touching Gemmaclaw " +
+    "code. Capture: dataset shape, scoring rule, required tools, expected runtime.",
+  "Verify the upstream run settings still match QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS " +
+    "(temperature=0.6, context length 256K). Any difference is a doc bug to flag.",
+  "Implement the Gemmaclaw adapter behind a feature flag with " +
+    "GEMMACLAW_BENCHMARK_CONTAINER=1 + fake-gog enforced. No host-mode run.",
+  "Do not use OPENAI_API_KEY anywhere in the adapter. If frontier judging is " +
+    "required, route through CC ACP / OAuth-backed CLI per Frank's directive.",
+  "Update QWENCLAW_BENCH_UPSTREAM_STATUS.status to 'released', set " +
+    "publicArtifactUrl, refresh asOf and evidence, and bump the table snapshot.",
+  "Add an end-to-end smoke that exercises the adapter against a small subset " +
+    "before any publishable run.",
+];


### PR DESCRIPTION
## Why

PR #218 brought Frank's old local Jake/Pi runner for Qwen 3.6 into the Gemmaclaw benchmark system and named the integration **QwenClaw** / `qwenclaw-models.ts` / `QWENCLAW_PORT_DESCRIPTION` etc. That naming conflicts with the Qwen team's official **QwenClawBench**, which is a separate internal coding-agent benchmark referenced in the Qwen3.6 model cards.

Per the Qwen-team Hugging Face cards (verified 2026-05-21):

> *QwenClawBench: An internal real-user-distribution Claw agent benchmark (open-sourcing soon); temp=0.6, 256K ctx.*

There is no public artifact yet. The `QwenLM/Qwen3.6` GitHub README does not mention QwenClawBench. Until Qwen ships it, Gemmaclaw should not publish anything under the QwenClawBench name.

## Changes

- Rename `src/gemmaclaw/benchmark/qwenclaw-models.ts` → `src/gemmaclaw/benchmark/qwen36-jake-models.ts`. Inside:
  - `QwenClawModelId` → `Qwen36JakeModelId`
  - `QWENCLAW_PORT_DESCRIPTION` → `QWEN36_JAKE_PROVENANCE` (with an explicit `distinctFromUpstream` field)
  - Run-id strings switch from `qwenclaw-36-*` to `qwen36-jake-*`
- `jake-manifest-validator.ts`: rewrite docstrings so they refer to the "historical Jake completion rule" instead of "QwenClaw completion criteria"; rename `validateQwenClawJakeRuns` → `validateQwen36JakeRuns`; import points at the renamed module
- Tests updated for the renames; new assertion that the provenance object explicitly distinguishes itself from upstream QwenClawBench
- **New** `src/gemmaclaw/benchmark/qwenclaw-bench-upstream.ts` holds the Qwen-team-anchored facts about the upstream benchmark:
  - `QWENCLAW_BENCH_UPSTREAM_SOURCES` (only Qwen-team-owned URLs)
  - Verbatim upstream footnote (open-sourcing soon, temp 0.6, 256K ctx)
  - `QWENCLAW_BENCH_UPSTREAM_RUN_SETTINGS`, `_TABLE_SNAPSHOT`, `_STATUS`
  - Pure `assessQwenClawBenchRelease()` watcher helper
  - `ensureQwenClawBenchImportAllowed()` throws while status ≠ released
  - `QWENCLAW_BENCH_RELEASE_CHECKLIST`
- **New** `src/gemmaclaw/benchmark/qwenclaw-bench-upstream.test.ts` (17 tests)
- `docs/cli/benchmark.md`: the old "QwenClaw 3.6 benchmark port" section is split into two clearly-named sections — **"Qwen 3.6 local Jake provenance"** and **"Upstream QwenClawBench (Qwen team, release-blocked)"** — with Qwen GitHub/HF anchors and the release checklist. Generic placeholders replace local hostnames/paths.

## Local checks (clean)

- `pnpm check:changed`: 0 warnings, 0 errors. typecheck core + core tests, lint core, import cycles, webhook/auth guards, conflict-marker guard.
- `pnpm test src/gemmaclaw/benchmark`: 9 test files / 179 tests passed.
- `pnpm test src/gemmaclaw/benchmark/jake-manifest-validator.test.ts src/gemmaclaw/benchmark/qwenclaw-bench-upstream.test.ts`: 44 tests passed (27 updated + 17 new).

## Fix consequence check

- **Original failure addressed?** Yes. PR #218 mis-scoped the request and labeled a local Jake port as `QwenClaw`. After this PR, the local provenance lives under `qwen36-jake-*` symbols/files, and any code path that wants to expose `QwenClawBench` must reference `qwenclaw-bench-upstream.ts` and pass the `ensureQwenClawBenchImportAllowed()` gate.
- **Edge cases introduced?** Renames could break callers; grep confirms PR #218 was the only producer and there are no external callers. The `assessQwenClawBenchRelease` watcher is a pure helper without network access — the consuming script must do its own HTTP fetch with retry/backoff.
- **Slow / partial / failing dependencies?** The watcher helper is offline. The import-guard throws synchronously. The Jake validator does not change behavior — it just renames symbols and docstrings.

## Followups

- A watcher script that fetches the three upstream URLs on a cadence and calls `assessQwenClawBenchRelease` to update `QWENCLAW_BENCH_UPSTREAM_STATUS` is a small follow-up; the pure helper here is ready to be plugged into it.
- Dense Qwen 3.6 GGUF llama.cpp blocker is unchanged and pre-existing; no scope change here.