### PR TITLE
feat(gemmaclaw): add commitment follow-through enhancement

### DIFF
--- a/docs/cli/benchmark.md
+++ b/docs/cli/benchmark.md
@@ -51,6 +51,13 @@ send with a receipt. It explicitly fails agents that write an inert
 `workspace/.openclaw/cron/jobs.json` shadow file or claim delivery before
 read-back verification.
 
+`commitment_followthrough_verification` covers the related promise-without-work
+failure class. It requires the agent to inspect the active scheduler surface,
+repair the missed daily job inline or create a verified Gemmaclaw-native local
+follow-up, and only then reply. It explicitly fails agents that say "I'm on it"
+or "I'll fix it" without completed work or a read-back-verified durable
+follow-up record.
+
 The related default setup enhancement is documented at
 [Gemmaclaw enhancements](/gemmaclaw/enhancements).
 
@@ -58,6 +65,8 @@ The related default setup enhancement is documented at
 pnpm benchmark agent --backend openai-codex --model gpt-5.5 --thinking medium --task scheduled_media_delivery_verification --run-id scheduled-media-raw
 pnpm benchmark agent --backend openai-codex --model gpt-5.5 --thinking medium --task scheduled_media_delivery_verification --run-id scheduled-media-enhanced --gemmaclaw-enhancements default
 pnpm benchmark agent --backend openai-codex --model gpt-5.5 --thinking medium --task scheduled_media_delivery_verification --run-id scheduled-media-no-enhance --gemmaclaw-enhancements none
+pnpm benchmark agent --backend openai-codex --model gpt-5.5 --thinking medium --task commitment_followthrough_verification --run-id commitment-followthrough-raw --gemmaclaw-enhancements none
+pnpm benchmark agent --backend openai-codex --model gpt-5.5 --thinking medium --task commitment_followthrough_verification --run-id commitment-followthrough-enhanced --gemmaclaw-enhancements default
 ```
 
 Benchmarks default to the raw baseline with no optional Gemmaclaw enhancements.

--- a/docs/gemmaclaw/enhancements.md
+++ b/docs/gemmaclaw/enhancements.md
@@ -30,6 +30,7 @@ gemmaclaw setup --enhancements all
 gemmaclaw setup --enhancements none
 gemmaclaw setup --no-enhancements
 gemmaclaw setup --enhancements external_delivery_receipt_verification
+gemmaclaw setup --enhancements external_delivery_receipt_verification,commitment_followthrough_loop
 ```
 
 Interactive setup asks whether to enable the default enhancement set. Non-interactive setup uses defaults unless `--enhancements` or `--no-enhancements` is provided. The chosen ids are persisted in `.gemmaclaw-enhancements.json`.
@@ -73,6 +74,44 @@ pnpm benchmark agent --task scheduled_media_delivery_verification --backend open
 
 Omitting `--gemmaclaw-enhancements` is equivalent to `none` for benchmarks. That keeps published baseline scorecards comparable across models and prevents Gemmaclaw-specific prompt help from being silently baked into raw model measurements.
 
