### PR TITLE
Fix Gemmaclaw source checkout updates

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -114,9 +114,12 @@ describe("runGatewayUpdate", () => {
     };
   }
 
-  async function setupGitCheckout(options?: { packageManager?: string }) {
+  async function setupGitCheckout(options?: { packageManager?: string; packageName?: string }) {
     await fs.mkdir(path.join(tempDir, ".git"));
-    const pkg: Record<string, string> = { name: "openclaw", version: "1.0.0" };
+    const pkg: Record<string, string> = {
+      name: options?.packageName ?? "openclaw",
+      version: "1.0.0",
+    };
     if (options?.packageManager) {
       pkg.packageManager = options.packageManager;
     }
@@ -1558,6 +1561,31 @@ describe("runGatewayUpdate", () => {
     expect(result.status).toBe("error");
     expect(result.reason).toBe("not-openclaw-root");
     expect(calls.some((call) => call.includes("status --porcelain"))).toBe(false);
+  });
+
+  it("accepts gemmaclaw source checkout roots for git updates", async () => {
+    await setupGitCheckout({ packageManager: "pnpm@8.0.0", packageName: "gemmaclaw" });
+    await setupUiIndex();
+
+    const stableTag = "v1.0.1-1";
+    const { runner, calls } = createRunner({
+      ...buildStableTagResponses(stableTag),
+      "pnpm install": { stdout: "" },
+      "pnpm build": { stdout: "" },
+      "pnpm ui:build": { stdout: "" },
+      [`${await resolveStableNodePath(process.execPath)} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`]:
+        { stdout: "" },
+      [`${await resolveStableNodePath(process.execPath)} ${path.join(tempDir, "openclaw.mjs")} gateway restart`]:
+        { stdout: "" },
+    });
+
+    const result = await runWithRunner(runner, { channel: "stable" });
+
+    expect(result.status).toBe("ok");
+    expect(result.mode).toBe("git");
+    expect(calls.some((call) => call === `git -C ${tempDir} checkout --detach ${stableTag}`)).toBe(
+      true,
+    );
   });
 
   it("fails with a clear reason when openclaw.mjs is missing", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -137,7 +137,8 @@ const MAX_LOG_CHARS = 8000;
 const PREFLIGHT_MAX_COMMITS = 10;
 const START_DIRS = ["cwd", "argv1", "process"];
 const DEFAULT_PACKAGE_NAME = "openclaw";
-const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME]);
+const GEMMACLAW_PACKAGE_NAME = "gemmaclaw";
+const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME, GEMMACLAW_PACKAGE_NAME]);
 const PREFLIGHT_TEMP_PREFIX =
   process.platform === "win32" ? "ocu-pf-" : "openclaw-update-preflight-";
 const PREFLIGHT_WORKTREE_DIRNAME = process.platform === "win32" ? "wt" : "worktree";


### PR DESCRIPTION
## Summary
- Allow the updater to recognize Gemmaclaw source checkouts as valid core roots, not only OpenClaw package roots.
- Add regression coverage so gemmaclaw package roots can run the git update flow.

## Validation
- `pnpm test src/infra/update-runner.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`

## Context
Found while validating PR #228 end to end on Jake: the source-checkout updater dry-run detected the git flow, but the live update rejected the gemmaclaw package root with `not-openclaw-root`.