### PR TITLE
Allow skipping dev update preflight lint

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -102,7 +102,7 @@ High-level:
 1. Requires a clean worktree (no uncommitted changes).
 2. Switches to the selected channel (tag or branch).
 3. Fetches upstream (dev only).
-4. Dev only: preflight lint + TypeScript build in a temp worktree; if the tip fails, walks back up to 10 commits to find the newest clean build.
+4. Dev only: preflight lint + TypeScript build in a temp worktree; if the tip fails, walks back up to 10 commits to find the newest clean build. On resource-constrained source hosts, set `OPENCLAW_UPDATE_SKIP_DEV_PREFLIGHT_LINT=1` to keep the dev preflight to dependency install and build only.
 5. Rebases onto the selected commit (dev only).
 6. Installs deps with the repo package manager. For pnpm checkouts, the updater bootstraps `pnpm` on demand (via `corepack` first, then a temporary `npm install pnpm@10` fallback) instead of running `npm run build` inside a pnpm workspace.
 7. Builds + builds the Control UI.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -152,6 +152,7 @@ To return to latest: `git checkout main && git pull`.
 
 - Run `openclaw doctor` again and read the output carefully.
 - For `openclaw update --channel dev` on source checkouts, the updater auto-bootstraps `pnpm` when needed. If you see a pnpm/corepack bootstrap error, install `pnpm` manually (or re-enable `corepack`) and rerun the update.
+- For low-memory source hosts, `OPENCLAW_UPDATE_SKIP_DEV_PREFLIGHT_LINT=1 openclaw update --channel dev` skips only the heavyweight dev preflight lint. The update still installs dependencies, builds, runs doctor, syncs plugins, and restarts unless you also pass `--no-restart`.
 - Check: [Troubleshooting](/gateway/troubleshooting)
 - Ask in Discord: [https://discord.gg/clawd](https://discord.gg/clawd)
 

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -591,6 +591,94 @@ describe("runGatewayUpdate", () => {
     expect(pnpmEnvPaths.some((value) => value.includes("openclaw-update-pnpm-"))).toBe(true);
   });
 
+  it("can skip dev preflight lint for resource-constrained source update hosts", async () => {
+    await setupGitPackageManagerFixture();
+    const calls: string[] = [];
+    const upstreamSha = "upstream123";
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      calls.push(key);
+
+      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
+        return { stdout: tempDir, stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} rev-parse HEAD`) {
+        return { stdout: "abc123", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
+        return { stdout: "main", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
+        return { stdout: "origin/main", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
+        return { stdout: upstreamSha, stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
+        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
+      }
+      if (key === "pnpm --version") {
+        return { stdout: "10.0.0", stderr: "", code: 0 };
+      }
+      if (
+        key.startsWith(`git -C ${tempDir} worktree add --detach /tmp/`) &&
+        key.endsWith(` ${upstreamSha}`) &&
+        preflightPrefixPattern.test(key)
+      ) {
+        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
+      }
+      if (
+        key.startsWith("git -C /tmp/") &&
+        preflightPrefixPattern.test(key) &&
+        key.includes(" checkout --detach ") &&
+        key.endsWith(upstreamSha)
+      ) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm ui:build") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (
+        key.startsWith(`git -C ${tempDir} worktree remove --force /tmp/`) &&
+        preflightPrefixPattern.test(key)
+      ) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} worktree prune`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === doctorCommand) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await withEnvAsync({ OPENCLAW_UPDATE_SKIP_DEV_PREFLIGHT_LINT: "1" }, async () => {
+      const result = await runWithCommand(runCommand, { channel: "dev" });
+
+      expect(result.status).toBe("ok");
+      expect(calls).toContain("pnpm install");
+      expect(calls).toContain("pnpm build");
+      expect(calls).toContain("pnpm ui:build");
+      expect(calls).not.toContain("pnpm lint");
+      expect(result.steps.map((step) => step.name)).not.toContain(
+        `preflight lint (${upstreamSha.slice(0, 8)})`,
+      );
+    });
+  });
+
   it("retries windows pnpm git installs with --ignore-scripts for dev updates", async () => {
     await setupGitPackageManagerFixture();
     const calls: string[] = [];

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -6,6 +6,7 @@ import {
   resolveControlUiDistIndexHealth,
   resolveControlUiDistIndexPathForRoot,
 } from "./control-ui-assets.js";
+import { isTruthyEnvValue } from "./env.js";
 import { readPackageName, readPackageVersion } from "./package-json.js";
 import { normalizePackageTagInput } from "./package-tag.js";
 import { trimLogTail } from "./restart-sentinel.js";
@@ -139,6 +140,7 @@ const START_DIRS = ["cwd", "argv1", "process"];
 const DEFAULT_PACKAGE_NAME = "openclaw";
 const GEMMACLAW_PACKAGE_NAME = "gemmaclaw";
 const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME, GEMMACLAW_PACKAGE_NAME]);
+const SKIP_DEV_PREFLIGHT_LINT_ENV = "OPENCLAW_UPDATE_SKIP_DEV_PREFLIGHT_LINT";
 const PREFLIGHT_TEMP_PREFIX =
   process.platform === "win32" ? "ocu-pf-" : "openclaw-update-preflight-";
 const PREFLIGHT_WORKTREE_DIRNAME = process.platform === "win32" ? "wt" : "worktree";
@@ -538,6 +540,9 @@ function mergeCommandEnvironments(
 }
 
 function shouldRunDevPreflightLint(): boolean {
+  if (isTruthyEnvValue(process.env[SKIP_DEV_PREFLIGHT_LINT_ENV])) {
+    return false;
+  }
   return process.platform !== "win32";
 }
 


### PR DESCRIPTION
## Summary
- Add `OPENCLAW_UPDATE_SKIP_DEV_PREFLIGHT_LINT=1` for dev-channel source updates so low-memory hosts can skip only the heavyweight temporary-worktree lint preflight.
- Keep dependency install, build, doctor, plugin sync, and restart behavior intact.
- Document the flag in update docs.

## Validation
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/infra/update-runner.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`

## Context
Found while validating Jake end to end after PR #228/#229. The source update path entered the dev preflight, spawned type-aware lint in a temporary worktree, and overloaded the 8GB Pi enough that SSH, Tailscale ping, and health checks stopped responding. This gives source-checkout installations a supported low-memory update path instead of requiring ad hoc manual updates.