### PR TITLE
Harden Gemmaclaw sandbox apt fetches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,17 +161,21 @@ LABEL org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
 
 WORKDIR /app
 
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99openclaw-network-retries && \
+    printf '#!/bin/sh\napt-get "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 0; fi\nexec apt-get -o Acquire::ForceIPv4=true "$@"\n' > /usr/local/bin/apt-get-retry && \
+    chmod 755 /usr/local/bin/apt-get-retry
+
 # Install system utilities present in bookworm but missing in bookworm-slim.
 # On the full bookworm image these are already installed (apt-get is a no-op).
 # Smoke workflows can opt out of distro upgrades to cut repeated CI time while
 # keeping the default runtime image behavior unchanged.
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
+    apt-get-retry update && \
     if [ "${OPENCLAW_DOCKER_APT_UPGRADE}" != "0" ]; then \
-      DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends; \
+      DEBIAN_FRONTEND=noninteractive apt-get-retry upgrade -y --no-install-recommends; \
     fi && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends \
       procps hostname curl git lsof openssl
 
 RUN chown node:node /app
@@ -209,8 +213,8 @@ ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES; \
+      apt-get-retry update && \
+      DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES; \
     fi
 
 # Optionally install Chromium and Xvfb for browser automation.
@@ -221,8 +225,8 @@ ARG OPENCLAW_INSTALL_BROWSER=""
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
+      apt-get-retry update && \
+      DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends xvfb && \
       mkdir -p /home/node/.cache/ms-playwright && \
       PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
@@ -238,8 +242,8 @@ ARG OPENCLAW_DOCKER_GPG_FINGERPRINT="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      apt-get-retry update && \
+      DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends \
         ca-certificates curl gnupg && \
       install -m 0755 -d /etc/apt/keyrings && \
       # Verify Docker apt signing key fingerprint before trusting it as a root key.
@@ -256,8 +260,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       chmod a+r /etc/apt/keyrings/docker.gpg && \
       printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable\n' \
         "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/docker.list && \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      apt-get-retry update && \
+      DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends \
         docker-ce-cli docker-compose-plugin; \
     fi
 

--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -16,7 +16,10 @@
 
 FROM node:22-bookworm
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99openclaw-network-retries && \
+    printf '#!/bin/sh\napt-get "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 0; fi\nexec apt-get -o Acquire::ForceIPv4=true "$@"\n' > /usr/local/bin/apt-get-retry && \
+    chmod 755 /usr/local/bin/apt-get-retry && \
+    apt-get-retry update && apt-get-retry install -y --no-install-recommends \
     curl ca-certificates procps zstd python3 && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -6,17 +6,25 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-  apt-get update \
-  && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y --no-install-recommends \
+  printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99openclaw-network-retries \
+  && printf '#!/bin/sh\napt-get "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 0; fi\nexec apt-get -o Acquire::ForceIPv4=true "$@"\n' > /usr/local/bin/apt-get-retry \
+  && chmod 755 /usr/local/bin/apt-get-retry \
+  && apt-get-retry update \
+  && apt-get-retry upgrade -y --no-install-recommends \
+  && apt-get-retry install -y --no-install-recommends \
     bash \
     ca-certificates \
     curl \
     ffmpeg \
+    file \
     git \
     jq \
+    less \
+    procps \
     python3 \
-    ripgrep
+    ripgrep \
+    unzip \
+    wget
 
 RUN useradd --create-home --shell /bin/bash sandbox
 USER sandbox

--- a/Dockerfile.sandbox-browser
+++ b/Dockerfile.sandbox-browser
@@ -6,22 +6,31 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=cache,id=openclaw-sandbox-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-  apt-get update \
-  && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y --no-install-recommends \
+  printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99openclaw-network-retries \
+  && printf '#!/bin/sh\napt-get "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 0; fi\nexec apt-get -o Acquire::ForceIPv4=true "$@"\n' > /usr/local/bin/apt-get-retry \
+  && chmod 755 /usr/local/bin/apt-get-retry \
+  && apt-get-retry update \
+  && apt-get-retry upgrade -y --no-install-recommends \
+  && apt-get-retry install -y --no-install-recommends \
     bash \
     ca-certificates \
     chromium \
     curl \