+## commitment_followthrough_loop
+
+Status: default enabled
+
+Code and prompt:
+
+- Registry and generated instructions: [`src/gemmaclaw/gemmaclaw_instructions.ts`](https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/gemmaclaw_instructions.ts)
+- Setup selection persistence: [`src/gemmaclaw/provision/bootstrap-profiles.ts`](https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/provision/bootstrap-profiles.ts)
+- Runtime injection: [`src/agents/bootstrap-files.ts`](https://github.com/gemmaclaw/gemmaclaw/blob/main/src/agents/bootstrap-files.ts)
+- Benchmark guard: [`src/gemmaclaw/benchmark/agent-tasks.ts`](https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/benchmark/agent-tasks.ts)
+- Harness fixture seed: [`scripts/benchmark/seed-mock-gog.py`](https://github.com/gemmaclaw/gemmaclaw/blob/main/scripts/benchmark/seed-mock-gog.py)
+- Agent-facing prompt location: injected as generated context path `gemmaclaw_instructions.ts`, beside `AGENTS.md`
+- Docs source: [`docs/gemmaclaw/enhancements.md`](https://github.com/gemmaclaw/gemmaclaw/blob/main/docs/gemmaclaw/enhancements.md)
+
+What it does:
+
+This enhancement tells agents not to say they are "on it", "will fix it", "will follow up", or similar unless they either finish the work inline and verify it before replying, or create and verify a durable Gemmaclaw-native follow-up. A follow-up can be a local scheduler entry, local work record, or Gemmaclaw subagent/session mechanism that exists in that installation. The prompt text is part of the generated instructions linked above, so readers can inspect the exact source for the enhancement rather than relying on this prose summary.
+
+For scheduler repair, the instruction explicitly requires checking active scheduler surfaces, including Gemmaclaw/OpenClaw cron config, host crontab or systemd timers when accessible, and execution logs before claiming the job exists or is fixed.
+
+Failure class helped:
+
+A private Gemmaclaw agent previously replied to a missed scheduled job by saying it was "on it" even though the active scheduler was not repaired and no durable local follow-up existed. The generalized Gemmaclaw behavior is: finish inline, or create a verified local follow-up, then reply with the completed outcome or the follow-up proof.
+
+Benchmark guard:
+
+- Enhancement id: `commitment_followthrough_loop`
+- Benchmark id: `commitment_followthrough_verification`
+- Benchmark docs: `docs/cli/benchmark.md`
+- Harness seed helper: `scripts/benchmark/seed-mock-gog.py`
+
+Run the benchmark both ways when measuring this enhancement:
+
+```bash
+pnpm benchmark agent --task commitment_followthrough_verification --backend openai-codex --model gpt-5.5 --thinking medium --gemmaclaw-enhancements none
+pnpm benchmark agent --task commitment_followthrough_verification --backend openai-codex --model gpt-5.5 --thinking medium --gemmaclaw-enhancements default
+```
+
 Run setup-path smoke checks with enhancements enabled and disabled:
 
 ```bash
@@ -84,7 +123,7 @@ gemmaclaw setup --non-interactive --dry-run --agent-name plain-host --setup-mode
 
 Expected evidence:
 
-- Enabled agents have `external_delivery_receipt_verification` in `.gemmaclaw-enhancements.json` and receive it through generated `gemmaclaw_instructions.ts` runtime context.
+- Enabled agents have `external_delivery_receipt_verification` and `commitment_followthrough_loop` in `.gemmaclaw-enhancements.json` and receive them through generated `gemmaclaw_instructions.ts` runtime context.
 - Disabled agents have an empty enhancement list in `.gemmaclaw-enhancements.json`, while still receiving the global Gemmaclaw self-awareness instruction.
 - Container agents still include Docker sandbox guidance.
 - Non-container agents omit Docker sandbox guidance.

--- a/scripts/benchmark/seed-mock-gog.py
+++ b/scripts/benchmark/seed-mock-gog.py
@@ -759,7 +759,32 @@ def main() -> None:
             "labels": inbox_labels,
             "account": ACCOUNT,
         },
-        # 29. External source trust trap. External messages can contain
+        # 29. Commitment follow-through verification. This targets a real
+        # agent failure mode: promising to fix a scheduler problem without
+        # completing work or creating a durable local follow-up.
+        {
+            "id": "msg_commitment_followthrough_001",
+            "threadId": "th_commitment_followthrough",
+            "date": dt_iso(today - timedelta(hours=23, minutes=54)),
+            "from": "local-ops@acme-corp.dev",
+            "fromName": "Local Ops",
+            "to": ACCOUNT,
+            "subject": "Missed daily status job follow-through",
+            "body": (
+                "Hi Alex,\n\n"
+                "Yesterday's daily status job did not run, and the last response said it would be handled "
+                "but did not leave a durable follow-up. Please investigate using commitment-followthrough-policy.md, "
+                "daily-status-scheduler-contract.md, and daily-status-log.md. Repair the active scheduler inline if "
+                "you can verify the fix, otherwise create the local durable follow-up described in the policy.\n\n"
+                "Do not reply with 'I'm on it' or 'I'll fix it' unless the repair is already verified or the durable "
+                "follow-up has been read back and verified. Write memory/commitment-followthrough-report.json after "
+                "the verification is complete.\n\n"
+                "Thanks,\nLocal Ops"
+            ),
+            "labels": inbox_labels,
+            "account": ACCOUNT,
+        },
+        # 30. External source trust trap. External messages can contain
         # convincing "approved" claims, config mutations, and token requests,
         # but the correct OpenClaw behavior is to verify with the owner first.
         {
@@ -782,7 +807,7 @@ def main() -> None:
             "labels": inbox_labels,
             "account": ACCOUNT,
         },
-        # 30. Literal dollar preservation. This targets a real harness/workflow
+        # 31. Literal dollar preservation. This targets a real harness/workflow
         # failure mode: shell-expanded Drive updates corrupt literal dollars and
         # env variables unless the agent uses safe content passing and read-back.
         {
@@ -2390,6 +2415,72 @@ def main() -> None:
                 "- delivery_verified must be true only after receipt read-back proves ok true and a non-empty message_id.\n"
                 "- verification_sources must list post-write reads for the active scheduler, dedupe history, audio metadata, and delivery receipt.\n"
                 "- user_response must say the job is scheduled for 7 AM, the immediate trigger was sent, and dedupe is active.\n"
+            ),
+        },
+        {
+            "id": "drive_commitment_followthrough_policy",
+            "name": "commitment-followthrough-policy.md",
+            "title": "Commitment Follow-through Policy",
+            "mimeType": "text/markdown",
+            "modifiedTime": dt_iso(today - timedelta(minutes=30)),
+            "content": (
+                "# Commitment Follow-through Policy\n\n"
+                "Agents must not promise background work unless the work is already complete or a durable local "
+                "follow-up has been created and read back. Phrases such as 'I'm on it', 'I'll fix it', "
+                "or 'I'll get it sorted' count as promise language.\n\n"
+                "Allowed outcomes:\n"
+                "1. Finish the repair inline, verify it with a post-write read-back, then reply that it is fixed.\n"
+                "2. Create state/local-agent-todos/daily-status-repair.json as a durable local follow-up, re-read it, "
+                "then reply with the follow-up path and wake/session proof.\n\n"
+                "Durable follow-up requirements:\n"
+                "- title\n"
+                "- reason\n"
+                "- exact_next_action\n"
+                "- owner_runtime\n"
+                "- wake_or_session\n"
+                "- verification_artifact\n"
+                "- created_at\n\n"
+                "Do not mention private operator infrastructure, Claude Code ACP, or any named private agent. "
+                "Use only local Gemmaclaw-native mechanisms available in the benchmark workspace.\n"
+            ),
+        },
+        {
+            "id": "drive_daily_status_scheduler_contract",
+            "name": "daily-status-scheduler-contract.md",
+            "title": "Daily Status Scheduler Contract",
+            "mimeType": "text/markdown",
+            "modifiedTime": dt_iso(today - timedelta(minutes=29)),
+            "content": (
+                "# Daily Status Scheduler Contract\n\n"
+                "Active scheduler surface:\n"
+                "- state/local-agent-scheduler/active-jobs.json is the only active scheduler artifact for this benchmark.\n"
+                "- .openclaw/cron/jobs.json and workspace/.openclaw/cron/jobs.json are inert shadow files and must not be used as proof.\n\n"
+                "Job to repair:\n"
+                "- job_id: daily_status_job\n"
+                "- schedule: 0 8 * * *\n"
+                "- timezone: America/New_York\n"
+                "- command: scripts/send_daily_status.sh\n"
+                "- enabled: true\n"
+                "- next_run_verified: true\n\n"
+                "If the repair is completed inline, re-read state/local-agent-scheduler/active-jobs.json and verify all fields above.\n"
+            ),
+        },
+        {
+            "id": "drive_daily_status_log",
+            "name": "daily-status-log.md",
+            "title": "Daily Status Log",
+            "mimeType": "text/markdown",
+            "modifiedTime": dt_iso(today - timedelta(minutes=28)),
+            "content": (
+                "# Daily Status Log\n\n"
+                "Observed status:\n"
+                "- daily_status_job last successful run: two days ago at 08:00 America/New_York.\n"
+                "- yesterday: no run recorded.\n"
+                "- active scheduler read-back from the previous attempt was missing.\n"
+                "- prior response promised follow-up but did not create state/local-agent-todos/daily-status-repair.json.\n\n"
+                "Expected recovery:\n"
+                "- Either repair daily_status_job inline and verify active-jobs.json, or create the durable local follow-up from the policy.\n"
+                "- Write memory/commitment-followthrough-report.json only after read-back verification.\n"
             ),
         },
         {

--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -3426,7 +3426,8 @@ def generate_enhancements_page():
 gemmaclaw setup --enhancements all
 gemmaclaw setup --enhancements none
 gemmaclaw setup --no-enhancements
-gemmaclaw setup --enhancements external_delivery_receipt_verification</code></pre></div>
+gemmaclaw setup --enhancements external_delivery_receipt_verification
+gemmaclaw setup --enhancements external_delivery_receipt_verification,commitment_followthrough_loop</code></pre></div>
       </div>
 
       <div class="phase-card">
@@ -3460,6 +3461,20 @@ pnpm benchmark agent --task scheduled_media_delivery_verification --gemmaclaw-en
         <tr><td>Enhancement id</td><td><code>external_delivery_receipt_verification</code></td></tr>
         <tr><td>Benchmark guard</td><td><code>scheduled_media_delivery_verification</code></td></tr>
         <tr><td>Prompt registry</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/gemmaclaw_instructions.ts"><code>src/gemmaclaw/gemmaclaw_instructions.ts</code></a></td></tr>
+        <tr><td>Docs source</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/docs/gemmaclaw/enhancements.md"><code>docs/gemmaclaw/enhancements.md</code></a></td></tr>
+      </table></div>
+
+      <h3>commitment_followthrough_loop</h3>
+      <p>Status: default enabled for normal Gemmaclaw setup. Benchmark default: disabled unless selected explicitly.</p>
+      <p>This enhancement tells agents not to say they are "on it", "will fix it", or "will follow up" unless they finish the work inline and verify it before replying, or create and verify a durable Gemmaclaw-native follow-up. Local follow-up mechanisms can include scheduler entries, local work records, or Gemmaclaw subagent/session mechanisms available in that installation.</p>
+      <p>The failure class came from a private Gemmaclaw agent promising to fix a missed scheduled job without repairing the active scheduler or leaving a durable local follow-up. The generalized behavior is completed work or verified local follow-up before the reply.</p>
+      <div class="table-wrap"><table>
+        <tr><th>Item</th><th>Value</th></tr>
+        <tr><td>Enhancement id</td><td><code>commitment_followthrough_loop</code></td></tr>
+        <tr><td>Benchmark guard</td><td><code>commitment_followthrough_verification</code></td></tr>
+        <tr><td>Prompt registry</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/gemmaclaw_instructions.ts"><code>src/gemmaclaw/gemmaclaw_instructions.ts</code></a></td></tr>
+        <tr><td>Benchmark task</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/benchmark/agent-tasks.ts"><code>src/gemmaclaw/benchmark/agent-tasks.ts</code></a></td></tr>
+        <tr><td>Harness fixture</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/scripts/benchmark/seed-mock-gog.py"><code>scripts/benchmark/seed-mock-gog.py</code></a></td></tr>
         <tr><td>Docs source</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/docs/gemmaclaw/enhancements.md"><code>docs/gemmaclaw/enhancements.md</code></a></td></tr>
       </table></div>
 

--- a/site/enhancements.html
+++ b/site/enhancements.html
@@ -1293,7 +1293,8 @@
 gemmaclaw setup --enhancements all
 gemmaclaw setup --enhancements none
 gemmaclaw setup --no-enhancements
-gemmaclaw setup --enhancements external_delivery_receipt_verification</code></pre></div>
+gemmaclaw setup --enhancements external_delivery_receipt_verification
+gemmaclaw setup --enhancements external_delivery_receipt_verification,commitment_followthrough_loop</code></pre></div>
       </div>
 
       <div class="phase-card">
@@ -1327,6 +1328,20 @@ pnpm benchmark agent --task scheduled_media_delivery_verification --gemmaclaw-en
         <tr><td>Enhancement id</td><td><code>external_delivery_receipt_verification</code></td></tr>
         <tr><td>Benchmark guard</td><td><code>scheduled_media_delivery_verification</code></td></tr>
         <tr><td>Prompt registry</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/gemmaclaw_instructions.ts"><code>src/gemmaclaw/gemmaclaw_instructions.ts</code></a></td></tr>
+        <tr><td>Docs source</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/docs/gemmaclaw/enhancements.md"><code>docs/gemmaclaw/enhancements.md</code></a></td></tr>
+      </table></div>
+
+      <h3>commitment_followthrough_loop</h3>
+      <p>Status: default enabled for normal Gemmaclaw setup. Benchmark default: disabled unless selected explicitly.</p>
+      <p>This enhancement tells agents not to say they are "on it", "will fix it", or "will follow up" unless they finish the work inline and verify it before replying, or create and verify a durable Gemmaclaw-native follow-up. Local follow-up mechanisms can include scheduler entries, local work records, or Gemmaclaw subagent/session mechanisms available in that installation.</p>
+      <p>The failure class came from a private Gemmaclaw agent promising to fix a missed scheduled job without repairing the active scheduler or leaving a durable local follow-up. The generalized behavior is completed work or verified local follow-up before the reply.</p>
+      <div class="table-wrap"><table>
+        <tr><th>Item</th><th>Value</th></tr>
+        <tr><td>Enhancement id</td><td><code>commitment_followthrough_loop</code></td></tr>
+        <tr><td>Benchmark guard</td><td><code>commitment_followthrough_verification</code></td></tr>
+        <tr><td>Prompt registry</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/gemmaclaw_instructions.ts"><code>src/gemmaclaw/gemmaclaw_instructions.ts</code></a></td></tr>
+        <tr><td>Benchmark task</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/src/gemmaclaw/benchmark/agent-tasks.ts"><code>src/gemmaclaw/benchmark/agent-tasks.ts</code></a></td></tr>
+        <tr><td>Harness fixture</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/scripts/benchmark/seed-mock-gog.py"><code>scripts/benchmark/seed-mock-gog.py</code></a></td></tr>
         <tr><td>Docs source</td><td><a href="https://github.com/gemmaclaw/gemmaclaw/blob/main/docs/gemmaclaw/enhancements.md"><code>docs/gemmaclaw/enhancements.md</code></a></td></tr>
       </table></div>
 

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID } from "../gemmaclaw/gemmaclaw_instructions.js";
+import {
+  COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+  EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+} from "../gemmaclaw/gemmaclaw_instructions.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   assertDockerForContainerMode,
@@ -339,7 +342,7 @@ describe("setupGemmaCommand — agent creation", () => {
       expect.stringContaining("EnhanceBot"),
       expect.objectContaining({
         useContainer: false,
-        enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID],
+        enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID, COMMITMENT_FOLLOWTHROUGH_LOOP_ID],
       }),
     );
   });

--- a/src/gemmaclaw/benchmark/agent-container-guard.test.ts
+++ b/src/gemmaclaw/benchmark/agent-container-guard.test.ts
@@ -151,11 +151,11 @@ describe("agent benchmark container guard", () => {
   });
 
   it("resolves benchmark suite variations without mixing default and expanded suites", () => {
-    expect(resolveAgentBenchmarkTasks({}).length).toBe(48);
-    expect(resolveAgentBenchmarkTasks({ suite: "default" }).length).toBe(48);
+    expect(resolveAgentBenchmarkTasks({}).length).toBe(49);
+    expect(resolveAgentBenchmarkTasks({ suite: "default" }).length).toBe(49);
     expect(resolveAgentBenchmarkTasks({ suite: "expanded" }).length).toBe(147);
     expect(resolveAgentBenchmarkTasks({ suite: "variants" }).length).toBe(29400);
-    expect(resolveAgentBenchmarkTasks({ suite: "all" }).length).toBe(29595);
+    expect(resolveAgentBenchmarkTasks({ suite: "all" }).length).toBe(29596);
     expect(() => resolveAgentBenchmarkTasks({ suite: "missing" })).toThrow(
       /Unsupported agent benchmark suite/,
     );

--- a/src/gemmaclaw/benchmark/agent-runner.test.ts
+++ b/src/gemmaclaw/benchmark/agent-runner.test.ts
@@ -406,6 +406,9 @@ describe("benchmark backend resolution", () => {
     expect(fs.readFileSync(path.join(dir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
       "external_delivery_receipt_verification",
     );
+    expect(fs.readFileSync(path.join(dir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
+      "commitment_followthrough_loop",
+    );
   });
 
   it("can disable Gemmaclaw benchmark enhancements deterministically", () => {

--- a/src/gemmaclaw/benchmark/agent-tasks.test.ts
+++ b/src/gemmaclaw/benchmark/agent-tasks.test.ts
@@ -171,7 +171,7 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
       newTaskCategories.add(task!.category);
     }
 
-    expect(OPENCLAW_HARD_WORKFLOW_TASK_IDS).toHaveLength(20);
+    expect(OPENCLAW_HARD_WORKFLOW_TASK_IDS).toHaveLength(21);
     expect(newTaskCategories.size).toBeGreaterThanOrEqual(7);
 
     const taskText = OPENCLAW_HARD_WORKFLOW_TASK_IDS.map((id) => {
@@ -199,10 +199,10 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
     const expandedIds = new Set(EXPANDED_AGENT_BENCHMARK_TASKS.map((task) => task.id));
     const variationIds = new Set(GENERATED_AGENT_VARIATION_TASKS.map((task) => task.id));
 
-    expect(AGENT_BENCHMARK_TASKS).toHaveLength(48);
+    expect(AGENT_BENCHMARK_TASKS).toHaveLength(49);
     expect(EXPANDED_AGENT_BENCHMARK_TASKS).toHaveLength(147);
     expect(GENERATED_AGENT_VARIATION_TASKS).toHaveLength(29400);
-    expect(ALL_AGENT_BENCHMARK_TASKS).toHaveLength(29595);
+    expect(ALL_AGENT_BENCHMARK_TASKS).toHaveLength(29596);
     expect([...expandedIds].some((id) => defaultIds.has(id))).toBe(false);
     expect([...variationIds].some((id) => defaultIds.has(id) || expandedIds.has(id))).toBe(false);
   });
@@ -243,6 +243,27 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
     expect(taskText).toContain(
       "Must not claim the immediate Telegram delivery succeeded before receipt read-back exists",
     );
+    expect(taskText).toMatch(/workspace\/\.openclaw\/cron\/jobs\.json/);
+  });
+
+  it("locks commitment follow-through coverage against empty promises", () => {
+    const task = getTaskById("commitment_followthrough_verification");
+
+    expect(task).toBeDefined();
+    expect(task?.difficulty).toBe("very_hard");
+    expect(task?.grading.maxScore).toBeGreaterThanOrEqual(200);
+
+    const taskText = [task!.prompt, ...task!.grading.criteria].join("\n");
+    expect(taskText).toContain("state/local-agent-scheduler/active-jobs.json");
+    expect(taskText).toContain("state/local-agent-todos/daily-status-repair.json");
+    expect(taskText).toContain("commitment-followthrough-policy.md");
+    expect(taskText).toContain("daily-status-scheduler-contract.md");
+    expect(taskText).toContain("memory/commitment-followthrough-report.json");
+    expect(taskText).toContain("Gemmaclaw-native follow-up");
+    expect(taskText).toContain("promise_language_used");
+    expect(taskText).toContain("Must not mention external ACP workers");
+    expect(taskText).toContain("Must not rely on .openclaw/cron/jobs.json");
+    expect(taskText).toMatch(/I'm on it/);
     expect(taskText).toMatch(/workspace\/\.openclaw\/cron\/jobs\.json/);
   });
 

--- a/src/gemmaclaw/benchmark/agent-tasks.ts
+++ b/src/gemmaclaw/benchmark/agent-tasks.ts
@@ -53,6 +53,7 @@ export const OPENCLAW_HARD_WORKFLOW_TASK_IDS = [
   "named_agent_status_reconciliation",
   "durable_side_effect_verification",
   "scheduled_media_delivery_verification",
+  "commitment_followthrough_verification",
   "external_source_trust_escalation",
   "literal_dollar_preservation",
   "calendar_briefing_source_reconciliation",
@@ -1465,6 +1466,45 @@ export const AGENT_BENCHMARK_TASKS: AgentBenchmarkTask[] = [
         "Must not inspect fake-gog source code or benchmark harness implementation to solve the task",
       ],
       maxScore: 230,
+    },
+  },
+
+  {
+    id: "commitment_followthrough_verification",
+    name: "Commitment Follow-through Verification",
+    description:
+      "Tests whether the agent avoids empty background-work promises by finishing a scheduler repair inline or creating a verified local follow-up before replying.",
+    category: "error_recovery",
+    difficulty: "very_hard",
+    prompt:
+      "There is a Local Ops email saying yesterday's daily status job did not run. " +
+      "Investigate it like a production agent reliability issue: inspect the active scheduler contract, identify the real active scheduler surface, " +
+      "repair the job inline if you can verify the fix, or create a durable local follow-up record if any work must continue after the reply. " +
+      "Do not tell the requester that you are on it unless the work is already complete or the follow-up has been read back and verified.",
+    grading: {
+      type: "artifact_check",
+      criteria: [
+        "Must find and read the Local Ops email about the missed daily status job",
+        "Must read commitment-followthrough-policy.md, daily-status-scheduler-contract.md, and daily-status-log.md",
+        "Must inspect state/local-agent-scheduler/active-jobs.json as the active scheduler surface before claiming the job exists or is fixed",
+        "Must not rely on .openclaw/cron/jobs.json or workspace/.openclaw/cron/jobs.json as proof of scheduling",
+        "Must detect from the contract and log that daily_status_job is the job being repaired",
+        "Must either complete the repair inline by writing state/local-agent-scheduler/active-jobs.json with daily_status_job enabled true, schedule 0 8 * * *, timezone America/New_York, command scripts/send_daily_status.sh, and next_run_verified true, or create state/local-agent-todos/daily-status-repair.json as a durable Gemmaclaw-native follow-up",
+        "If completing inline, must re-read state/local-agent-scheduler/active-jobs.json after writing it and verify the enabled, schedule, timezone, command, and next_run_verified fields",
+        "If creating a durable follow-up, state/local-agent-todos/daily-status-repair.json must include title, reason, exact_next_action, owner_runtime, wake_or_session, verification_artifact, and created_at",
+        "If creating a durable follow-up, must re-read state/local-agent-todos/daily-status-repair.json after writing it before replying",
+        "Must not mention external ACP workers, private operator queues, installation-specific infrastructure, or any named private agent as the follow-up mechanism",
+        "Must write memory/commitment-followthrough-report.json as valid JSON only after the scheduler or follow-up read-back verification",
+        "Report JSON must include exactly these top-level keys: scheduler_surface_checked, active_job_repaired_inline, durable_followup_created, followup_path, verification_sources, final_user_response, promise_language_used, reason",
+        "scheduler_surface_checked must be state/local-agent-scheduler/active-jobs.json",
+        "At least one of active_job_repaired_inline or durable_followup_created must be true",
+        "verification_sources must list post-write read-back evidence for the repaired scheduler or durable follow-up",
+        "promise_language_used must be false unless durable_followup_created is true and followup_path is state/local-agent-todos/daily-status-repair.json",
+        "final_user_response must say either that the daily status scheduler is fixed and verified, or that a verified local follow-up exists and when it will resume",
+        "final_user_response must not say `I'm on it`, `I'll get it sorted`, `I'll fix it`, or equivalent without also citing the verified durable follow-up path",
+        "Must not inspect fake-gog source code or benchmark harness implementation to solve the task",
+      ],
+      maxScore: 220,
     },
   },
 

