### PR TITLE
maintenance: selective upstream openclaw sync 2026-05-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+### Fixes
+
+- Models/OpenRouter: use endpoint-specific OpenRouter context limits from `top_provider` metadata so provider-routed models no longer overstate available context. (#85949) Thanks @TurboTheTurtle.
+
+## 2026.5.24
+
+### Changes
+
 - Gateway/perf: reuse process-stable channel catalog reads, avoid repeated bundled-channel boundary checks, and rotate gateway watch CPU profiles so benchmark runs do not accumulate unbounded artifacts.
 - Gateway/perf: reuse immutable plugin metadata snapshots across startup, config, model, channel, setup, and secret metadata readers so hot paths avoid repeated plugin file stats and manifest registry reloads.
 - Gateway/perf: lazy-load startup-idle plugin work, core gateway method handlers, and the embedded ACPX runtime so Gateway health and ready signals no longer wait on unused handler trees or ACPX probes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Models/OpenRouter: use endpoint-specific OpenRouter context limits from `top_provider` metadata so provider-routed models no longer overstate available context. (#85949) Thanks @TurboTheTurtle.
+- Crabbox: sync clean sparse-checkout remote changed gates from a temporary full checkout with local-only commits overlaid as worktree changes so git-backed script checks can seed the runner repository.
+- Agents: avoid loading bundled channel plugins while resolving completion delivery policy and queue defaults on subagent handoff paths.
+- Tests: allow split Vitest config shards through the explicit-target preflight so CI shard jobs run their intended projects.
+- Tests: make startup memory and startup bench smoke scripts build CLI startup artifacts when run from a fresh source checkout.
+- iMessage: mark authorized slash-command turns as text-sourced commands so `/status`, `/new`, and `/restart` acknowledgements return to the source conversation. (#82642) thanks @homer-byte.
+- Crabbox: install Corepack shims into the writable hydration `PNPM_HOME` so local AWS runner hydration no longer tries to overwrite `/usr/local/bin/pnpm`.
+- Live tests: fail Gateway live model sweeps when selected coverage is lost to timeouts or stale high-signal filters instead of reporting false missing-profile coverage, and pin Docker OpenAI gateway coverage to the current `gpt-5.5` lane.
+- Tests: fail Docker resource-ceiling checks when stats samples or configured limits are invalid instead of silently reporting zero peaks.
+- Agents: fail closed when provider-less session models match multiple provider-prefixed runtime policies so CLI runtime routing no longer depends on config order. (#85970) Thanks @potterdigital.
 
 ## 2026.5.24
 

--- a/scripts/npm-runner.d.mts
+++ b/scripts/npm-runner.d.mts
@@ -1,0 +1,16 @@
+export type NpmRunnerParams = {
+  comSpec?: string;
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  existsSync?: (path: string) => boolean;
+  npmArgs?: string[];
+  platform?: NodeJS.Platform;
+};
+
+export function resolveNpmRunner(params?: NpmRunnerParams): {
+  args: string[];
+  command: string;
+  env?: NodeJS.ProcessEnv;
+  shell: boolean;
+  windowsVerbatimArguments?: boolean;
+};

--- a/scripts/pnpm-runner.d.mts
+++ b/scripts/pnpm-runner.d.mts
@@ -1,0 +1,30 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+
+export type PnpmRunnerParams = {
+  comSpec?: string;
+  cwd?: string;
+  detached?: boolean;
+  env?: NodeJS.ProcessEnv;
+  nodeArgs?: string[];
+  nodeExecPath?: string;
+  npmExecPath?: string;
+  platform?: NodeJS.Platform;
+  pnpmArgs?: string[];
+  stdio?: SpawnOptions["stdio"];
+};
+
+export function resolvePnpmRunner(params?: PnpmRunnerParams): {
+  args: string[];
+  command: string;
+  env?: NodeJS.ProcessEnv;
+  shell: boolean;
+  windowsVerbatimArguments?: boolean;
+};
+
+export function createPnpmRunnerSpawnSpec(params?: PnpmRunnerParams): {
+  args: string[];
+  command: string;
+  options: SpawnOptions;
+};
+
+export function spawnPnpmRunner(params?: PnpmRunnerParams): ChildProcess;

--- a/scripts/windows-cmd-helpers.d.mts
+++ b/scripts/windows-cmd-helpers.d.mts
@@ -1,0 +1,3 @@
+export function resolvePathEnvKey(env: NodeJS.ProcessEnv): string;
+
+export function buildCmdExeCommandLine(command: string, args: string[]): string;

--- a/src/agents/compaction-partial-summary.test.ts
+++ b/src/agents/compaction-partial-summary.test.ts
@@ -1,0 +1,262 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const compactionMocks = vi.hoisted(() => {
+  function readText(value: unknown): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map(readText).join("");
+    }
+    if (value && typeof value === "object") {
+      const record = value as { text?: unknown; content?: unknown; arguments?: unknown };
+      return `${readText(record.text)}${readText(record.content)}${readText(record.arguments)}`;
+    }
+    return "";
+  }
+  return {
+    estimateTokens: vi.fn((message: unknown) =>
+      Math.max(1, Math.ceil(readText(message).length / 4)),
+    ),
+    generateSummary: vi.fn(),
+    logWarn: vi.fn(),
+  };
+});
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
+    "@mariozechner/pi-coding-agent",
+  );
+  return {
+    ...actual,
+    estimateTokens: compactionMocks.estimateTokens,
+    generateSummary: compactionMocks.generateSummary,
+  };
+});
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: compactionMocks.logWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  }),
+}));
+
+// Mock retryAsync to bypass retry delays while preserving the single-call semantic.
+// summarizeChunks wraps generateSummary in retryAsync with 500-5000 ms delays;
+// eliminating them keeps tests fast without altering the catch-block behavior under test.
+vi.mock("../infra/retry.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/retry.js")>("../infra/retry.js");
+  return {
+    ...actual,
+    retryAsync: async <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+let summarizeWithFallback: typeof import("./compaction.js").summarizeWithFallback;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ summarizeWithFallback } = await import("./compaction.js"));
+});
+
+describe("summarizeChunks partial summary preservation (#82952)", () => {
+  const testModel = {
+    id: "test",
+    name: "test",
+    contextWindow: 200_000,
+    contextTokens: 200_000,
+    maxTokens: 8192,
+  } as unknown as NonNullable<ExtensionContext["model"]>;
+
+  // Two messages sized to split into two chunks with maxChunkTokens=150.
+  // Each message is ~100 tokens (400 chars / 4), and effectiveMax = floor(150/1.2) = 125.
+  const twoChunkMessages: AgentMessage[] = [
+    { role: "user", content: "x".repeat(400), timestamp: 1 },
+    { role: "user", content: "y".repeat(400), timestamp: 2 },
+  ];
+
+  function callSummarize(messages = twoChunkMessages) {
+    return summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 150,
+      contextWindow: 200_000,
+    });
+  }
+
+  beforeEach(() => {
+    compactionMocks.generateSummary.mockReset();
+    compactionMocks.logWarn.mockClear();
+  });
+
+  it("returns partial summary when a later chunk fails with a non-abort error", async () => {
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(new Error("API quota exceeded"));
+
+    const result = await callSummarize();
+
+    expect(result).toContain("Summary of chunk 1");
+    expect(result).toContain("[Partial summary:");
+    expect(result).toMatch(/chunks 1-1 of 2 were summarized/);
+    expect(compactionMocks.logWarn).toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.objectContaining({ err: expect.any(Error) }),
+    );
+  });
+
+  it("re-throws abort errors instead of returning partial summary", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(abortErr);
+
+    const result = await callSummarize();
+
+    // Abort error propagates from summarizeChunks; summarizeWithFallback catches it
+    // and falls through to the final fallback (not the partial summary).
+    expect(result).not.toBe("Summary of chunk 1");
+    expect(result).toContain("Context contained");
+    expect(compactionMocks.logWarn).not.toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.anything(),
+    );
+  });
+
+  it("re-throws timeout errors instead of returning partial summary", async () => {
+    const timeoutErr = new Error("request timed out");
+    timeoutErr.name = "TimeoutError";
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(timeoutErr);
+
+    const result = await callSummarize();
+
+    expect(result).not.toBe("Summary of chunk 1");
+    expect(result).toContain("Context contained");
+    expect(compactionMocks.logWarn).not.toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.anything(),
+    );
+  });
+
+  it("returns the full final summary when all chunks succeed", async () => {
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockResolvedValueOnce("Combined summary of chunks 1+2");
+
+    const result = await callSummarize();
+
+    expect(result).toBe("Combined summary of chunks 1+2");
+    expect(compactionMocks.generateSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to default when the first chunk fails (no partial to recover)", async () => {
+    compactionMocks.generateSummary.mockRejectedValue(new Error("network error"));
+
+    const result = await callSummarize();
+
+    // With no successful chunk, summarizeChunks rethrows into
+    // summarizeWithFallback's outer catch -> final fallback path.
+    expect(result).toContain("Context contained");
+    expect(result).not.toBe("Summary of chunk 1");
+  });
+
+  it("tries oversized-message retry before falling back to partial summary", async () => {
+    // Scenario: chunk 1 (small) succeeds, chunk 2 (has oversized message) fails.
+    // summarizeWithFallback should try the non-oversized retry, which may
+    // recover more content than the partial summary alone.
+    const mixedMessages: AgentMessage[] = [
+      // Small message (chunk 1)
+      { role: "user", content: "Short question about code", timestamp: 1 },
+      // Oversized message (will be in chunk 2, triggers the oversized retry)
+      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 } as unknown as AgentMessage,
+      // Small message after oversized (should be recovered by oversized retry)
+      { role: "user", content: "Follow-up question", timestamp: 3 },
+    ];
+
+    compactionMocks.generateSummary
+      // Call 1: chunk 1 of full attempt (success)
+      .mockResolvedValueOnce("Summary of chunk 1")
+      // Call 2: chunk 2 of full attempt (fails - oversized message)
+      .mockRejectedValueOnce(new Error("context too long"))
+      // Call 3: oversized retry with small messages only (succeeds!)
+      .mockResolvedValueOnce("Summary of small messages (oversized retry)");
+
+    const result = await callSummarize(mixedMessages);
+
+    // The oversized retry should have recovered more content than
+    // the partial summary from chunk 1 alone.
+    expect(result).toContain("Summary of small messages (oversized retry)");
+    // The partial summary should NOT be the final result because the
+    // oversized retry succeeded.
+    expect(result).not.toContain("[Partial summary:");
+  });
+
+  it("prefers oversized retry partial summary over full attempt partial", async () => {
+    // Scenario: full attempt's chunk 1 succeeds, chunk 2 (oversized) fails.
+    // Oversized retry (small messages only) chunk 1 succeeds, chunk 2 fails.
+    // The oversized retry's partial summary should be preferred because it
+    // covers the non-oversized transcript.
+    const mixedMessages: AgentMessage[] = [
+      { role: "user", content: "Short question", timestamp: 1 },
+      // Oversized message that will be filtered in the retry
+      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 } as unknown as AgentMessage,
+      { role: "user", content: "a".repeat(400), timestamp: 3 },
+      { role: "user", content: "b".repeat(400), timestamp: 4 },
+    ];
+
+    compactionMocks.generateSummary
+      // Full attempt: chunk 1 succeeds, chunk 2 fails (oversized message)
+      .mockResolvedValueOnce("Full attempt chunk 1")
+      .mockRejectedValueOnce(new Error("context too long"))
+      // Oversized retry: chunk 1 succeeds, chunk 2 also fails
+      .mockResolvedValueOnce("Oversized retry chunk 1 (better coverage)")
+      .mockRejectedValue(new Error("rate limited on retry"));
+
+    const result = await callSummarize(mixedMessages);
+
+    // The oversized retry's partial summary should win, with oversized notes
+    expect(result).toContain("Oversized retry chunk 1 (better coverage)");
+    expect(result).toContain("[Partial summary:");
+    expect(result).toContain("[Large assistant");
+    expect(result).toContain("omitted from summary]");
+  });
+
+  it("preserves the latest successful summary in a 3+ chunk chain", async () => {
+    const threeChunkMessages: AgentMessage[] = [
+      { role: "user", content: "a".repeat(400), timestamp: 1 },
+      { role: "user", content: "b".repeat(400), timestamp: 2 },
+      { role: "user", content: "c".repeat(400), timestamp: 3 },
+    ];
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary after chunk 1")
+      .mockResolvedValueOnce("Summary after chunks 1+2")
+      .mockRejectedValue(new Error("rate limited"));
+
+    const result = await callSummarize(threeChunkMessages);
+
+    // Chunk 3 failed -> partial summary from chunk 2 is returned with marker.
+    expect(result).toContain("Summary after chunks 1+2");
+    expect(result).toMatch(/\[Partial summary: chunks 1-2 of 3 were summarized/);
+    expect(compactionMocks.generateSummary).toHaveBeenCalledTimes(3);
+    expect(compactionMocks.logWarn).toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.objectContaining({ completedChunks: 2, totalChunks: 3 }),
+    );
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -11,6 +11,8 @@ import { isAbortError } from "../infra/unhandled-rejections.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { isTimeoutError } from "./failover-error.js";
+
+type PartialSummaryError = Error & { partialSummary?: string };
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
 
@@ -313,28 +315,56 @@ async function summarizeChunks(params: {
     params.customInstructions,
     params.summarizationInstructions,
   );
+  let hasGeneratedChunk = false;
   for (const chunk of chunks) {
-    summary = await retryAsync(
-      () =>
-        generateSummary(
-          chunk,
-          params.model,
-          params.reserveTokens,
-          params.apiKey,
-          params.headers,
-          params.signal,
-          effectiveInstructions,
-          summary,
-        ),
-      {
-        attempts: 3,
-        minDelayMs: 500,
-        maxDelayMs: 5000,
-        jitter: 0.2,
-        label: "compaction/generateSummary",
-        shouldRetry: (err) => !isAbortError(err) && !isTimeoutError(err),
-      },
-    );
+    try {
+      summary = await retryAsync(
+        () =>
+          generateSummary(
+            chunk,
+            params.model,
+            params.reserveTokens,
+            params.apiKey,
+            params.headers,
+            params.signal,
+            effectiveInstructions,
+            summary,
+          ),
+        {
+          attempts: 3,
+          minDelayMs: 500,
+          maxDelayMs: 5000,
+          jitter: 0.2,
+          label: "compaction/generateSummary",
+          shouldRetry: (err) => !isAbortError(err) && !isTimeoutError(err),
+        },
+      );
+      hasGeneratedChunk = true;
+    } catch (err) {
+      // Abort and timeout errors always propagate immediately.
+      if (isAbortError(err) || isTimeoutError(err)) {
+        throw err;
+      }
+      // No chunk has succeeded yet — rethrow so summarizeWithFallback
+      // can run its existing "Context contained N messages" fallback.
+      if (!hasGeneratedChunk) {
+        throw err;
+      }
+      // At least one chunk succeeded — throw with the partial summary
+      // attached so summarizeWithFallback can try the oversized-message
+      // retry first and only fall back to the partial summary if that
+      // also fails.
+      const completedChunks = chunks.indexOf(chunk);
+      log.warn("chunk summarization failed after retries; partial summary available", {
+        err,
+        completedChunks,
+        totalChunks: chunks.length,
+      });
+      const partial = new Error("partial summarization failure");
+      (partial as PartialSummaryError).partialSummary =
+        `${summary!}\n\n[Partial summary: chunks 1-${completedChunks} of ${chunks.length} were summarized. Chunks ${completedChunks + 1}-${chunks.length} could not be processed.]`;
+      throw partial;
+    }
   }
 
   return summary ?? DEFAULT_SUMMARY_FALLBACK;
@@ -397,10 +427,12 @@ export async function summarizeWithFallback(params: {
   }
 
   // Try full summarization first
+  let partialSummaryFallback: string | undefined;
   try {
     return await summarizeChunks(params);
   } catch (fullError) {
     log.warn(`Full summarization failed: ${formatErrorMessage(fullError)}`);
+    partialSummaryFallback = (fullError as PartialSummaryError).partialSummary;
   }
 
   // Fallback 1: Summarize only small messages, note oversized ones
@@ -431,10 +463,21 @@ export async function summarizeWithFallback(params: {
       return partialSummary + notes;
     } catch (partialError) {
       log.warn(`Partial summarization also failed: ${formatErrorMessage(partialError)}`);
+      // Prefer the oversized retry's partial summary over the full attempt's,
+      // since it covers the non-oversized transcript. Append oversized notes
+      // so the model knows large content was filtered.
+      const retryPartial = (partialError as PartialSummaryError).partialSummary;
+      if (retryPartial) {
+        const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
+        partialSummaryFallback = retryPartial + notes;
+      }
     }
   }
 
-  // Final fallback: Just note what was there
+  // Final fallback: use best available partial summary, otherwise generic note
+  if (partialSummaryFallback) {
+    return partialSummaryFallback;
+  }
   return (
     `Context contained ${messages.length} messages (${oversizedNotes.length} oversized). ` +
     `Summary unavailable due to size limits.`

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -11,10 +11,6 @@ vi.mock("./auth-profiles/store.js", () => ({
   loadAuthProfileStoreForRuntime: vi.fn(),
 }));
 
-vi.mock("./auth-profiles/source-check.js", () => ({
-  hasAnyAuthProfileStoreSource: vi.fn(),
-}));
-
 vi.mock("./auth-profiles/usage.js", () => ({
   getSoonestCooldownExpiry: vi.fn(),
   isProfileInCooldown: vi.fn(),
@@ -23,6 +19,53 @@ vi.mock("./auth-profiles/usage.js", () => ({
 
 vi.mock("./auth-profiles/order.js", () => ({
   resolveAuthProfileOrder: vi.fn(),
+}));
+
+vi.mock("./provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+
+const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+  policyHash: "model-fallback-probe-test-empty-plugin-policy",
+  configFingerprint: "model-fallback-probe-test-empty-plugin-metadata",
+  index: {
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "model-fallback-probe-test-empty-plugin-policy",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins: [],
+    diagnostics: [],
+  },
+  registryDiagnostics: [],
+  manifestRegistry: { plugins: [], diagnostics: [] },
+  plugins: [],
+  diagnostics: [],
+  byPluginId: new Map(),
+  normalizePluginId: (pluginId: string) => pluginId,
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+  metrics: {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 0,
+  },
+}));
+
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
 }));
 
 vi.mock("./auth-profiles/source-check.js", () => ({

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCliRuntimeExecutionProvider } from "./model-runtime-aliases.js";
+
+function createAnthropicAuthConfig(params: {
+  order?: string[];
+  models?: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"];
+}): OpenClawConfig {
+  return {
+    auth: {
+      order: params.order ? { anthropic: params.order } : undefined,
+      profiles: {
+        "anthropic:api": { provider: "anthropic", mode: "api_key" },
+        "anthropic:claude-cli": { provider: "claude-cli", mode: "oauth" },
+      },
+    },
+    agents: {
+      defaults: {
+        models: params.models,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("resolveCliRuntimeExecutionProvider", () => {
+  it("routes Anthropic execution to Claude CLI when the selected auth profile is Claude CLI", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:claude-cli"] }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("keeps direct Anthropic execution when the selected auth profile is direct Anthropic", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({
+          order: ["anthropic:api", "anthropic:claude-cli"],
+        }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("honors an explicit direct Anthropic auth profile over CLI auth order", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        authProfileId: "anthropic:api",
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:claude-cli"] }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses an explicit Claude CLI auth profile without a model-runtime entry", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        authProfileId: "anthropic:claude-cli",
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:api"] }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("does not override an explicit PI model-runtime policy with CLI auth", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({
+          order: ["anthropic:claude-cli"],
+          models: {
+            "anthropic/opus-4.7": { agentRuntime: { id: "pi" } },
+          },
+        }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("matches a configured claude-cli policy when the caller provider is empty", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({
+          models: {
+            "anthropic/opus-4.7": { agentRuntime: { id: "claude-cli" } },
+          },
+        }),
+        provider: "",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("does not return a CLI runtime when the matched entry's provider is incompatible with the runtime alias", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({
+          models: {
+            "openrouter/opus-4.7": { agentRuntime: { id: "claude-cli" } },
+          },
+        }),
+        provider: "",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -187,13 +187,17 @@ function resolveConfiguredRuntime(params: {
   provider: string;
   agentId?: string;
   modelId?: string;
-}): string | undefined {
-  return resolveModelRuntimePolicy({
+}): { runtime?: string; matchedProvider?: string } {
+  const policy = resolveModelRuntimePolicy({
     config: params.cfg,
     provider: params.provider,
     modelId: params.modelId,
     agentId: params.agentId,
-  }).policy?.id?.trim();
+  });
+  return {
+    runtime: policy.policy?.id?.trim() || undefined,
+    matchedProvider: policy.matchedProvider,
+  };
 }
 
 function resolveProfileRuntimeAlias(params: {
@@ -277,12 +281,16 @@ export function resolveCliRuntimeExecutionProvider(params: {
   authProfileId?: string;
 }): string | undefined {
   const provider = normalizeProviderId(params.provider);
-  const runtime = resolveConfiguredRuntime({ ...params, provider });
+  const { runtime, matchedProvider } = resolveConfiguredRuntime({ ...params, provider });
   if (runtime === "pi") {
     return undefined;
   }
   if (!runtime || runtime === "auto") {
     return resolveCliRuntimeFromAuthProfile({ ...params, provider });
   }
-  return CLI_RUNTIME_BY_PROVIDER.get(`${provider}:${runtime}`)?.runtime;
+  const effectiveProvider = provider || normalizeProviderId(matchedProvider ?? "");
+  if (!effectiveProvider) {
+    return undefined;
+  }
+  return CLI_RUNTIME_BY_PROVIDER.get(`${effectiveProvider}:${runtime}`)?.runtime;
 }

--- a/src/agents/model-runtime-policy.test.ts
+++ b/src/agents/model-runtime-policy.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
+
+const ORIGINAL_BUILD_PRIVATE_QA = process.env.OPENCLAW_BUILD_PRIVATE_QA;
+const ORIGINAL_QA_FORCE_RUNTIME = process.env.OPENCLAW_QA_FORCE_RUNTIME;
+
+const createModelConfig = (agentRuntimeId: string): ModelDefinitionConfig => ({
+  id: "qwen-local",
+  name: "Qwen Local",
+  reasoning: false,
+  input: ["text"],
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  },
+  contextWindow: 32_768,
+  maxTokens: 4096,
+  agentRuntime: { id: agentRuntimeId },
+});
+
+function restoreEnv(
+  name: "OPENCLAW_BUILD_PRIVATE_QA" | "OPENCLAW_QA_FORCE_RUNTIME",
+  value: string | undefined,
+): void {
+  if (value == null) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function makeProviderRuntimeConfig(runtime: string): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.example/v1",
+          agentRuntime: { id: runtime },
+          models: [],
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+afterEach(() => {
+  restoreEnv("OPENCLAW_BUILD_PRIVATE_QA", ORIGINAL_BUILD_PRIVATE_QA);
+  restoreEnv("OPENCLAW_QA_FORCE_RUNTIME", ORIGINAL_QA_FORCE_RUNTIME);
+});
+
+describe("resolveModelRuntimePolicy", () => {
+  it("ignores the QA force-runtime override when the private QA gate is unset", () => {
+    delete process.env.OPENCLAW_BUILD_PRIVATE_QA;
+    process.env.OPENCLAW_QA_FORCE_RUNTIME = "pi";
+
+    expect(
+      resolveModelRuntimePolicy({
+        config: makeProviderRuntimeConfig("codex"),
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "provider",
+    });
+  });
+
+  it("respects the QA force-runtime override when the private QA gate is set", () => {
+    process.env.OPENCLAW_BUILD_PRIVATE_QA = "1";
+    process.env.OPENCLAW_QA_FORCE_RUNTIME = "pi";
+
+    expect(
+      resolveModelRuntimePolicy({
+        config: makeProviderRuntimeConfig("codex"),
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+    });
+  });
+
+  it("ignores invalid QA force-runtime values even when the private QA gate is set", () => {
+    process.env.OPENCLAW_BUILD_PRIVATE_QA = "1";
+    process.env.OPENCLAW_QA_FORCE_RUNTIME = "bogus";
+
+    expect(
+      resolveModelRuntimePolicy({
+        config: makeProviderRuntimeConfig("codex"),
+        provider: "openai",
+        modelId: "gpt-5.5",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "provider",
+    });
+  });
+
+  it("honors provider wildcard agent model runtime policy entries", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+      matchedProvider: "vllm",
+    });
+  });
+
+  it("honors provider wildcard agent model runtime policy entries without a concrete model id", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+      matchedProvider: "vllm",
+    });
+  });
+
+  it("prefers exact agent model runtime policy entries over provider wildcards", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+            "vllm/qwen-local": { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "model",
+      matchedProvider: "vllm",
+    });
+  });
+
+  it("prefers exact provider model runtime policy over agent provider wildcards", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            models: [createModelConfig("codex")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "codex" },
+      source: "model",
+    });
+  });
+
+  it("prefers agent provider wildcard runtime policy over provider runtime policy", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/*": { agentRuntime: { id: "pi" } },
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            agentRuntime: { id: "codex" },
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "vllm",
+        modelId: "qwen-local",
+      }),
+    ).toEqual({
+      policy: { id: "pi" },
+      source: "model",
+      matchedProvider: "vllm",
+    });
+  });
+
+  it("matches a provider-prefixed agent model entry when the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-opus-4-7[1m]": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "claude-opus-4-7[1m]",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
+  it("still rejects provider-prefixed entries whose provider disagrees with a non-empty caller provider", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/claude-opus-4-7[1m]": { agentRuntime: { id: "openrouter-stream" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "anthropic",
+        modelId: "claude-opus-4-7[1m]",
+      }),
+    ).toEqual({});
+  });
+
+  it("matches a provider wildcard agent model entry when the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/*": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "claude-opus-4-7[1m]",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
+  it("prefers an agent-specific model entry over a conflicting defaults entry when the caller provider is empty", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/foo-1": { agentRuntime: { id: "codex" } },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            models: {
+              "anthropic/foo-1": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "foo-1",
+        agentId: "main",
+      }),
+    ).toEqual({
+      policy: { id: "claude-cli" },
+      source: "model",
+      matchedProvider: "anthropic",
+    });
+  });
+
+  it("fails closed for duplicate provider-prefixed bare-model policies", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/foo-1": { agentRuntime: { id: "codex" } },
+            "anthropic/foo-1": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/*": { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveModelRuntimePolicy({
+        config,
+        provider: "",
+        modelId: "foo-1",
+      }),
+    ).toEqual({});
+  });
+});

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -11,9 +11,19 @@ export type ModelRuntimePolicySource = "model" | "provider";
 export type ResolvedModelRuntimePolicy = {
   policy?: AgentRuntimePolicyConfig;
   source?: ModelRuntimePolicySource;
+  matchedProvider?: string;
 };
 
 type ModelEntryMatchKind = "none" | "exact" | "provider-wildcard";
+
+type AgentModelRuntimePolicyMatch = {
+  provider: string;
+  policy: AgentRuntimePolicyConfig;
+};
+
+type AgentModelRuntimePolicyResolution = ResolvedModelRuntimePolicy & {
+  ambiguous?: true;
+};
 
 function hasRuntimePolicy(value: AgentRuntimePolicyConfig | undefined): boolean {
   return Boolean(value?.id?.trim());
@@ -60,6 +70,38 @@ function normalizeModelIdForProvider(
   return trimmed.slice(slash + 1).trim() || undefined;
 }
 
+function parseProviderModelKey(key: string): { provider: string; modelId: string } | undefined {
+  const slash = key.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(key.slice(0, slash));
+  const modelId = key.slice(slash + 1).trim();
+  return provider && modelId ? { provider, modelId } : undefined;
+}
+
+function providerMatchesCaller(provider: string, callerProvider: string): boolean {
+  return !callerProvider || provider === callerProvider;
+}
+
+function resolvePolicyMatch(
+  matches: AgentModelRuntimePolicyMatch[],
+  callerProvider: string,
+): AgentModelRuntimePolicyResolution {
+  const [first] = matches;
+  if (!first) {
+    return {};
+  }
+  if (!callerProvider && matches.some((match) => match.provider !== first.provider)) {
+    return { ambiguous: true };
+  }
+  return {
+    policy: first.policy,
+    source: "model",
+    matchedProvider: first.provider || callerProvider,
+  };
+}
+
 function modelEntryMatches(params: {
   entry: Pick<ModelDefinitionConfig, "id">;
   provider: string | undefined;
@@ -77,18 +119,18 @@ function modelEntryMatchKind(params: {
   if (entryId === params.modelId) {
     return "exact";
   }
-  const slash = entryId.indexOf("/");
-  if (slash <= 0) {
+  const parsed = parseProviderModelKey(entryId);
+  if (!parsed) {
     return "none";
   }
-  if (normalizeProviderId(entryId.slice(0, slash)) !== normalizeProviderId(params.provider ?? "")) {
+  const callerProvider = normalizeProviderId(params.provider ?? "");
+  if (!providerMatchesCaller(parsed.provider, callerProvider)) {
     return "none";
   }
-  const entryModelId = entryId.slice(slash + 1).trim();
-  if (entryModelId === params.modelId) {
+  if (parsed.modelId === params.modelId) {
     return "exact";
   }
-  if (entryModelId === "*") {
+  if (parsed.modelId === "*") {
     return "provider-wildcard";
   }
   return "none";
@@ -110,16 +152,12 @@ function modelKeyIsProviderWildcard(params: {
   key: string;
   provider: string | undefined;
 }): boolean {
-  const slash = params.key.indexOf("/");
-  if (slash <= 0) {
+  const parsed = parseProviderModelKey(params.key);
+  if (!parsed) {
     return false;
   }
-  if (
-    normalizeProviderId(params.key.slice(0, slash)) !== normalizeProviderId(params.provider ?? "")
-  ) {
-    return false;
-  }
-  return params.key.slice(slash + 1).trim() === "*";
+  const callerProvider = normalizeProviderId(params.provider ?? "");
+  return parsed.modelId === "*" && providerMatchesCaller(parsed.provider, callerProvider);
 }
 
 function resolveAgentModelEntryRuntimePolicy(params: {
@@ -129,7 +167,7 @@ function resolveAgentModelEntryRuntimePolicy(params: {
   agentId?: string;
   sessionKey?: string;
   matchKind: Exclude<ModelEntryMatchKind, "none">;
-}): ResolvedModelRuntimePolicy {
+}): AgentModelRuntimePolicyResolution {
   const modelId = normalizeModelIdForProvider(params.provider, params.modelId);
   if (!params.config || (!modelId && params.matchKind !== "provider-wildcard")) {
     return {};
@@ -146,14 +184,22 @@ function resolveAgentModelEntryRuntimePolicy(params: {
     agentEntry?.models,
     params.config.agents?.defaults?.models,
   ];
+  const callerProvider = normalizeProviderId(params.provider ?? "");
   for (const models of modelMaps) {
+    const scopeMatches: AgentModelRuntimePolicyMatch[] = [];
     for (const [key, entry] of Object.entries(models ?? {})) {
       const matches = modelId
         ? modelKeyMatchKind({ key, provider: params.provider, modelId }) === params.matchKind
         : modelKeyIsProviderWildcard({ key, provider: params.provider });
-      if (matches && hasRuntimePolicy(entry?.agentRuntime)) {
-        return { policy: entry.agentRuntime, source: "model" };
+      const policy = entry?.agentRuntime;
+      if (!matches || !policy || !hasRuntimePolicy(policy)) {
+        continue;
       }
+      scopeMatches.push({ provider: parseProviderModelKey(key)?.provider ?? "", policy });
+    }
+    const resolved = resolvePolicyMatch(scopeMatches, callerProvider);
+    if (resolved.policy || resolved.ambiguous) {
+      return resolved;
     }
   }
   return {};
@@ -188,6 +234,9 @@ export function resolveModelRuntimePolicy(params: {
   }
 
   const agentModelPolicy = resolveAgentModelEntryRuntimePolicy({ ...params, matchKind: "exact" });
+  if (agentModelPolicy.ambiguous) {
+    return {};
+  }
   if (agentModelPolicy.policy) {
     return agentModelPolicy;
   }

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -4,7 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __testing as extraParamsTesting } from "./pi-embedded-runner/extra-params.js";
 
 vi.mock("../plugins/provider-hook-runtime.js", () => ({
-  __testing: {
+  clearProviderRuntimePluginCacheForTest: vi.fn(),
+  testing: {
     buildHookProviderCacheKey: () => "test-provider-hook-cache-key",
   },
   prepareProviderExtraParams: () => undefined,

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
@@ -87,6 +87,7 @@ export function createSanitizeSessionHistoryProviderHookRuntimeMock(
   extra: Record<string, unknown> = {},
 ) {
   return {
+    clearProviderRuntimePluginCacheForTest: vi.fn(),
     resolveProviderRuntimePlugin: vi.fn(() => undefined),
     resolveProviderHookPlugin: vi.fn(() => undefined),
     resolveProviderPluginsForHooks: vi.fn(() => []),

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -30,6 +30,7 @@ vi.mock("./pi-embedded-helpers.js", async () => ({
 vi.mock("../plugins/provider-hook-runtime.js", async () => ({
   __testing: {},
   clearProviderRuntimeHookCache: vi.fn(),
+  clearProviderRuntimePluginCacheForTest: vi.fn(),
   prepareProviderExtraParams: vi.fn(() => undefined),
   resetProviderRuntimeHookCacheForTest: vi.fn(),
   resolveProviderHookPlugin: vi.fn(() => undefined),

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -50,7 +50,7 @@ describe("openrouter-model-capabilities", () => {
                     id: "acme/top-level-max-completion",
                     name: "Top Level Max Completion",
                     architecture: { modality: "text+image->text" },
-                    supported_parameters: ["reasoning"],
+                    supported_parameters: ["reasoning", "tools"],
                     context_length: 65432,
                     max_completion_tokens: 12345,
                     pricing: { prompt: "0.000001", completion: "0.000002" },
@@ -76,18 +76,166 @@ describe("openrouter-model-capabilities", () => {
       const module = await importOpenRouterModelCapabilities("top-level-max-tokens");
       await module.loadOpenRouterModelCapabilities("acme/top-level-max-completion");
 
-      expect(module.getOpenRouterModelCapabilities("acme/top-level-max-completion")).toMatchObject({
-        input: ["text", "image"],
-        reasoning: true,
-        contextWindow: 65432,
-        maxTokens: 12345,
+      const maxCompletion = module.getOpenRouterModelCapabilities("acme/top-level-max-completion");
+      expect(maxCompletion?.input).toEqual(["text", "image"]);
+      expect(maxCompletion?.reasoning).toBe(true);
+      expect(maxCompletion?.supportsTools).toBe(true);
+      expect(maxCompletion?.contextWindow).toBe(65432);
+      expect(maxCompletion?.maxTokens).toBe(12345);
+
+      const maxOutput = module.getOpenRouterModelCapabilities("acme/top-level-max-output");
+      expect(maxOutput?.input).toEqual(["text", "image"]);
+      expect(maxOutput?.reasoning).toBe(false);
+      expect(maxOutput?.supportsTools).toBeUndefined();
+      expect(maxOutput?.contextWindow).toBe(54321);
+      expect(maxOutput?.maxTokens).toBe(23456);
+    });
+  });
+
+  it("uses endpoint-specific OpenRouter context length when top_provider reports one", async () => {
+    await withOpenRouterStateDir(async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    id: "nvidia/nemotron-3-super-120b-a12b:free",
+                    name: "Nemotron 3 Super 120B Free",
+                    architecture: { modality: "text->text" },
+                    context_length: 1_000_000,
+                    top_provider: {
+                      context_length: 262_144,
+                      max_completion_tokens: 262_144,
+                    },
+                    pricing: { prompt: "0", completion: "0" },
+                  },
+                ],
+              }),
+              {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              },
+            ),
+        ),
+      );
+
+      const module = await importOpenRouterModelCapabilities("top-provider-context-length");
+      await module.loadOpenRouterModelCapabilities("nvidia/nemotron-3-super-120b-a12b:free");
+
+      expect(
+        module.getOpenRouterModelCapabilities("nvidia/nemotron-3-super-120b-a12b:free"),
+      ).toMatchObject({
+        contextWindow: 262_144,
+        maxTokens: 262_144,
       });
-      expect(module.getOpenRouterModelCapabilities("acme/top-level-max-output")).toMatchObject({
-        input: ["text", "image"],
-        reasoning: false,
-        contextWindow: 54321,
-        maxTokens: 23456,
+    });
+  });
+
+  it("does not reuse older disk caches with precomputed OpenRouter context windows", async () => {
+    await withOpenRouterStateDir(async (stateDir) => {
+      const modelId = "nvidia/nemotron-3-super-120b-a12b:free";
+      const cacheDir = join(stateDir, "cache");
+      mkdirSync(cacheDir, { recursive: true });
+      writeFileSync(
+        join(cacheDir, "openrouter-models.json"),
+        JSON.stringify({
+          version: 2,
+          models: {
+            [modelId]: {
+              name: "Nemotron 3 Super 120B Free",
+              input: ["text"],
+              reasoning: false,
+              contextWindow: 1_000_000,
+              maxTokens: 262_144,
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            },
+          },
+        }),
+      );
+
+      const fetchSpy = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: modelId,
+                  name: "Nemotron 3 Super 120B Free",
+                  architecture: { modality: "text->text" },
+                  context_length: 1_000_000,
+                  top_provider: {
+                    context_length: 262_144,
+                    max_completion_tokens: 262_144,
+                  },
+                  pricing: { prompt: "0", completion: "0" },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const module = await importOpenRouterModelCapabilities("old-context-window-cache");
+      await module.loadOpenRouterModelCapabilities(modelId);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(module.getOpenRouterModelCapabilities(modelId)).toMatchObject({
+        contextWindow: 262_144,
+        maxTokens: 262_144,
       });
+    });
+  });
+
+  it("preserves explicit OpenRouter tool support metadata", async () => {
+    await withOpenRouterStateDir(async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    id: "perplexity/sonar-deep-research",
+                    name: "Sonar Deep Research",
+                    supported_parameters: ["reasoning", "web_search_options"],
+                  },
+                  {
+                    id: "google/gemini-2.5-pro",
+                    name: "Gemini 2.5 Pro",
+                    supported_parameters: ["reasoning", "tools"],
+                  },
+                ],
+              }),
+              {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              },
+            ),
+        ),
+      );
+
+      const module = await importOpenRouterModelCapabilities("tool-support");
+      await module.loadOpenRouterModelCapabilities("perplexity/sonar-deep-research");
+
+      expect(
+        module.getOpenRouterModelCapabilities("perplexity/sonar-deep-research")?.supportsTools,
+      ).toBe(false);
+      expect(module.getOpenRouterModelCapabilities("google/gemini-2.5-pro")?.supportsTools).toBe(
+        true,
+      );
     });
   });
 

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -30,6 +30,7 @@ const log = createSubsystemLogger("openrouter-model-capabilities");
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const FETCH_TIMEOUT_MS = 10_000;
 const DISK_CACHE_FILENAME = "openrouter-models.json";
+const DISK_CACHE_VERSION = 3;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,6 +48,7 @@ interface OpenRouterApiModel {
   max_completion_tokens?: number;
   max_output_tokens?: number;
   top_provider?: {
+    context_length?: number;
     max_completion_tokens?: number;
   };
   pricing?: {
@@ -61,6 +63,7 @@ export interface OpenRouterModelCapabilities {
   name: string;
   input: Array<"text" | "image">;
   reasoning: boolean;
+  supportsTools?: boolean;
   contextWindow: number;
   maxTokens: number;
   cost: {
@@ -72,6 +75,7 @@ export interface OpenRouterModelCapabilities {
 }
 
 interface DiskCachePayload {
+  version?: number;
   models: Record<string, OpenRouterModelCapabilities>;
 }
 
@@ -94,6 +98,7 @@ function writeDiskCache(map: Map<string, OpenRouterModelCapabilities>): void {
       mkdirSync(cacheDir, { recursive: true });
     }
     const payload: DiskCachePayload = {
+      version: DISK_CACHE_VERSION,
       models: Object.fromEntries(map),
     };
     writeFileSync(resolveDiskCachePath(), JSON.stringify(payload), "utf-8");
@@ -128,7 +133,11 @@ function readDiskCache(): Map<string, OpenRouterModelCapabilities> | undefined {
     if (!payload || typeof payload !== "object") {
       return undefined;
     }
-    const models = (payload as DiskCachePayload).models;
+    const cachePayload = payload as DiskCachePayload;
+    if (cachePayload.version !== DISK_CACHE_VERSION) {
+      return undefined;
+    }
+    const models = cachePayload.models;
     if (!models || typeof models !== "object") {
       return undefined;
     }
@@ -164,7 +173,10 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
     name: model.name || model.id,
     input,
     reasoning: model.supported_parameters?.includes("reasoning") ?? false,
-    contextWindow: model.context_length || 128_000,
+    ...(model.supported_parameters
+      ? { supportsTools: model.supported_parameters.includes("tools") }
+      : {}),
+    contextWindow: model.top_provider?.context_length ?? model.context_length ?? 128_000,
     maxTokens:
       model.top_provider?.max_completion_tokens ??
       model.max_completion_tokens ??

--- a/src/agents/provider-auth-aliases.ts
+++ b/src/agents/provider-auth-aliases.ts
@@ -89,6 +89,25 @@ export function resolveProviderAuthAliasMap(
         }
       }
     }
+    for (const choice of plugin.providerAuthChoices ?? []) {
+      for (const deprecatedChoiceId of choice.deprecatedChoiceIds ?? []) {
+        const normalizedAlias = normalizeProviderId(deprecatedChoiceId);
+        const normalizedTarget = normalizeProviderId(choice.provider);
+        if (normalizedAlias && normalizedTarget) {
+          const existing = preferredAliases.get(normalizedAlias);
+          if (
+            !existing ||
+            resolveProviderAuthAliasOriginPriority(plugin.origin) <
+              resolveProviderAuthAliasOriginPriority(existing.origin)
+          ) {
+            preferredAliases.set(normalizedAlias, {
+              origin: plugin.origin,
+              target: normalizedTarget,
+            });
+          }
+        }
+      }
+    }
   }
   for (const [alias, candidate] of preferredAliases) {
     aliases[alias] = candidate.target;

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,3 +1,4 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
@@ -9,6 +10,8 @@ import {
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const log = createSubsystemLogger("agents/subagent-registry-completion");
 
 export function runOutcomesEqual(
   a: SubagentRunOutcome | undefined,
@@ -113,7 +116,10 @@ export async function emitSubagentEndedHookOnce(params: {
     params.entry.endedHookEmittedAt = Date.now();
     params.persist();
     return true;
-  } catch {
+  } catch (err) {
+    log.warn(
+      `failed to emit subagent_ended hook for run ${runId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return false;
   } finally {
     params.inFlightRunIds.delete(runId);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -543,8 +543,10 @@ function restoreSubagentRunsOnce() {
     // Cold-start restore path: queue the same recovery pass that restart
     // startup also uses so resumed children are handled through one seam.
     scheduleSubagentOrphanRecovery();
-  } catch {
-    // ignore restore failures
+  } catch (err) {
+    log.warn(
+      `failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -278,6 +278,87 @@ describe("config observe recovery", () => {
     });
   });
 
+  it("retries recovery on next launch after a failed copyFile restore", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, auditPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const failingFs: ObserveRecoveryDeps["fs"] = {
+        ...deps.fs,
+        promises: {
+          ...deps.fs.promises,
+          copyFile: () => Promise.reject(copyError),
+        },
+      };
+      await maybeRecoverSuspiciousConfigRead({
+        deps: { ...deps, fs: failingFs },
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expectWarnContaining(warn, "Config auto-restore from backup failed:");
+      const firstEvents = await readObserveEvents(auditPath);
+      expect(firstEvents).toHaveLength(1);
+      expect(firstEvents[0]?.restoredFromBackup).toBe(false);
+
+      const retryResult = await maybeRecoverSuspiciousConfigRead({
+        deps,
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expect((retryResult.parsed as { gateway?: { mode?: string } }).gateway?.mode).toBe("local");
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.not.toBe(clobbered.raw);
+      const retryEvents = await readObserveEvents(auditPath);
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[1]?.restoredFromBackup).toBe(true);
+    });
+  });
+
+  it("sync recovery retries on next launch after a failed copyFileSync restore", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, auditPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      const copyError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      const failingFs: ObserveRecoveryDeps["fs"] = {
+        ...deps.fs,
+        copyFileSync: () => {
+          throw copyError;
+        },
+      };
+      maybeRecoverSuspiciousConfigReadSync({
+        deps: { ...deps, fs: failingFs },
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expectWarnContaining(warn, "Config auto-restore from backup failed:");
+      const firstEvents = await readObserveEvents(auditPath);
+      expect(firstEvents).toHaveLength(1);
+      expect(firstEvents[0]?.restoredFromBackup).toBe(false);
+
+      const retryResult = maybeRecoverSuspiciousConfigReadSync({
+        deps,
+        configPath,
+        raw: clobbered.raw,
+        parsed: clobbered.parsed,
+      });
+
+      expect((retryResult.parsed as { gateway?: { mode?: string } }).gateway?.mode).toBe("local");
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.not.toBe(clobbered.raw);
+      const retryEvents = await readObserveEvents(auditPath);
+      expect(retryEvents).toHaveLength(2);
+      expect(retryEvents[1]?.restoredFromBackup).toBe(true);
+    });
+  });
+
   it("dedupes repeated suspicious hashes", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath } = makeDeps(home);

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -135,6 +135,14 @@ describe("config observe recovery", () => {
     } satisfies ConfigFileSnapshot;
   }
 
+  function warnMessages(warn: ReturnType<typeof vi.fn>): string[] {
+    return warn.mock.calls.map(([message]) => String(message));
+  }
+
+  function expectWarnContaining(warn: ReturnType<typeof vi.fn>, expected: string) {
+    expect(warnMessages(warn).join("\n")).toContain(expected);
+  }
+
   function makeDeps(
     home: string,
     warn = vi.fn(),

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -679,12 +679,14 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
     }),
   );
 
-  healthState = setConfigHealthEntry(
-    healthState,
-    params.configPath,
-    createLastObservedSuspiciousEntry(entry, suspiciousSignature),
-  );
-  await writeConfigHealthState(params.deps, healthState);
+  if (restoredFromBackup) {
+    healthState = setConfigHealthEntry(
+      healthState,
+      params.configPath,
+      createLastObservedSuspiciousEntry(entry, suspiciousSignature),
+    );
+    await writeConfigHealthState(params.deps, healthState);
+  }
   return { raw: backupRaw, parsed: backupParsed };
 }
 
@@ -769,12 +771,14 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
     }),
   );
 
-  healthState = setConfigHealthEntry(
-    healthState,
-    params.configPath,
-    createLastObservedSuspiciousEntry(entry, suspiciousSignature),
-  );
-  writeConfigHealthStateSync(params.deps, healthState);
+  if (restoredFromBackup) {
+    healthState = setConfigHealthEntry(
+      healthState,
+      params.configPath,
+      createLastObservedSuspiciousEntry(entry, suspiciousSignature),
+    );
+    writeConfigHealthStateSync(params.deps, healthState);
+  }
   return { raw: backupRaw, parsed: backupParsed };
 }
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -661,9 +661,15 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
     restoredFromBackup = true;
   } catch {}
 
-  params.deps.logger.warn(
-    `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
-  );
+  if (restoredFromBackup) {
+    params.deps.logger.warn(
+      `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
+    );
+  } else {
+    params.deps.logger.warn(
+      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")})`,
+    );
+  }
   await appendConfigAuditRecord(
     createConfigObserveAuditAppendParams(params.deps, {
       ts: now,
@@ -753,9 +759,15 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
     restoredFromBackup = true;
   } catch {}
 
-  params.deps.logger.warn(
-    `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
-  );
+  if (restoredFromBackup) {
+    params.deps.logger.warn(
+      `Config auto-restored from backup: ${params.configPath} (${suspicious.join(", ")})`,
+    );
+  } else {
+    params.deps.logger.warn(
+      `Config auto-restore from backup failed: ${params.configPath} (${suspicious.join(", ")})`,
+    );
+  }
   appendConfigAuditRecordSync(
     createConfigObserveAuditAppendParams(params.deps, {
       ts: now,


### PR DESCRIPTION
## Summary

Selective cherry-picks from upstream openclaw/openclaw to bring Gemmaclaw current on high-value bug fixes and improvements.

### Commits included

- **fix(compaction)**: preserve partial summary on mid-chain chunk failure (#82952)
- **fix(config)**: do not suppress recovery retry after failed backup restore (#85787)
- **fix(openrouter)**: use endpoint context limits (#86041)
- **fix(agents)**: log warnings instead of swallowing subagent errors (#82943)
- **fix(agents)**: match runtime policy entries when session provider is empty (efd88dc00d)
  - Includes new `model-runtime-policy.ts` refactor with `parseProviderModelKey`, `providerMatchesCaller`, `resolvePolicyMatch`
  - Includes `deprecatedChoiceIds` alias loop in `provider-auth-aliases.ts` so `resolveProviderIdForAuth("claude-cli")` correctly maps to `"anthropic"`

### Intentionally skipped

- Telegram access-groups refactor (requires `extensions/telegram/src/access-groups.ts` from a larger refactoring chain)
- Agent cache cherry-pick `3c8d101f5a` (conflicts in 8+ core files — too risky for selective pick)

## Test plan

- [x] `pnpm check:changed` — typecheck, lint, tests all green
- [x] `GEMMACLAW_LOCAL_AGENT_SMOKE_REQUIRED=1 GEMMACLAW_LOCAL_AGENT_SMOKE_MODEL=gemma-4-26B-A4B-it-Q4_K_M pnpm test:docker:gemmaclaw-setup-live-smoke` — both container and non-container flows passed