+    file \
     fonts-liberation \
     fonts-noto-cjk \
     fonts-noto-color-emoji \
     git \
     jq \
+    less \
     novnc \
+    procps \
     python3 \
+    ripgrep \
     socat \
+    unzip \
     websockify \
+    wget \
     x11vnc \
     xvfb
 

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -7,7 +7,7 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG PACKAGES="curl wget jq coreutils grep nodejs npm python3 git ca-certificates ffmpeg golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file"
+ARG PACKAGES="curl wget jq coreutils grep nodejs npm python3 git ca-certificates ffmpeg golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file ripgrep procps less"
 ARG INSTALL_PNPM=1
 ARG INSTALL_BUN=1
 ARG BUN_INSTALL_DIR=/opt/bun
@@ -23,9 +23,12 @@ ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin
 
 RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \
-  apt-get update \
-  && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y --no-install-recommends ${PACKAGES}
+  printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99openclaw-network-retries \
+  && printf '#!/bin/sh\napt-get "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 0; fi\nexec apt-get -o Acquire::ForceIPv4=true "$@"\n' > /usr/local/bin/apt-get-retry \
+  && chmod 755 /usr/local/bin/apt-get-retry \
+  && apt-get-retry update \
+  && apt-get-retry upgrade -y --no-install-recommends \
+  && apt-get-retry install -y --no-install-recommends ${PACKAGES}
 
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -351,11 +351,19 @@ Build it once:
 scripts/sandbox-setup.sh
 ```
 
-Note: the default image includes basic shell tools plus Python and `ffmpeg`,
-but it does **not** include Node. If a skill needs Node (or
-other runtimes), either bake a custom image or install via
-`sandbox.docker.setupCommand` (requires network egress + writable root +
-root user).
+Note: the default image includes basic shell and inspection tools (`bash`,
+`curl`, `wget`, `git`, `jq`, `ripgrep`, `file`, `unzip`, `procps`, `less`) plus
+Python and `ffmpeg`, but it does **not** include Node. If a skill needs Node
+(or other runtimes), either bake a custom image or install via
+`sandbox.docker.setupCommand` (requires network egress + writable root + root
+user).
+
+The bundled sandbox images install apt retry/timeouts and an `apt-get-retry`
+helper. `apt-get-retry` runs apt normally first, then retries once with
+`Acquire::ForceIPv4=true` if the first attempt fails. This makes setup and
+agent-initiated package installs more resilient to transient DNS, mirror, and
+IPv6 routing failures without forcing IPv4-only behavior for every plain apt
+command.
 
 If you want a more functional sandbox image with common tooling (for example
 `curl`, `jq`, `nodejs`, `python3`, `git`), build:
@@ -440,6 +448,9 @@ Common pitfalls:
 - `docker.network: "container:<id>"` requires `dangerouslyAllowContainerNamespaceJoin: true` and is break-glass only.
 - `readOnlyRoot: true` prevents writes; set `readOnlyRoot: false` or bake a custom image.
 - `user` must be root for package installs (omit `user` or set `user: "0:0"`).
+- Prefer `apt-get-retry` in Gemmaclaw container setup commands and agent
+  instructions. It preserves normal apt behavior first, then falls back to an
+  IPv4 retry when DNS or mirror fetches fail.
 - Sandbox exec does **not** inherit host `process.env`. Use
   `agents.defaults.sandbox.docker.env` (or a custom image) for skill API keys.
 

--- a/scripts/e2e/gemmaclaw-container-agent-smoke.sh
+++ b/scripts/e2e/gemmaclaw-container-agent-smoke.sh
@@ -132,8 +132,17 @@ if (docker?.readOnlyRoot !== false || docker?.network !== "bridge" || docker?.us
 if (!Array.isArray(docker?.capDrop) || docker.capDrop.length !== 0) {
   fail(`capDrop must be empty for package-manager behavior, got ${JSON.stringify(docker?.capDrop)}`);
 }
-if (!String(docker?.setupCommand ?? "").includes("git python3")) {
-  fail("setupCommand must install git and python3");
+const setupCommand = String(docker?.setupCommand ?? "");
+for (const pkg of ["git", "python3", "jq", "ripgrep", "file", "unzip", "wget", "procps", "less"]) {
+  if (!setupCommand.includes(pkg)) {
+    fail(`setupCommand must install ${pkg}`);
+  }
+}
+if (!setupCommand.includes("apt-get-retry")) {
+  fail("setupCommand must install the retry-aware apt helper");
+}
+if (!setupCommand.includes("99gemmaclaw-network-retries")) {
+  fail("setupCommand must install apt network retry config");
 }
 if (cfg.tools?.exec?.security !== "full" || cfg.tools?.exec?.ask !== "off") {
   fail(`exec policy is not full/off: ${JSON.stringify(cfg.tools?.exec)}`);
@@ -149,7 +158,7 @@ Use your exec tool to run shell commands inside the Docker container. Do not jus
 
 Run these checks:
 1. Print whoami, id, pwd, and uname -a.
-2. Install cowsay with apt-get -o APT::Sandbox::User=root update and DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y cowsay.
+2. Install cowsay with apt-get-retry update and DEBIAN_FRONTEND=noninteractive apt-get-retry install -y cowsay.
 3. Write WORKSPACE_WRITE_OK to /workspace/workspace_e2e.txt and read it back.
 4. Write SHARED_WRITE_OK to /workspace/shared/shared_e2e.txt and read it back.
 5. Write MOVED_SHARED_OK to /workspace/moved_e2e.txt, move it to /workspace/shared/moved_e2e.txt, then read it back from /workspace/shared/moved_e2e.txt.

--- a/scripts/e2e/gemmaclaw-local-agent-smoke.sh
+++ b/scripts/e2e/gemmaclaw-local-agent-smoke.sh
@@ -272,6 +272,18 @@ if (flow === "container") {
   if (!Array.isArray(docker?.capDrop) || docker.capDrop.length !== 0) {
     fail(`capDrop must be empty, got ${JSON.stringify(docker?.capDrop)}`);
   }
+  const setupCommand = String(docker?.setupCommand ?? "");
+  for (const pkg of ["git", "python3", "jq", "ripgrep", "file", "unzip", "wget", "procps", "less"]) {
+    if (!setupCommand.includes(pkg)) {
+      fail(`setupCommand must install ${pkg}`);
+    }
+  }
+  if (!setupCommand.includes("apt-get-retry")) {
+    fail("setupCommand must install the retry-aware apt helper");
+  }
+  if (!setupCommand.includes("99gemmaclaw-network-retries")) {
+    fail("setupCommand must install apt network retry config");
+  }
   if (mode(sharedDir) !== "777" || mode(workspaceDir) !== "777") {
     fail(`bind host dirs must be mode 777, got shared=${mode(sharedDir)} workspace=${mode(workspaceDir)}`);
   }
@@ -307,7 +319,7 @@ Use your exec tool to run shell commands. Do not just explain.
 
 Run these checks:
 1. Print whoami, id, pwd, and uname -a.
-2. Install cowsay with apt-get -o APT::Sandbox::User=root update and DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y cowsay.
+2. Install cowsay with apt-get-retry update and DEBIAN_FRONTEND=noninteractive apt-get-retry install -y cowsay.
 3. Write WORKSPACE_WRITE_OK to $WORKSPACE_PATH/workspace_e2e.txt and read it back.
 4. Write SHARED_WRITE_OK to $SHARED_PATH/shared_e2e.txt and read it back.
 5. Write MOVED_SHARED_OK to $WORKSPACE_PATH/moved_e2e.txt, move it to $SHARED_PATH/moved_e2e.txt, then read it back from $SHARED_PATH/moved_e2e.txt.

--- a/scripts/e2e/gemmaclaw-local-agent-smoke.sh
+++ b/scripts/e2e/gemmaclaw-local-agent-smoke.sh
@@ -347,6 +347,13 @@ if [ "$FLOW" = "container" ]; then
     echo "FAIL: no sandbox container found for $AGENT_NAME" >&2
     exit 1
   fi
+  if ! docker exec "$CONTAINER_NAME" sh -lc 'command -v cowsay >/dev/null || test -x /usr/games/cowsay'; then
+    echo "FAIL: agent did not install cowsay inside the sandbox container" >&2
+    exit 1
+  fi
+elif ! { command -v cowsay >/dev/null 2>&1 || [ -x /usr/games/cowsay ]; }; then
+  echo "FAIL: agent did not install cowsay in the non-container smoke environment" >&2
+  exit 1
 fi
 
 echo "==> Verifying smoke artifacts and isolation ($FLOW)"

--- a/scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh
+++ b/scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh
@@ -93,7 +93,7 @@ docker run --rm -i \
   -v "$ROOT_DIR:/repo" \
   -w /repo \
   "$IMAGE" \
-  bash -lc 'printf '"'"'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n'"'"' > /etc/apt/apt.conf.d/99gemmaclaw-network-retries; apt_get() { apt-get "$@" || apt-get -o Acquire::ForceIPv4=true "$@"; }; apt_get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt_get install -y ca-certificates curl git >/dev/null && corepack enable >/dev/null 2>&1 || true; bash scripts/e2e/gemmaclaw-local-agent-smoke.sh'
+  bash -lc 'printf '"'"'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n'"'"' > /etc/apt/apt.conf.d/99gemmaclaw-network-retries; printf '"'"'#!/bin/sh\napt-get "$@"\nstatus=$?\nif [ "$status" -eq 0 ]; then exit 0; fi\nexec apt-get -o Acquire::ForceIPv4=true "$@"\n'"'"' > /usr/local/bin/apt-get-retry; chmod 755 /usr/local/bin/apt-get-retry; apt-get-retry update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get-retry install -y ca-certificates curl git >/dev/null && corepack enable >/dev/null 2>&1 || true; bash scripts/e2e/gemmaclaw-local-agent-smoke.sh'
 
 if [ "$(cat "$HOST_SENTINEL")" != "HOST_SENTINEL_ORIGINAL" ]; then
   echo "FAIL: outer-host sentinel was modified" >&2

--- a/scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh
+++ b/scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh
@@ -93,7 +93,7 @@ docker run --rm -i \
   -v "$ROOT_DIR:/repo" \
   -w /repo \
   "$IMAGE" \
-  bash -lc 'apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git >/dev/null && corepack enable >/dev/null 2>&1 || true; bash scripts/e2e/gemmaclaw-local-agent-smoke.sh'
+  bash -lc 'printf '"'"'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n'"'"' > /etc/apt/apt.conf.d/99gemmaclaw-network-retries; apt_get() { apt-get "$@" || apt-get -o Acquire::ForceIPv4=true "$@"; }; apt_get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt_get install -y ca-certificates curl git >/dev/null && corepack enable >/dev/null 2>&1 || true; bash scripts/e2e/gemmaclaw-local-agent-smoke.sh'
 
 if [ "$(cat "$HOST_SENTINEL")" != "HOST_SENTINEL_ORIGINAL" ]; then
   echo "FAIL: outer-host sentinel was modified" >&2

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -472,6 +472,7 @@ describe("setupGemmaCommand — agent creation", () => {
     expect(setupCommand).toContain("/etc/apt/apt.conf.d/99gemmaclaw-network-retries");
     expect(setupCommand).toContain('Acquire::Retries "5";');
     expect(setupCommand).toContain("apt-get-retry");
+    expect(setupCommand).not.toContain("<<");
     expect(setupCommand).toContain("Acquire::ForceIPv4=true");
     expect(setupCommand).toContain(
       "DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends bash ca-certificates curl wget git jq ripgrep python3 ffmpeg file unzip procps less",

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -462,15 +462,24 @@ describe("setupGemmaCommand — agent creation", () => {
         readOnlyRoot: false,
         network: "bridge",
         capDrop: [],
-        setupCommand:
-          "apt-get -o APT::Sandbox::User=root update && " +
-          "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 ffmpeg && " +
-          "printf '\\numask 000\\n' >> /etc/profile && " +
-          "rm -rf /var/lib/apt/lists/*",
+        setupCommand: expect.any(String),
         user: "0:0",
       },
     });
     const docker = sandbox?.docker as Record<string, unknown> | undefined;
+    expect(docker?.setupCommand).toEqual(expect.any(String));
+    const setupCommand = docker?.setupCommand as string;
+    expect(setupCommand).toContain("/etc/apt/apt.conf.d/99gemmaclaw-network-retries");
+    expect(setupCommand).toContain('Acquire::Retries "5";');
+    expect(setupCommand).toContain("apt-get-retry");
+    expect(setupCommand).toContain("Acquire::ForceIPv4=true");
+    expect(setupCommand).toContain(
+      "DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends bash ca-certificates curl wget git jq ripgrep python3 ffmpeg file unzip procps less",
+    );
+    for (const pkg of ["jq", "ripgrep", "file", "unzip", "wget", "procps", "less"]) {
+      expect(setupCommand).toContain(` ${pkg}`);
+    }
+    expect(setupCommand).toContain("printf '\\numask 000\\n' >> /etc/profile");
     expect(docker?.binds).toEqual([
       `${process.env.HOME ?? "/root"}/.gemmaclaw/shared:/workspace/shared:rw`,
     ]);

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -69,6 +69,48 @@ function resolveGemmaclawSharedDir(): string {
   return path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
 }
 
+const GEMMACLAW_APT_NETWORK_RETRY_CONF = [
+  'Acquire::Retries "5";',
+  'Acquire::http::Timeout "30";',
+  'Acquire::https::Timeout "30";',
+].join("\n");
+
+const GEMMACLAW_DEFAULT_SANDBOX_PACKAGES = [
+  "bash",
+  "ca-certificates",
+  "curl",
+  "wget",
+  "git",
+  "jq",
+  "ripgrep",
+  "python3",
+  "ffmpeg",
+  "file",
+  "unzip",
+  "procps",
+  "less",
+].join(" ");
+
+function buildGemmaclawSandboxSetupCommand(): string {
+  return [
+    `cat > /etc/apt/apt.conf.d/99gemmaclaw-network-retries <<'EOF'\n${GEMMACLAW_APT_NETWORK_RETRY_CONF}\nEOF`,
+    [
+      "cat > /usr/local/bin/apt-get-retry <<'EOF'",
+      "#!/bin/sh",
+      'apt-get -o APT::Sandbox::User=root "$@"',
+      "status=$?",
+      'if [ "$status" -eq 0 ]; then exit 0; fi',
+      'exec apt-get -o APT::Sandbox::User=root -o Acquire::ForceIPv4=true "$@"',
+      "EOF",
+      "chmod 755 /usr/local/bin/apt-get-retry",
+    ].join("\n"),
+    "apt-get-retry update",
+    `DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends ${GEMMACLAW_DEFAULT_SANDBOX_PACKAGES}`,
+    "printf '\\numask 000\\n' >> /etc/profile",
+    "rm -rf /var/lib/apt/lists/*",
+  ].join(" && ");
+}
+
 function buildGemmaclawDockerSandboxConfig(): NonNullable<
   NonNullable<OpenClawConfig["agents"]>["defaults"]
 >["sandbox"] {
@@ -85,12 +127,7 @@ function buildGemmaclawDockerSandboxConfig(): NonNullable<
       readOnlyRoot: false,
       network: "bridge",
       capDrop: [],
-      setupCommand: [
-        "apt-get -o APT::Sandbox::User=root update",
-        "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 ffmpeg",
-        "printf '\\numask 000\\n' >> /etc/profile",
-        "rm -rf /var/lib/apt/lists/*",
-      ].join(" && "),
+      setupCommand: buildGemmaclawSandboxSetupCommand(),
       user: "0:0",
     },
   };

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -93,17 +93,19 @@ const GEMMACLAW_DEFAULT_SANDBOX_PACKAGES = [
 
 function buildGemmaclawSandboxSetupCommand(): string {
   return [
-    `cat > /etc/apt/apt.conf.d/99gemmaclaw-network-retries <<'EOF'\n${GEMMACLAW_APT_NETWORK_RETRY_CONF}\nEOF`,
+    `printf '%s\\n' ${GEMMACLAW_APT_NETWORK_RETRY_CONF.split("\n")
+      .map((line) => `'${line}'`)
+      .join(" ")} > /etc/apt/apt.conf.d/99gemmaclaw-network-retries`,
     [
-      "cat > /usr/local/bin/apt-get-retry <<'EOF'",
-      "#!/bin/sh",
-      'apt-get -o APT::Sandbox::User=root "$@"',
-      "status=$?",
-      'if [ "$status" -eq 0 ]; then exit 0; fi',
-      'exec apt-get -o APT::Sandbox::User=root -o Acquire::ForceIPv4=true "$@"',
-      "EOF",
-      "chmod 755 /usr/local/bin/apt-get-retry",
-    ].join("\n"),
+      "printf '%s\\n'",
+      "'#!/bin/sh'",
+      "'apt-get -o APT::Sandbox::User=root \"$@\"'",
+      "'status=$?'",
+      "'if [ \"$status\" -eq 0 ]; then exit 0; fi'",
+      "'exec apt-get -o APT::Sandbox::User=root -o Acquire::ForceIPv4=true \"$@\"'",
+      "> /usr/local/bin/apt-get-retry",
+    ].join(" "),
+    "chmod 755 /usr/local/bin/apt-get-retry",
     "apt-get-retry update",
     `DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends ${GEMMACLAW_DEFAULT_SANDBOX_PACKAGES}`,
     "printf '\\numask 000\\n' >> /etc/profile",

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -8,6 +8,8 @@ const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
 const sandboxDockerfilePath = join(repoRoot, "Dockerfile.sandbox");
 const sandboxCommonDockerfilePath = join(repoRoot, "Dockerfile.sandbox-common");
+const sandboxBrowserDockerfilePath = join(repoRoot, "Dockerfile.sandbox-browser");
+const benchmarkDockerfilePath = join(repoRoot, "Dockerfile.benchmark");
 const dockerReleaseWorkflowPath = join(repoRoot, ".github/workflows/docker-release.yml");
 
 function collapseDockerContinuations(dockerfile: string): string {
@@ -42,7 +44,7 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       "node /app/node_modules/playwright-core/cli.js install --with-deps chromium",
     );
-    expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
+    expect(dockerfile).toContain("apt-get-retry install -y --no-install-recommends xvfb");
   });
 
   it("verifies matrix-sdk-crypto native addons without hardcoded pnpm virtual-store paths", async () => {
@@ -113,8 +115,47 @@ describe("Dockerfile", () => {
     const sandboxCommonDockerfile = await readFile(sandboxCommonDockerfilePath, "utf8");
 
     expect(sandboxDockerfile).toMatch(
-      /apt-get install -y --no-install-recommends[\s\S]*\bffmpeg\b/,
+      /apt-get-retry install -y --no-install-recommends[\s\S]*\bffmpeg\b/,
     );
     expect(sandboxCommonDockerfile).toMatch(/ARG PACKAGES=.*\bffmpeg\b/);
+  });
+
+  it("includes common agent inspection tools in sandbox images", async () => {
+    const sandboxDockerfile = await readFile(sandboxDockerfilePath, "utf8");
+    const sandboxCommonDockerfile = await readFile(sandboxCommonDockerfilePath, "utf8");
+    const sandboxBrowserDockerfile = await readFile(sandboxBrowserDockerfilePath, "utf8");
+
+    for (const tool of ["jq", "ripgrep", "file", "unzip", "wget", "procps", "less"]) {
+      expect(sandboxDockerfile, `default sandbox should include ${tool}`).toMatch(
+        new RegExp(`\\b${tool}\\b`),
+      );
+      expect(sandboxCommonDockerfile, `common sandbox should include ${tool}`).toMatch(
+        new RegExp(`\\b${tool}\\b`),
+      );
+      expect(sandboxBrowserDockerfile, `browser sandbox should include ${tool}`).toMatch(
+        new RegExp(`\\b${tool}\\b`),
+      );
+    }
+  });
+
+  it("hardens apt fetches in runtime and sandbox image builds", async () => {
+    for (const [label, path] of [
+      ["runtime", dockerfilePath],
+      ["sandbox", sandboxDockerfilePath],
+      ["sandbox-common", sandboxCommonDockerfilePath],
+      ["sandbox-browser", sandboxBrowserDockerfilePath],
+      ["benchmark", benchmarkDockerfilePath],
+    ] as const) {
+      const dockerfile = await readFile(path, "utf8");
+      expect(dockerfile, `${label} image should configure apt retries`).toContain(
+        'Acquire::Retries "5";',
+      );
+      expect(dockerfile, `${label} image should install apt-get-retry`).toContain(
+        "/usr/local/bin/apt-get-retry",
+      );
+      expect(dockerfile, `${label} image should retry apt over IPv4 after failure`).toContain(
+        "Acquire::ForceIPv4=true",
+      );
+    }
   });
 });

--- a/src/gemmaclaw/provision/bootstrap-profiles.test.ts
+++ b/src/gemmaclaw/provision/bootstrap-profiles.test.ts
@@ -129,6 +129,7 @@ describe("bootstrap-profiles", () => {
       );
       expect(written).toContain("## Docker Sandbox Environment");
       expect(written).toContain("/workspace/shared");
+      expect(written).toContain("apt-get-retry install");
       expect(written).toContain("apt-get -o APT::Sandbox::User=root install");
     });
 

--- a/src/gemmaclaw/provision/bootstrap-profiles.ts
+++ b/src/gemmaclaw/provision/bootstrap-profiles.ts
@@ -154,7 +154,7 @@ export function applyBootstrapProfile(
 ## Docker Sandbox Environment
 - You are running inside an isolated Docker container.
 - Shared files with the host machine should be placed in \`/workspace/shared\`.
-- If you need to install system packages, you MUST use \`apt-get -o APT::Sandbox::User=root install <package>\` to bypass privilege-dropping security errors.
+- If you need to install system packages, use \`apt-get-retry install <package>\` when available. Otherwise use \`apt-get -o APT::Sandbox::User=root install <package>\` to bypass privilege-dropping security errors.
 `;
     }
     fs.writeFileSync(target, contentToOutput);


### PR DESCRIPTION
## Summary
- add retry/timeouts plus an apt-get-retry helper for sandbox and runtime Docker apt fetches
- expand Gemmaclaw default sandbox setup with common agent tools: jq, ripgrep, file, unzip, wget, procps, less, plus ffmpeg
- update smoke checks, bootstrap instructions, and sandbox docs so agents use the retry-aware helper

## Verification
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/commands/setup-gemma.test.ts src/gemmaclaw/provision/bootstrap-profiles.test.ts src/dockerfile.test.ts src/docker-build-cache.test.ts
- docker build -f Dockerfile.sandbox -t gemmaclaw-sandbox-fetchdns-test .
- docker run --rm --user root gemmaclaw-sandbox-fetchdns-test sh -lc "cat /etc/apt/apt.conf.d/99openclaw-network-retries; apt-get-retry -o Acquire::Retries=1 update >/dev/null; for bin in bash curl wget git jq rg python3 ffmpeg file unzip ps less; do command -v \"$bin\" >/dev/null || { echo missing:$bin; exit 1; }; done; jq --version; rg --version | head -n 1; file --version | head -n 1; echo toolbox-ok"
- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
- bash -n scripts/e2e/gemmaclaw-container-agent-smoke.sh scripts/e2e/gemmaclaw-local-agent-smoke.sh scripts/e2e/gemmaclaw-non-container-agent-smoke-docker.sh

## Additional Verification
- GEMMACLAW_LOCAL_AGENT_SMOKE_REQUIRED=1 GEMMACLAW_LOCAL_AGENT_SMOKE_MODEL=gemma-4-26B-A4B-it-Q4_K_M OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test:docker:gemmaclaw-setup-live-smoke