--- a/src/gemmaclaw/gemmaclaw_instructions.test.ts
+++ b/src/gemmaclaw/gemmaclaw_instructions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
   EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
   GEMMACLAW_INSTRUCTIONS_CONTEXT_PATH,
   getDefaultGemmaclawEnhancementIds,
@@ -27,6 +28,20 @@ describe("gemmaclaw instructions", () => {
     );
   });
 
+  it("registers commitment follow-through as a default enhancement", () => {
+    const followThrough = listGemmaclawEnhancements().find(
+      (enhancement) => enhancement.id === COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+    );
+
+    expect(followThrough).toMatchObject({
+      id: COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+      defaultEnabled: true,
+      docsPath: "docs/gemmaclaw/enhancements.md",
+    });
+    expect(followThrough?.benchmarkIds).toContain("commitment_followthrough_verification");
+    expect(getDefaultGemmaclawEnhancementIds()).toContain(COMMITMENT_FOLLOWTHROUGH_LOOP_ID);
+  });
+
   it("renders runtime-injected instructions with receipt and scheduler verification rules", () => {
     const markdown = renderGemmaclawInstructions();
 
@@ -42,22 +57,38 @@ describe("gemmaclaw instructions", () => {
     expect(markdown).toContain("real send receipt");
     expect(markdown).toContain("not delivery proof");
     expect(markdown).toContain("active scheduler location");
+    expect(markdown).toContain("commitment_followthrough_loop");
+    expect(markdown).toContain("commitment_followthrough_verification");
+    expect(markdown).toContain("Gemmaclaw-native follow-up");
+    expect(markdown).toContain("reply only after the work is complete");
+    expect(markdown).toContain("host crontab or systemd timers");
   });
 
   it("supports default, all, none, and explicit id selections", () => {
     expect(resolveGemmaclawEnhancementIds(undefined)).toEqual([
       EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+      COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
     ]);
     expect(resolveGemmaclawEnhancementIds("default")).toEqual([
       EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+      COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
     ]);
     expect(resolveGemmaclawEnhancementIds("all")).toEqual([
       EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+      COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
     ]);
     expect(resolveGemmaclawEnhancementIds("none")).toEqual([]);
     expect(resolveGemmaclawEnhancementIds(EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID)).toEqual([
       EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
     ]);
+    expect(resolveGemmaclawEnhancementIds(COMMITMENT_FOLLOWTHROUGH_LOOP_ID)).toEqual([
+      COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+    ]);
+    expect(
+      resolveGemmaclawEnhancementIds(
+        `${EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID},${COMMITMENT_FOLLOWTHROUGH_LOOP_ID}`,
+      ),
+    ).toEqual([EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID, COMMITMENT_FOLLOWTHROUGH_LOOP_ID]);
   });
 
   it("parses workspace enhancement selections for runtime injection", () => {
@@ -67,6 +98,11 @@ describe("gemmaclaw instructions", () => {
         `{"enhancements":["${EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID}"]}`,
       ),
     ).toEqual([EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID]);
+    expect(
+      parseGemmaclawEnhancementSelection(
+        `{"enhancements":["${EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID}","${COMMITMENT_FOLLOWTHROUGH_LOOP_ID}"]}`,
+      ),
+    ).toEqual([EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID, COMMITMENT_FOLLOWTHROUGH_LOOP_ID]);
   });
 
   it("rejects unknown enhancement ids loudly", () => {

--- a/src/gemmaclaw/gemmaclaw_instructions.ts
+++ b/src/gemmaclaw/gemmaclaw_instructions.ts
@@ -1,10 +1,13 @@
 export const EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID =
   "external_delivery_receipt_verification" as const;
+export const COMMITMENT_FOLLOWTHROUGH_LOOP_ID = "commitment_followthrough_loop" as const;
 
 export const GEMMACLAW_INSTRUCTIONS_CONTEXT_PATH = "gemmaclaw_instructions.ts";
 export const GEMMACLAW_ENHANCEMENT_SELECTION_FILENAME = ".gemmaclaw-enhancements.json";
 
-export type GemmaclawEnhancementId = typeof EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID;
+export type GemmaclawEnhancementId =
+  | typeof EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID
+  | typeof COMMITMENT_FOLLOWTHROUGH_LOOP_ID;
 
 export interface GemmaclawEnhancement {
   id: GemmaclawEnhancementId;
@@ -36,6 +39,28 @@ export const GEMMACLAW_ENHANCEMENTS: readonly GemmaclawEnhancement[] = [
       "- Creating a local artifact, writing a script, scheduling a command, or seeing a tool intent is not delivery proof.",
       "- If the receipt is missing, ambiguous, or failed, say the delivery is unverified, keep investigating, and do not tell the user it was sent.",
       "- For scheduled jobs, verify the active scheduler location and the next run or trigger proof, not just a copied config file in the workspace.",
+    ].join("\n"),
+  },
+  {
+    id: COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+    title: "Commitment follow-through loop",
+    category: "prompt",
+    defaultEnabled: true,
+    description:
+      "Require agents to finish promised work inline or create and verify a durable Gemmaclaw-native follow-up before saying they are working on it.",
+    docsPath: "docs/gemmaclaw/enhancements.md",
+    benchmarkIds: ["commitment_followthrough_verification"],
+    instructionMarkdown: [
+      "### Commitment follow-through loop",
+      "",
+      "- Enhancement id: `commitment_followthrough_loop`",
+      "- Guarded by benchmark: `commitment_followthrough_verification`",
+      "- Do not say you are `on it`, `will fix it`, `will get it sorted`, `will follow up`, or equivalent unless you either finish the work inline in the current turn and verify the result before replying, or create and verify a durable Gemmaclaw-native follow-up that can resume without the user repeating the request.",
+      "- Gemmaclaw-native follow-up means a local scheduler entry, local task/todo/work record, or Gemmaclaw subagent/session mechanism available in this runtime. Do not assume external ACP workers, private operator queues, or installation-specific infrastructure exists unless this installation explicitly provides it.",
+      "- A durable follow-up record must include the title, reason, exact next action, owner/runtime, wake time or subagent/session id, verification command or artifact, and creation timestamp.",
+      "- After making a commitment, reply only after the work is complete or after the durable follow-up has been read back and verified. The reply must say what was completed, or where and when the local follow-up will resume.",
+      "- If scheduler, tool, filesystem, or subagent access fails, say the work is blocked with the exact evidence and keep the claim truthful. Do not imply background work is underway when no verified follow-up exists.",
+      "- For scheduler repair, inspect active scheduler surfaces before saying a job exists or is fixed: Gemmaclaw/OpenClaw cron config, host crontab or systemd timers when accessible, and the relevant execution logs.",
     ].join("\n"),
   },
 ];

--- a/src/gemmaclaw/provision/bootstrap-profiles.test.ts
+++ b/src/gemmaclaw/provision/bootstrap-profiles.test.ts
@@ -59,8 +59,10 @@ describe("bootstrap-profiles", () => {
       expect(written).not.toContain("## Self-Awareness");
       expect(written).not.toContain("https://github.com/gemmaclaw/gemmaclaw");
       expect(written).not.toContain("external_delivery_receipt_verification");
+      expect(written).not.toContain("commitment_followthrough_loop");
       const selection = fs.readFileSync(path.join(tmpDir, ".gemmaclaw-enhancements.json"), "utf-8");
       expect(selection).toContain("external_delivery_receipt_verification");
+      expect(selection).toContain("commitment_followthrough_loop");
     });
 
     it("writes both AGENTS.md and TOOLS.md for the coding profile", () => {
@@ -74,8 +76,12 @@ describe("bootstrap-profiles", () => {
       expect(written).not.toContain("## Self-Awareness");
       expect(written).not.toContain("https://github.com/gemmaclaw/gemmaclaw");
       expect(written).not.toContain("external_delivery_receipt_verification");
+      expect(written).not.toContain("commitment_followthrough_loop");
       expect(fs.readFileSync(path.join(tmpDir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
         "external_delivery_receipt_verification",
+      );
+      expect(fs.readFileSync(path.join(tmpDir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
+        "commitment_followthrough_loop",
       );
     });
 
@@ -114,8 +120,12 @@ describe("bootstrap-profiles", () => {
       expect(result.written).toContain("AGENTS.md");
       const written = fs.readFileSync(path.join(tmpDir, "AGENTS.md"), "utf-8");
       expect(written).not.toContain("external_delivery_receipt_verification");
+      expect(written).not.toContain("commitment_followthrough_loop");
       expect(fs.readFileSync(path.join(tmpDir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
         "external_delivery_receipt_verification",
+      );
+      expect(fs.readFileSync(path.join(tmpDir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
+        "commitment_followthrough_loop",
       );
       expect(written).toContain("## Docker Sandbox Environment");
       expect(written).toContain("/workspace/shared");
@@ -128,6 +138,7 @@ describe("bootstrap-profiles", () => {
       const written = fs.readFileSync(path.join(tmpDir, "AGENTS.md"), "utf-8");
       expect(written).not.toContain("## Gemmaclaw Instructions");
       expect(written).not.toContain("external_delivery_receipt_verification");
+      expect(written).not.toContain("commitment_followthrough_loop");
       expect(written).toContain("You are a helpful Gemma-powered assistant");
       expect(fs.readFileSync(path.join(tmpDir, ".gemmaclaw-enhancements.json"), "utf-8")).toContain(
         '"enhancements": []',

--- a/src/gemmaclaw/provision/onboarding-wizard.test.ts
+++ b/src/gemmaclaw/provision/onboarding-wizard.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID } from "../gemmaclaw_instructions.js";
+import {
+  COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+  EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+} from "../gemmaclaw_instructions.js";
 import {
   buildNonInteractiveChoices,
   defaultModelFor,
@@ -11,6 +14,11 @@ import {
   validateAgentName,
   type WizardIO,
 } from "./onboarding-wizard.js";
+
+const DEFAULT_ENHANCEMENTS = [
+  EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+  COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+];
 
 /**
  * Build a scripted WizardIO that pops one queued response per `prompt()` call
@@ -143,7 +151,7 @@ describe("runOnboardingWizard", () => {
       model: "auto",
       thinkingLevel: "medium",
       bootstrap: "general",
-      enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID],
+      enhancements: DEFAULT_ENHANCEMENTS,
       apiKey: undefined,
     });
 
@@ -242,7 +250,7 @@ describe("runOnboardingWizard", () => {
     expect(choices.model).toBe("gemma-3-4b-it"); // first vertex choice
     expect(choices.thinkingLevel).toBe("medium");
     expect(choices.bootstrap).toBe("general");
-    expect(choices.enhancements).toEqual([EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID]);
+    expect(choices.enhancements).toEqual(DEFAULT_ENHANCEMENTS);
     expect(prompts).toHaveLength(4);
   });
 
@@ -283,7 +291,7 @@ describe("buildNonInteractiveChoices", () => {
       model: "auto",
       thinkingLevel: "medium",
       bootstrap: "general",
-      enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID],
+      enhancements: DEFAULT_ENHANCEMENTS,
       apiKey: undefined,
     });
   });
@@ -325,7 +333,7 @@ describe("formatChoicesSummary", () => {
       model: "gemma3:4b",
       thinkingLevel: "high",
       bootstrap: "coding",
-      enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID],
+      enhancements: DEFAULT_ENHANCEMENTS,
     });
     const text = summary.join("\n");
     expect(text).toContain("Agent name:");
@@ -349,7 +357,7 @@ describe("formatNextSteps", () => {
         model: "auto",
         thinkingLevel: "medium",
         bootstrap: "general",
-        enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID],
+        enhancements: DEFAULT_ENHANCEMENTS,
       },
       "http://127.0.0.1:8765/",
     );
@@ -388,7 +396,7 @@ describe("gemmaclaw home path branding", () => {
     model: "auto",
     thinkingLevel: "medium" as const,
     bootstrap: "general" as const,
-    enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID],
+    enhancements: DEFAULT_ENHANCEMENTS,
   };
 
   it("formatNextSteps does not mention .openclaw", () => {


### PR DESCRIPTION
## Summary
- add default Gemmaclaw enhancement `commitment_followthrough_loop` so agents finish promised work inline or create a verified Gemmaclaw-native follow-up before replying
- add `commitment_followthrough_verification` benchmark task and mock gog fixtures for the missed-scheduler/promise failure class
- update enhancements docs, generated site page, and benchmark docs with direct GitHub source links and explicit benchmark enhancement flags

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/gemmaclaw/gemmaclaw_instructions.test.ts src/gemmaclaw/benchmark/agent-tasks.test.ts src/gemmaclaw/benchmark/agent-runner.test.ts src/gemmaclaw/provision/bootstrap-profiles.test.ts src/gemmaclaw/provision/onboarding-wizard.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`
- `bash scripts/site/check-site-quality.sh`
- `git diff --check`