### PR TITLE
Add ffmpeg to Gemmaclaw sandbox defaults

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -12,6 +12,7 @@ RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/
     bash \
     ca-certificates \
     curl \
+    ffmpeg \
     git \
     jq \
     python3 \

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -7,7 +7,7 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG PACKAGES="curl wget jq coreutils grep nodejs npm python3 git ca-certificates golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file"
+ARG PACKAGES="curl wget jq coreutils grep nodejs npm python3 git ca-certificates ffmpeg golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file"
 ARG INSTALL_PNPM=1
 ARG INSTALL_BUN=1
 ARG BUN_INSTALL_DIR=/opt/bun

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -351,7 +351,8 @@ Build it once:
 scripts/sandbox-setup.sh
 ```
 
-Note: the default image does **not** include Node. If a skill needs Node (or
+Note: the default image includes basic shell tools plus Python and `ffmpeg`,
+but it does **not** include Node. If a skill needs Node (or
 other runtimes), either bake a custom image or install via
 `sandbox.docker.setupCommand` (requires network egress + writable root +
 root user).

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -464,7 +464,7 @@ describe("setupGemmaCommand — agent creation", () => {
         capDrop: [],
         setupCommand:
           "apt-get -o APT::Sandbox::User=root update && " +
-          "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 && " +
+          "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 ffmpeg && " +
           "printf '\\numask 000\\n' >> /etc/profile && " +
           "rm -rf /var/lib/apt/lists/*",
         user: "0:0",

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -87,7 +87,7 @@ function buildGemmaclawDockerSandboxConfig(): NonNullable<
       capDrop: [],
       setupCommand: [
         "apt-get -o APT::Sandbox::User=root update",
-        "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3",
+        "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 ffmpeg",
         "printf '\\numask 000\\n' >> /etc/profile",
         "rm -rf /var/lib/apt/lists/*",
       ].join(" && "),

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -6,6 +6,8 @@ import { BUNDLED_PLUGIN_ROOT_DIR } from "../test/helpers/bundled-plugin-paths.js
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
+const sandboxDockerfilePath = join(repoRoot, "Dockerfile.sandbox");
+const sandboxCommonDockerfilePath = join(repoRoot, "Dockerfile.sandbox-common");
 const dockerReleaseWorkflowPath = join(repoRoot, ".github/workflows/docker-release.yml");
 
 function collapseDockerContinuations(dockerfile: string): string {
@@ -104,5 +106,15 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       'corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate',
     );
+  });
+
+  it("includes video decoding tools in sandbox images", async () => {
+    const sandboxDockerfile = await readFile(sandboxDockerfilePath, "utf8");
+    const sandboxCommonDockerfile = await readFile(sandboxCommonDockerfilePath, "utf8");
+
+    expect(sandboxDockerfile).toMatch(
+      /apt-get install -y --no-install-recommends[\s\S]*\bffmpeg\b/,
+    );
+    expect(sandboxCommonDockerfile).toMatch(/ARG PACKAGES=.*\bffmpeg\b/);
   });
 });


### PR DESCRIPTION
## Summary
- add ffmpeg to the Gemmaclaw Docker sandbox setup command so sandboxed agents can decode video media
- include ffmpeg in default sandbox Dockerfiles
- add Dockerfile regression coverage and update sandbox docs

## Verification
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/commands/setup-gemma.test.ts src/dockerfile.test.ts src/media/ffmpeg-exec.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
- GEMMACLAW_LOCAL_AGENT_SMOKE_REQUIRED=1 GEMMACLAW_LOCAL_AGENT_SMOKE_MODEL=gemma-4-26B-A4B-it-Q4_K_M pnpm test:docker:gemmaclaw-setup-live-smoke

## Notes
- The first setup live smoke preflight with the old default dense model failed because `gemma-4-31B-it-Q4_K_M` is no longer the active local default. Frank confirmed the MoE model is the default until further notice, so the required smoke was rerun against `gemma-4-26B-A4B-it-Q4_K_M` and passed.
