### PR TITLE
Add Home AI hill-climb benchmark

### DIFF
--- a/src/gemmaclaw/benchmark/agent-container-guard.test.ts
+++ b/src/gemmaclaw/benchmark/agent-container-guard.test.ts
@@ -154,11 +154,11 @@ describe("agent benchmark container guard", () => {
   });
 
   it("resolves benchmark suite variations without mixing default and expanded suites", () => {
-    expect(resolveAgentBenchmarkTasks({}).length).toBe(50);
-    expect(resolveAgentBenchmarkTasks({ suite: "default" }).length).toBe(50);
+    expect(resolveAgentBenchmarkTasks({}).length).toBe(51);
+    expect(resolveAgentBenchmarkTasks({ suite: "default" }).length).toBe(51);
     expect(resolveAgentBenchmarkTasks({ suite: "expanded" }).length).toBe(147);
     expect(resolveAgentBenchmarkTasks({ suite: "variants" }).length).toBe(29400);
-    expect(resolveAgentBenchmarkTasks({ suite: "all" }).length).toBe(29597);
+    expect(resolveAgentBenchmarkTasks({ suite: "all" }).length).toBe(29598);
     expect(() => resolveAgentBenchmarkTasks({ suite: "missing" })).toThrow(
       /Unsupported agent benchmark suite/,
     );

--- a/src/gemmaclaw/benchmark/agent-tasks.test.ts
+++ b/src/gemmaclaw/benchmark/agent-tasks.test.ts
@@ -171,7 +171,7 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
       newTaskCategories.add(task!.category);
     }
 
-    expect(OPENCLAW_HARD_WORKFLOW_TASK_IDS).toHaveLength(22);
+    expect(OPENCLAW_HARD_WORKFLOW_TASK_IDS).toHaveLength(23);
     expect(newTaskCategories.size).toBeGreaterThanOrEqual(7);
 
     const taskText = OPENCLAW_HARD_WORKFLOW_TASK_IDS.map((id) => {
@@ -199,10 +199,10 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
     const expandedIds = new Set(EXPANDED_AGENT_BENCHMARK_TASKS.map((task) => task.id));
     const variationIds = new Set(GENERATED_AGENT_VARIATION_TASKS.map((task) => task.id));
 
-    expect(AGENT_BENCHMARK_TASKS).toHaveLength(50);
+    expect(AGENT_BENCHMARK_TASKS).toHaveLength(51);
     expect(EXPANDED_AGENT_BENCHMARK_TASKS).toHaveLength(147);
     expect(GENERATED_AGENT_VARIATION_TASKS).toHaveLength(29400);
-    expect(ALL_AGENT_BENCHMARK_TASKS).toHaveLength(29597);
+    expect(ALL_AGENT_BENCHMARK_TASKS).toHaveLength(29598);
     expect([...expandedIds].some((id) => defaultIds.has(id))).toBe(false);
     expect([...variationIds].some((id) => defaultIds.has(id) || expandedIds.has(id))).toBe(false);
   });
@@ -298,6 +298,34 @@ describe("Gemma 3n easy agent benchmark tasks", () => {
     expect(taskText).toContain("required_step_count must be at least 20");
     expect(taskText).toContain("promise_language_used");
     expect(taskText).toContain("Must not rely on .openclaw/cron/jobs.json");
+  });
+
+  it("locks Home AI hill-climb coverage to labelled examples and same-label dedupe", () => {
+    const task = getTaskById("home_ai_hill_climb_labelled_examples");
+
+    expect(task).toBeDefined();
+    expect(task?.difficulty).toBe("very_hard");
+    expect(task?.grading.maxScore).toBeGreaterThanOrEqual(200);
+
+    const taskText = [task!.prompt, ...task!.grading.criteria].join("\n");
+    expect(taskText).toContain("ex_litter_white_1956");
+    expect(taskText).toContain("2026-05-24T19:56:00-04:00");
+    expect(taskText).toContain("white_cat");
+    expect(taskText).toContain("ex_feed_cluster_1759_1806");
+    expect(taskText).toContain("black_cat/eating");
+    expect(taskText).toContain("white_cat/eating");
+    expect(taskText).toContain("ex_empty_equipment_negative");
+    expect(taskText).toContain("dedupe_window_seconds");
+    expect(taskText).toContain("900");
+    expect(taskText).toContain("cat and activity");
+    expect(taskText).toContain("cat and usage_status");
+    expect(taskText).toContain("memory/home-ai-hill-climb-report.json");
+    expect(taskText).toContain("state/home-ai-hill-climb/cat_feeding_water/config.json");
+    expect(taskText).toContain("state/home-ai-hill-climb/cat_litter_box/config.json");
+    expect(taskText).toContain("semantic evaluation");
+    expect(taskText).toContain("keyword");
+    expect(taskText).toContain("clicked dashboard graph point");
+    expect(taskText).toContain("future_agent_prompt");
   });
 
   it("keeps expanded benchmark task prompts and rubrics publishable", () => {

--- a/src/gemmaclaw/benchmark/agent-tasks.ts
+++ b/src/gemmaclaw/benchmark/agent-tasks.ts
@@ -55,6 +55,7 @@ export const OPENCLAW_HARD_WORKFLOW_TASK_IDS = [
   "scheduled_media_delivery_verification",
   "commitment_followthrough_verification",
   "long_horizon_20_step_followthrough",
+  "home_ai_hill_climb_labelled_examples",
   "external_source_trust_escalation",
   "literal_dollar_preservation",
   "calendar_briefing_source_reconciliation",
@@ -1584,6 +1585,57 @@ export const AGENT_BENCHMARK_TASKS: AgentBenchmarkTask[] = [
         "Must not inspect fake-gog source code or benchmark harness implementation to solve the task",
       ],
       maxScore: 320,
+    },
+  },
+
+  {
+    id: "home_ai_hill_climb_labelled_examples",
+    name: "Home AI Hill-Climb From Labelled Examples",
+    description:
+      "Tests whether the agent can improve a mock local Home AI job from labelled QA examples, including same-label dedupe and example promotion.",
+    category: "data_analysis",
+    difficulty: "very_hard",
+    prompt:
+      "Simulate repairing a local Home AI cat-monitoring setup from labelled QA examples. " +
+      "Do not inspect benchmark harness source. Work only from this prompt and the files you create. " +
+      "Create a mock workspace under state/home-ai-hill-climb with two jobs: cat_feeding_water and cat_litter_box. " +
+      "The current mock feeding job incorrectly dedupes by activity only, so black-cat eating and white-cat eating inside the same 15-minute window can collapse into one row. " +
+      "The current mock litter job has no positive example for white-cat litter-box usage. " +
+      "Use these labelled examples as the source of truth: " +
+      "ex_litter_white_1956 is a positive example from 2026-05-24T19:56:00-04:00 where the white cat is visibly using the litter box and should become a cat_litter_box QA example; " +
+      "ex_feed_cluster_1759_1806 contains rows at 2026-05-24T17:59:00-04:00, 18:02, 18:05, and 18:06 where black_cat/eating and white_cat/eating both occur in the same window; " +
+      "the expected hill climb is one deduped black_cat/eating point and one deduped white_cat/eating point, not one combined activity-only point; " +
+      "ex_empty_equipment_negative is a negative feeding-area example where equipment is visible but no cat is eating or drinking, so no SQLite row should be written. " +
+      "Infer the hill-climb changes needed from those labels, write corrected mock job config JSON files, write the QA example records, and write memory/home-ai-hill-climb-report.json. " +
+      "The report must explain the inferred prompt/config changes, the dedupe rule, how the 7:56 PM white-cat litter example is promoted, and how a future Gemmaclaw agent should verify the same behavior without keyword matching.",
+    grading: {
+      type: "artifact_check",
+      criteria: [
+        "Must create state/home-ai-hill-climb/cat_feeding_water/config.json",
+        "Must create state/home-ai-hill-climb/cat_litter_box/config.json",
+        "Must create state/home-ai-hill-climb/cat_litter_box/qa_examples/ex_litter_white_1956.json",
+        "Must create memory/home-ai-hill-climb-report.json as valid JSON",
+        "Must explicitly infer the hill-climb need from the labelled examples, not merely say the setup is updated",
+        "Feeding config must set dedupe_window_seconds to 900 or otherwise explicitly encode a 15-minute dedupe window",
+        "Feeding config must use same-label dedupe keys that include both cat and activity",
+        "Feeding config or report must state that black_cat/eating and white_cat/eating in the same 15-minute window remain separate visible points",
+        "Litter config must set dedupe_window_seconds to 900 or otherwise explicitly encode a 15-minute dedupe window",
+        "Litter config must use same-label dedupe keys that include cat and usage_status, or an equivalent explicit cat plus usage-label key",
+        "Litter QA example ex_litter_white_1956 must identify white_cat and visible litter-box usage as positive",
+        "The report must mention ex_litter_white_1956 and 2026-05-24T19:56:00-04:00 or 7:56 PM",
+        "The report must mention ex_feed_cluster_1759_1806 and the expected two points: black_cat/eating and white_cat/eating",
+        "The report must mention ex_empty_equipment_negative and that no row should be written for visible empty equipment",
+        "The report must include an expectation that Gemmaclaw performs semantic evaluation from labelled examples rather than keyword or fixed-phrase checks",
+        "The report must include an expectation that a clicked dashboard graph point can be inspected, removed, or promoted as an example",
+        "The report JSON must include top-level keys inferred_changes, dedupe_expectation, examples_to_add, verification_expectation, and future_agent_prompt",
+        "inferred_changes must include both prompt/semantic reasoning changes and config/dedupe changes",
+        "dedupe_expectation must preserve separate black_cat and white_cat actions in the same 15-minute window",
+        "examples_to_add must include ex_litter_white_1956 with cat white_cat and positive litter-box usage",
+        "verification_expectation must say that a future Gemmaclaw agent should reproduce the same hill-climb on the mock Home AI setup",
+        "future_agent_prompt must ask the agent to read the mock Home AI config/examples and hill-climb from labelled examples before changing behavior",
+        "Must not inspect fake-gog source code or benchmark harness implementation to solve the task",
+      ],
+      maxScore: 240,
     },
   },
 


### PR DESCRIPTION
Adds a hard benchmark task for a mock Home AI hill-climb from labelled cat examples, including same-label 15-minute dedupe, white-cat litter-box example promotion, dashboard point actions, and semantic evaluation expectations.\n\nValidation:\n- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/gemmaclaw/benchmark/agent-tasks.test.ts\n- OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed