### PR TITLE
qa: fix stale community report count (153→195)

### DIFF
--- a/site/community.html
+++ b/site/community.html
@@ -1641,8 +1641,8 @@
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1tax6hj" target="_blank" rel="noopener">Models and Quants quality test results — the chessboard svg</a> (May 12, 2026, 46 score, 19 comments — Gemma 4 26B Q4_K_L does &quot;very good job&quot; on visual geometry tasks; strong spatial reasoning at Q4 quant)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ta7ce9" target="_blank" rel="noopener">Strix Halo or DGX Spark for a home LLM server?</a> (May 11, 2026, 21 score, 91 comments — owner of both confirms Spark faster prompt processing and better long-context scaling; Strix Halo more repurposable; community split on inference-specialization vs. longevity)</li>
 </ul>
-<p>The full set of 153 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
-<p><em>Last updated: 2026-05-18 (May 18 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
+<p>The full set of 195 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
+<p><em>Last updated: 2026-05-26 (May 26 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
       <div class="community-section" id="community">
       <h3>Community Reports (195 from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>

--- a/site/data/field-notes.md
+++ b/site/data/field-notes.md
@@ -456,6 +456,6 @@ The most relevant Gemma-mentioning posts driving this update, with the newest fi
 - [Models and Quants quality test results — the chessboard svg](https://reddit.com/r/LocalLLaMA/comments/1tax6hj) (May 12, 2026, 46 score, 19 comments — Gemma 4 26B Q4_K_L does "very good job" on visual geometry tasks; strong spatial reasoning at Q4 quant)
 - [Strix Halo or DGX Spark for a home LLM server?](https://reddit.com/r/LocalLLaMA/comments/1ta7ce9) (May 11, 2026, 21 score, 91 comments — owner of both confirms Spark faster prompt processing and better long-context scaling; Strix Halo more repurposable; community split on inference-specialization vs. longevity)
 
-The full set of 153 community reports lives in the Community Reports section above, filterable by hardware category and search.
+The full set of 195 community reports lives in the Community Reports section above, filterable by hardware category and search.
 
-_Last updated: 2026-05-18 (May 18 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings._
+_Last updated: 2026-05-26 (May 26 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings._


### PR DESCRIPTION
## Summary

- Updates the static footer text in `site/data/field-notes.md` from "153 community reports" to "195 community reports"
- Updates the Last-updated date from 2026-05-18 to 2026-05-26
- Regenerates `site/community.html`

This text was pre-existing before PR #238 and became stale when the card count grew from 153 to 195. Caught during QA of todo t_01KSGTK7KVFKY7W9GEG1WT25PP.

## Source files touched
- `site/data/field-notes.md` (2-line footer update)
- `site/community.html` (regenerated from generate-site.py)

## Checks run
- `pnpm check:changed` (pre-commit hook: docs lane, no type errors)