### PR TITLE
fix(auth): harden Vertex AI authentication, dedicated URL support, and Gemma 4 model routing

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -184,6 +184,16 @@ describe("google generative ai helpers", () => {
     expect(result.headers["Content-Type"]).toBe("application/json");
   });
 
+  it("fails loudly when gcloud automated credentials cannot resolve a token", () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("gcloud failed");
+    });
+
+    expect(() => parseGeminiAuth("gcp-vertex-credentials")).toThrow(
+      "Failed to resolve Vertex AI credentials via gcloud",
+    );
+  });
+
   it("falls back to API key headers for raw tokens", () => {
     expect(parseGeminiAuth("api-key-123")).toEqual({
       headers: {

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -1,5 +1,6 @@
+import { execSync } from "node:child_process";
 import type { ProviderRequestTransportOverrides } from "openclaw/plugin-sdk/provider-http";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   isGoogleGenerativeAiApi,
   normalizeGoogleApiBaseUrl,
@@ -12,7 +13,19 @@ import {
   shouldNormalizeGoogleGenerativeAiProviderConfig,
 } from "./api.js";
 
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execSync: vi.fn(),
+  };
+});
+
 describe("google generative ai helpers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("detects the Google Generative AI transport id", () => {
     expect(isGoogleGenerativeAiApi("google-generative-ai")).toBe(true);
     expect(isGoogleGenerativeAiApi("google-gemini-cli")).toBe(false);
@@ -156,6 +169,19 @@ describe("google generative ai helpers", () => {
         "Content-Type": "application/json",
       },
     });
+  });
+
+  it("resolves token via gcloud for gcp-vertex-credentials marker", () => {
+    vi.mocked(execSync).mockReturnValue("mocked-token\n" as any);
+
+    const result = parseGeminiAuth("gcp-vertex-credentials");
+
+    expect(execSync).toHaveBeenCalledWith(
+      "gcloud auth application-default print-access-token",
+      expect.any(Object),
+    );
+    expect(result.headers.Authorization).toBe("Bearer mocked-token");
+    expect(result.headers["Content-Type"]).toBe("application/json");
   });
 
   it("falls back to API key headers for raw tokens", () => {

--- a/extensions/google/gemini-auth.ts
+++ b/extensions/google/gemini-auth.ts
@@ -18,8 +18,10 @@ export function parseGeminiAuth(apiKey: string): { headers: Record<string, strin
         },
       };
     } catch (e) {
-      // In case gcloud fails, we log it and return empty headers (which will likely result in a 401).
-      console.error("Failed to resolve Vertex AI credentials via gcloud application-default:", e);
+      const message = e instanceof Error ? e.message : String(e);
+      throw new Error(`Failed to resolve Vertex AI credentials via gcloud: ${message}`, {
+        cause: e,
+      });
     }
   }
 

--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -385,4 +385,25 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
       reasoning: false,
     });
   });
+
+  it("resolves Gemma 4 model with reasoning enabled even when modelId has publishers/google/models/ prefix", () => {
+    const model = resolveGoogleGeminiForwardCompatModel({
+      providerId: "google-vertex",
+      ctx: createContext({
+        provider: "google-vertex",
+        modelId: "publishers/google/models/gemma-4-31b-it",
+        models: [createTemplateModel("google", "gemini-3-flash-preview", { reasoning: false })],
+      }),
+    });
+
+    expect(model).toMatchObject({
+      provider: "google-vertex",
+      id: "publishers/google/models/gemma-4-31b-it",
+      reasoning: true,
+    });
+  });
+
+  it("treats publishers/google/models/gemma prefixed models as modern models", () => {
+    expect(isModernGoogleModel("publishers/google/models/gemma-4-31b-it")).toBe(true);
+  });
 });

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -121,7 +121,12 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
   ctx: ProviderResolveDynamicModelContext;
 }): ProviderRuntimeModel | undefined {
   const trimmed = params.ctx.modelId.trim();
-  const lower = normalizeOptionalLowercaseString(trimmed) ?? "";
+  let lower = normalizeOptionalLowercaseString(trimmed) ?? "";
+
+  const prefix = "publishers/google/models/";
+  if (lower.startsWith(prefix)) {
+    lower = lower.slice(prefix.length);
+  }
 
   let family: GoogleForwardCompatFamily;
   let patch: Partial<ProviderRuntimeModel> | undefined;
@@ -201,7 +206,11 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
 }
 
 export function isModernGoogleModel(modelId: string): boolean {
-  const lower = normalizeOptionalLowercaseString(modelId) ?? "";
+  let lower = normalizeOptionalLowercaseString(modelId) ?? "";
+  const prefix = "publishers/google/models/";
+  if (lower.startsWith(prefix)) {
+    lower = lower.slice(prefix.length);
+  }
   return (
     lower.startsWith("gemini-2.5") ||
     lower.startsWith("gemini-3") ||

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -97,7 +97,7 @@ function buildGoogleTemplateSources(params: {
     params.family.preferExternalFirstForCli === true;
   const orderedTemplateProviderIds = preferredExternalFirst
     ? [defaultTemplateProviderId, params.providerId]
-    : [params.providerId, defaultTemplateProviderId];
+    : [params.providerId, defaultTemplateProviderId, "google"];
 
   const seen = new Set<string>();
   const sources: GoogleTemplateSource[] = [];

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -19,6 +19,7 @@ export type OpenAICompletionsCompatDefaults = {
   thinkingFormat: "openai" | "openrouter" | "zai";
   visibleReasoningDetailTypes: string[];
   supportsStrictMode: boolean;
+  requiresStringContent: boolean;
 };
 
 export type DetectedOpenAICompletionsCompat = {
@@ -83,31 +84,41 @@ export function resolveOpenAICompletionsCompatDefaults(
     (isDefaultRoute &&
       isDefaultRouteProvider(input.provider, "cerebras", "chutes", "deepseek", "opencode", "xai"));
   const isOpenRouterLike = input.provider === "openrouter" || endpointClass === "openrouter";
-  const usesMaxTokens =
-    endpointClass === "chutes-native" ||
-    endpointClass === "mistral-public" ||
-    knownProviderFamily === "mistral" ||
-    (isDefaultRoute && isDefaultRouteProvider(provider, "chutes"));
   const supportsKnownLocalStreamingUsage = isKnownLocalStreamingUsageProvider(
     provider,
     knownProviderFamily,
   );
+  const isGoogleVertex = endpointClass === "google-vertex";
+  const usesMaxTokens =
+    endpointClass === "chutes-native" ||
+    endpointClass === "mistral-public" ||
+    knownProviderFamily === "mistral" ||
+    isGoogleVertex ||
+    (isDefaultRoute && isDefaultRouteProvider(provider, "chutes"));
   return {
     supportsStore:
-      !isNonStandard && knownProviderFamily !== "mistral" && !usesExplicitProxyLikeEndpoint,
-    supportsDeveloperRole: !isNonStandard && !isMoonshotLike && !usesConfiguredNonOpenAIEndpoint,
+      !isNonStandard &&
+      knownProviderFamily !== "mistral" &&
+      !usesExplicitProxyLikeEndpoint &&
+      !isGoogleVertex,
+    supportsDeveloperRole:
+      !isNonStandard && !isMoonshotLike && !usesConfiguredNonOpenAIEndpoint && !isGoogleVertex,
     supportsReasoningEffort:
       !isZai &&
       knownProviderFamily !== "mistral" &&
       endpointClass !== "xai-native" &&
-      !usesExplicitProxyLikeEndpoint,
+      !usesExplicitProxyLikeEndpoint &&
+      !isGoogleVertex,
     supportsUsageInStreaming:
       supportsKnownLocalStreamingUsage ||
-      (!isNonStandard && (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat)),
+      (!isNonStandard &&
+        (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat) &&
+        !isGoogleVertex),
     maxTokensField: usesMaxTokens ? "max_tokens" : "max_completion_tokens",
     thinkingFormat: isZai ? "zai" : isOpenRouterLike ? "openrouter" : "openai",
     visibleReasoningDetailTypes: isOpenRouterLike ? ["response.output_text", "response.text"] : [],
-    supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint,
+    supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint && !isGoogleVertex,
+    requiresStringContent: isGoogleVertex,
   };
 }
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -87,6 +87,33 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("does not convert non-Google OpenAI-compatible keys into Google headers", () => {
+    const auth = __testing.resolveOpenAICompatAuth(
+      { provider: "openai" } as Model<"openai-completions">,
+      "sk-test-key",
+    );
+
+    expect(auth).toEqual({
+      apiKey: "sk-test-key",
+      headers: {},
+    });
+  });
+
+  it("extracts Google OAuth bearer tokens for OpenAI-compatible clients", () => {
+    const auth = __testing.resolveOpenAICompatAuth(
+      { provider: "google-vertex" } as Model<"openai-completions">,
+      "ya29.mock-token",
+    );
+
+    expect(auth).toEqual({
+      apiKey: "ya29.mock-token",
+      headers: {
+        Authorization: "Bearer ya29.mock-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
   it("reports the supported transport-aware APIs", () => {
     expect(isTransportAwareApiSupported("openai-responses")).toBe(true);
     expect(isTransportAwareApiSupported("openai-codex-responses")).toBe(true);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -627,6 +627,20 @@ function buildOpenAIClientHeaders(
   return headers;
 }
 
+function resolveOpenAICompatAuth(
+  model: Pick<Model<Api>, "provider">,
+  rawApiKey: string,
+): { apiKey: string; headers: Record<string, string> } {
+  if (model.provider !== "google" && model.provider !== "google-vertex") {
+    return { apiKey: rawApiKey, headers: {} };
+  }
+
+  const authHeaders = parseGeminiAuth(rawApiKey).headers;
+  const bearer = authHeaders["Authorization"] ?? authHeaders["authorization"];
+  const apiKey = bearer?.startsWith("Bearer ") ? bearer.slice(7) : rawApiKey;
+  return { apiKey, headers: authHeaders };
+}
+
 function resolveProviderTransportTurnState(
   model: Model<Api>,
   params: {
@@ -690,11 +704,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
       };
       try {
         const rawApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const auth = parseGeminiAuth(rawApiKey);
-        const authHeaders = auth.headers;
-        const apiKey = authHeaders["Authorization"]?.startsWith("Bearer ")
-          ? authHeaders["Authorization"].slice(7)
-          : rawApiKey;
+        const auth = resolveOpenAICompatAuth(model, rawApiKey);
 
         const turnState = resolveProviderTransportTurnState(model, {
           sessionId: options?.sessionId,
@@ -705,8 +715,8 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
         const client = createOpenAIResponsesClient(
           model,
           context,
-          apiKey,
-          { ...options?.headers, ...authHeaders },
+          auth.apiKey,
+          { ...options?.headers, ...auth.headers },
           turnState?.headers,
         );
         let params = buildOpenAIResponsesParams(
@@ -924,12 +934,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
         timestamp: Date.now(),
       };
       try {
-        const rawApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const auth = parseGeminiAuth(rawApiKey);
-        const authHeaders = auth.headers;
-        const apiKey = authHeaders["Authorization"]?.startsWith("Bearer ")
-          ? authHeaders["Authorization"].slice(7)
-          : rawApiKey;
+        const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 
         const turnState = resolveProviderTransportTurnState(model, {
           sessionId: options?.sessionId,
@@ -941,7 +946,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           model,
           context,
           apiKey,
-          { ...options?.headers, ...authHeaders },
+          options?.headers,
           turnState?.headers,
         );
         const deploymentName = resolveAzureDeploymentName(model);
@@ -1145,15 +1150,11 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       };
       try {
         const rawApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const auth = parseGeminiAuth(rawApiKey);
-        const authHeaders = auth.headers;
-        const apiKey = authHeaders["Authorization"]?.startsWith("Bearer ")
-          ? authHeaders["Authorization"].slice(7)
-          : rawApiKey;
+        const auth = resolveOpenAICompatAuth(model, rawApiKey);
 
-        const client = createOpenAICompletionsClient(model, context, apiKey, {
+        const client = createOpenAICompletionsClient(model, context, auth.apiKey, {
           ...options?.headers,
-          ...authHeaders,
+          ...auth.headers,
         });
 
         let params = buildOpenAICompletionsParams(
@@ -1165,7 +1166,6 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
-        process.stderr.write(`DEBUG: [openai-completions] Final Body: ${JSON.stringify(params)}\n`);
         const responseStream = (await client.chat.completions.create(params as never, {
           signal: options?.signal,
         })) as unknown as AsyncIterable<ChatCompletionChunk>;
@@ -1761,4 +1761,5 @@ function mapStopReason(reason: string | null) {
 export const __testing = {
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
+  resolveOpenAICompatAuth,
 };

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -19,6 +19,7 @@ import type {
   ResponseInput,
   ResponseInputMessageContentList,
 } from "openai/resources/responses/responses.js";
+import { parseGeminiAuth } from "../infra/gemini-auth.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
@@ -615,6 +616,14 @@ function buildOpenAIClientHeaders(
   if (turnHeaders) {
     Object.assign(headers, turnHeaders);
   }
+
+  // If we have an Authorization header (token-based auth), strip the
+  // vendor-specific x-goog-api-key to avoid credential interference
+  // at the bridge/proxy layer.
+  if (headers["Authorization"] || headers["authorization"]) {
+    delete headers["x-goog-api-key"];
+  }
+
   return headers;
 }
 
@@ -680,7 +689,13 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
         timestamp: Date.now(),
       };
       try {
-        const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+        const rawApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+        const auth = parseGeminiAuth(rawApiKey);
+        const authHeaders = auth.headers;
+        const apiKey = authHeaders["Authorization"]?.startsWith("Bearer ")
+          ? authHeaders["Authorization"].slice(7)
+          : rawApiKey;
+
         const turnState = resolveProviderTransportTurnState(model, {
           sessionId: options?.sessionId,
           turnId: randomUUID(),
@@ -691,7 +706,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           model,
           context,
           apiKey,
-          options?.headers,
+          { ...options?.headers, ...authHeaders },
           turnState?.headers,
         );
         let params = buildOpenAIResponsesParams(
@@ -909,7 +924,13 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
         timestamp: Date.now(),
       };
       try {
-        const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+        const rawApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+        const auth = parseGeminiAuth(rawApiKey);
+        const authHeaders = auth.headers;
+        const apiKey = authHeaders["Authorization"]?.startsWith("Bearer ")
+          ? authHeaders["Authorization"].slice(7)
+          : rawApiKey;
+
         const turnState = resolveProviderTransportTurnState(model, {
           sessionId: options?.sessionId,
           turnId: randomUUID(),
@@ -920,7 +941,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           model,
           context,
           apiKey,
-          options?.headers,
+          { ...options?.headers, ...authHeaders },
           turnState?.headers,
         );
         const deploymentName = resolveAzureDeploymentName(model);
@@ -1051,6 +1072,17 @@ function buildOpenAICompletionsClientConfig(
   defaultQuery?: Record<string, string>;
 } {
   const headers = buildOpenAIClientHeaders(model, context, optionHeaders);
+
+  // OpenAI SDK always generates an Authorization header from the apiKey
+  // constructor argument. Strip it from defaultHeaders to avoid sending
+  // duplicate or conflicting authorization headers.
+  if (headers["Authorization"]) {
+    delete headers["Authorization"];
+  }
+  if (headers["authorization"]) {
+    delete headers["authorization"];
+  }
+
   const defaultQuery: Record<string, string> = {};
   let baseURL = model.baseUrl;
   let isAzureHost = false;
@@ -1112,8 +1144,18 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         timestamp: Date.now(),
       };
       try {
-        const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
+        const rawApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+        const auth = parseGeminiAuth(rawApiKey);
+        const authHeaders = auth.headers;
+        const apiKey = authHeaders["Authorization"]?.startsWith("Bearer ")
+          ? authHeaders["Authorization"].slice(7)
+          : rawApiKey;
+
+        const client = createOpenAICompletionsClient(model, context, apiKey, {
+          ...options?.headers,
+          ...authHeaders,
+        });
+
         let params = buildOpenAICompletionsParams(
           model as OpenAIModeModel,
           context,
@@ -1123,6 +1165,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
+        process.stderr.write(`DEBUG: [openai-completions] Final Body: ${JSON.stringify(params)}\n`);
         const responseStream = (await client.chat.completions.create(params as never, {
           signal: options?.signal,
         })) as unknown as AsyncIterable<ChatCompletionChunk>;
@@ -1474,6 +1517,7 @@ function detectCompat(model: OpenAIModeModel) {
     openRouterRouting: {},
     vercelGatewayRouting: {},
     supportsStrictMode: compatDefaults.supportsStrictMode,
+    requiresStringContent: compatDefaults.requiresStringContent,
   };
 }
 
@@ -1525,7 +1569,8 @@ function getCompat(model: OpenAIModeModel): {
       detected.vercelGatewayRouting,
     supportsStrictMode:
       (compat.supportsStrictMode as boolean | undefined) ?? detected.supportsStrictMode,
-    requiresStringContent: (compat.requiresStringContent as boolean | undefined) ?? false,
+    requiresStringContent:
+      (compat.requiresStringContent as boolean | undefined) ?? detected.requiresStringContent,
     visibleReasoningDetailTypes:
       (compat.visibleReasoningDetailTypes as string[] | undefined) ??
       detected.visibleReasoningDetailTypes,
@@ -1593,13 +1638,18 @@ export function buildOpenAICompletionsParams(
       }
     : context;
   const messages = convertMessages(model as never, completionsContext, compat as never);
+  const isGoogleVertex = model.provider === "google-vertex";
+  let modelId = model.id;
+  if (isGoogleVertex && model.id.includes("publishers/")) {
+    modelId = model.id.slice(model.id.indexOf("publishers/"));
+  }
   const params: Record<string, unknown> = {
-    model: model.id,
+    model: modelId,
     messages: compat.requiresStringContent
       ? flattenCompletionMessagesToStringContent(messages)
       : messages,
     stream: true,
-    stream_options: { include_usage: true },
+    ...(isGoogleVertex ? {} : { stream_options: { include_usage: true } }),
   };
   if (compat.supportsStore) {
     params.store = false;
@@ -1629,12 +1679,12 @@ export function buildOpenAICompletionsParams(
   if (options?.seed !== undefined) {
     params.seed = options.seed;
   }
-  if (context.tools) {
+  if (context.tools && model.provider !== "google-vertex") {
     params.tools = convertTools(context.tools, compat, model);
     if (options?.toolChoice) {
       params.tool_choice = options.toolChoice;
     }
-  } else if (hasToolHistory(context.messages)) {
+  } else if (model.provider !== "google-vertex" && hasToolHistory(context.messages)) {
     params.tools = [];
   }
   const completionsReasoningEffort = resolveOpenAICompletionsReasoningEffort(options);

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   setupCommandMock: vi.fn(),
   setupWizardCommandMock: vi.fn(),
   setupGemmaCommandMock: vi.fn(),
+  applySetupAgentConfigMock: vi.fn(),
+  applyAgentNameAndBootstrapMock: vi.fn(),
   runtime: {
     log: vi.fn(),
     error: vi.fn(),
@@ -16,6 +18,8 @@ const mocks = vi.hoisted(() => ({
 const setupCommandMock = mocks.setupCommandMock;
 const setupWizardCommandMock = mocks.setupWizardCommandMock;
 const setupGemmaCommandMock = mocks.setupGemmaCommandMock;
+const applySetupAgentConfigMock = mocks.applySetupAgentConfigMock;
+const applyAgentNameAndBootstrapMock = mocks.applyAgentNameAndBootstrapMock;
 const runtime = mocks.runtime;
 
 vi.mock("../../commands/setup.js", () => ({
@@ -28,6 +32,31 @@ vi.mock("../../commands/onboard.js", () => ({
 
 vi.mock("../../commands/setup-gemma.js", () => ({
   setupGemmaCommand: mocks.setupGemmaCommandMock,
+  applySetupAgentConfig: mocks.applySetupAgentConfigMock,
+  applyAgentNameAndBootstrap: mocks.applyAgentNameAndBootstrapMock,
+}));
+
+vi.mock("../../gemmaclaw/provision/vertex-setup.js", () => ({
+  interactiveVertexSetup: vi.fn().mockResolvedValue({
+    ok: true,
+    config: {
+      project: "test-project",
+      region: "us-central1",
+      model: "gemma-3-27b-it",
+    },
+  }),
+  buildVertexConfig: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  mutateConfigFile: vi.fn().mockImplementation(async ({ mutate }) => {
+    const draft = { agents: { list: [] } };
+    await mutate(draft);
+  }),
+}));
+
+vi.mock("../../config/merge-patch.js", () => ({
+  applyMergePatch: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock("../../runtime.js", () => ({
@@ -137,8 +166,6 @@ describe("registerSetupCommand", () => {
       "high",
       "--bootstrap",
       "coding",
-      "--enhancements",
-      "external_delivery_receipt_verification",
       "--dry-run",
     ]);
 
@@ -149,7 +176,6 @@ describe("registerSetupCommand", () => {
         model: "google/gemini-2.5-pro",
         thinking: "high",
         bootstrap: "coding",
-        enhancements: "external_delivery_receipt_verification",
         dryRun: true,
       }),
       runtime,
@@ -172,20 +198,6 @@ describe("registerSetupCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
-  it("forwards --no-enhancements as an explicit disabled enhancement selection", async () => {
-    await runCli(["setup", "--non-interactive", "--setup-mode", "local", "--no-enhancements"]);
-
-    expect(setupGemmaCommandMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        nonInteractive: true,
-        setupMode: "local",
-        enhancements: "none",
-      }),
-      runtime,
-    );
-    expect(setupWizardCommandMock).not.toHaveBeenCalled();
-  });
-
   it("ignores invalid enum values for --thinking / --bootstrap / --setup-mode", async () => {
     await runCli(["setup", "--setup-mode", "bogus", "--thinking", "ultra", "--bootstrap", "weird"]);
 
@@ -196,6 +208,24 @@ describe("registerSetupCommand", () => {
         bootstrap: undefined,
       }),
       runtime,
+    );
+  });
+
+  it("triggers agent creation and bootstrap during Vertex setup when --vertex is set", async () => {
+    await runCli(["setup", "--vertex", "--agent-name", "vertex-bot"]);
+
+    expect(applySetupAgentConfigMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        agentName: "vertex-bot",
+        backend: "vertex",
+      }),
+    );
+    expect(applyAgentNameAndBootstrapMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: "vertex-bot",
+        backend: "vertex",
+      }),
     );
   });
 });

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -6,8 +6,7 @@ const mocks = vi.hoisted(() => ({
   setupCommandMock: vi.fn(),
   setupWizardCommandMock: vi.fn(),
   setupGemmaCommandMock: vi.fn(),
-  applySetupAgentConfigMock: vi.fn(),
-  applyAgentNameAndBootstrapMock: vi.fn(),
+  runVertexSetupCommandMock: vi.fn(),
   runtime: {
     log: vi.fn(),
     error: vi.fn(),
@@ -18,8 +17,7 @@ const mocks = vi.hoisted(() => ({
 const setupCommandMock = mocks.setupCommandMock;
 const setupWizardCommandMock = mocks.setupWizardCommandMock;
 const setupGemmaCommandMock = mocks.setupGemmaCommandMock;
-const applySetupAgentConfigMock = mocks.applySetupAgentConfigMock;
-const applyAgentNameAndBootstrapMock = mocks.applyAgentNameAndBootstrapMock;
+const runVertexSetupCommandMock = mocks.runVertexSetupCommandMock;
 const runtime = mocks.runtime;
 
 vi.mock("../../commands/setup.js", () => ({
@@ -32,31 +30,10 @@ vi.mock("../../commands/onboard.js", () => ({
 
 vi.mock("../../commands/setup-gemma.js", () => ({
   setupGemmaCommand: mocks.setupGemmaCommandMock,
-  applySetupAgentConfig: mocks.applySetupAgentConfigMock,
-  applyAgentNameAndBootstrap: mocks.applyAgentNameAndBootstrapMock,
 }));
 
-vi.mock("../../gemmaclaw/provision/vertex-setup.js", () => ({
-  interactiveVertexSetup: vi.fn().mockResolvedValue({
-    ok: true,
-    config: {
-      project: "test-project",
-      region: "us-central1",
-      model: "gemma-3-27b-it",
-    },
-  }),
-  buildVertexConfig: vi.fn().mockReturnValue({}),
-}));
-
-vi.mock("../../config/config.js", () => ({
-  mutateConfigFile: vi.fn().mockImplementation(async ({ mutate }) => {
-    const draft = { agents: { list: [] } };
-    await mutate(draft);
-  }),
-}));
-
-vi.mock("../../config/merge-patch.js", () => ({
-  applyMergePatch: vi.fn().mockReturnValue({}),
+vi.mock("../../gemmaclaw/provision/vertex-command.js", () => ({
+  runVertexSetupCommand: mocks.runVertexSetupCommandMock,
 }));
 
 vi.mock("../../runtime.js", () => ({
@@ -75,6 +52,7 @@ describe("registerSetupCommand", () => {
     setupCommandMock.mockResolvedValue(undefined);
     setupWizardCommandMock.mockResolvedValue(undefined);
     setupGemmaCommandMock.mockResolvedValue(undefined);
+    runVertexSetupCommandMock.mockResolvedValue(undefined);
   });
 
   it("runs Gemma setup wizard by default", async () => {
@@ -166,6 +144,8 @@ describe("registerSetupCommand", () => {
       "high",
       "--bootstrap",
       "coding",
+      "--enhancements",
+      "external_delivery_receipt_verification",
       "--dry-run",
     ]);
 
@@ -176,6 +156,7 @@ describe("registerSetupCommand", () => {
         model: "google/gemini-2.5-pro",
         thinking: "high",
         bootstrap: "coding",
+        enhancements: "external_delivery_receipt_verification",
         dryRun: true,
       }),
       runtime,
@@ -198,6 +179,59 @@ describe("registerSetupCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
+  it("forwards --no-enhancements as an explicit disabled enhancement selection", async () => {
+    await runCli(["setup", "--non-interactive", "--setup-mode", "local", "--no-enhancements"]);
+
+    expect(setupGemmaCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nonInteractive: true,
+        setupMode: "local",
+        enhancements: "none",
+      }),
+      runtime,
+    );
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("routes direct Vertex setup through the Gemmaclaw Vertex command helper", async () => {
+    await runCli([
+      "setup",
+      "--vertex",
+      "--agent-name",
+      "vertex-bot",
+      "--vertex-project",
+      "proj",
+      "--vertex-region",
+      "us-central1",
+      "--vertex-model",
+      "gemma-4-31b-it",
+      "--vertex-api-format",
+      "openai",
+      "--vertex-dedicated-url",
+      "https://vertex.example/v1",
+      "--non-interactive",
+      "--no-enhancements",
+    ]);
+
+    expect(runVertexSetupCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: "vertex-bot",
+        nonInteractive: true,
+        enhancements: "none",
+      }),
+      expect.objectContaining({
+        project: "proj",
+        region: "us-central1",
+        model: "gemma-4-31b-it",
+        apiFormat: "openai",
+        dedicatedUrl: "https://vertex.example/v1",
+      }),
+      runtime,
+    );
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+    expect(setupGemmaCommandMock).not.toHaveBeenCalled();
+  });
+
   it("ignores invalid enum values for --thinking / --bootstrap / --setup-mode", async () => {
     await runCli(["setup", "--setup-mode", "bogus", "--thinking", "ultra", "--bootstrap", "weird"]);
 
@@ -208,24 +242,6 @@ describe("registerSetupCommand", () => {
         bootstrap: undefined,
       }),
       runtime,
-    );
-  });
-
-  it("triggers agent creation and bootstrap during Vertex setup when --vertex is set", async () => {
-    await runCli(["setup", "--vertex", "--agent-name", "vertex-bot"]);
-
-    expect(applySetupAgentConfigMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        agentName: "vertex-bot",
-        backend: "vertex",
-      }),
-    );
-    expect(applyAgentNameAndBootstrapMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentName: "vertex-bot",
-        backend: "vertex",
-      }),
     );
   });
 });

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -1,16 +1,11 @@
 import type { Command } from "commander";
 import { setupWizardCommand } from "../../commands/onboard.js";
 import { setupCommand } from "../../commands/setup.js";
-import {
-  OnboardingBootstrap,
-  OnboardingThinking,
-} from "../../gemmaclaw/provision/onboarding-wizard.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
-import { getDefaultGemmaclawEnhancementIds } from "../../gemmaclaw/gemmaclaw_instructions.js";
 
 export function registerSetupCommand(program: Command) {
   program
@@ -59,6 +54,11 @@ export function registerSetupCommand(program: Command) {
     .option("--model <id>", "Model id (e.g. gemma3:4b, google/gemini-2.5-flash)")
     .option("--thinking <level>", "Thinking level: off|low|medium|high (default: medium)")
     .option("--bootstrap <profile>", "Bootstrap profile: general|coding|minimal (default: general)")
+    .option(
+      "--enhancements <selection>",
+      "Gemmaclaw enhancements: default|all|none|comma-separated ids (default: default)",
+    )
+    .option("--no-enhancements", "Disable all Gemmaclaw setup enhancements")
     .option("--dry-run", "Run wizard + write config without provisioning the backend", false)
     .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
@@ -79,6 +79,7 @@ export function registerSetupCommand(program: Command) {
           "agentName",
           "thinking",
           "bootstrap",
+          "enhancements",
           "dryRun",
           "model",
         ]);
@@ -107,85 +108,29 @@ export function registerSetupCommand(program: Command) {
 
         // Vertex AI setup
         if (opts.vertex) {
-          const { interactiveVertexSetup, buildVertexConfig } =
-            await import("../../gemmaclaw/provision/vertex-setup.js");
-          const fs = await import("node:fs");
-          const path = await import("node:path");
-
-          const result = await interactiveVertexSetup({
-            project: opts.vertexProject as string | undefined,
-            region: opts.vertexRegion as string | undefined,
-            model: opts.vertexModel as string | undefined,
-            apiFormat: opts.vertexApiFormat as "native" | "openai" | undefined,
-            dedicatedUrl: opts.vertexDedicatedUrl as string | undefined,
-            nonInteractive: Boolean(opts.nonInteractive),
-          });
-          if (!result.ok || !result.config) {
-            console.error(`\nVertex AI setup failed: ${result.error}`);
-            process.exit(1);
-          }
-
-          // Write config
-          const { mutateConfigFile } = await import("../../config/config.js");
-          const { applyMergePatch } = await import("../../config/merge-patch.js");
-          const { applySetupAgentConfig, applyAgentNameAndBootstrap } =
-            await import("../../commands/setup-gemma.js");
-
-          const choices = {
-            agentName: (opts.agentName as string) || "main",
-            useContainer: opts.container !== false,
-            backend: "vertex" as const,
-            model: result.config.model,
-            thinkingLevel: (opts.thinking as OnboardingThinking) || "medium",
-            bootstrap: (opts.bootstrap as OnboardingBootstrap) || "general",
-            enhancements: getDefaultGemmaclawEnhancementIds(),
-          };
-
-          const vertexConfigPatch = buildVertexConfig(result.config);
-          await mutateConfigFile({
-            mutate: (draft) => {
-              Object.assign(draft, applyMergePatch(draft, vertexConfigPatch));
-              applySetupAgentConfig(draft, choices);
+          const { runVertexSetupCommand } =
+            await import("../../gemmaclaw/provision/vertex-command.js");
+          await runVertexSetupCommand(
+            {
+              agentName: opts.agentName as string | undefined,
+              noContainer: opts.container === false,
+              thinking: opts.thinking as string | undefined,
+              bootstrap: opts.bootstrap as string | undefined,
+              nonInteractive: Boolean(opts.nonInteractive),
+              acceptRisk: Boolean(opts.acceptRisk),
+              dryRun: Boolean(opts.dryRun),
+              enhancements:
+                opts.enhancements === false ? "none" : (opts.enhancements as string | undefined),
             },
-          });
-          console.log("\nConfig updated with Vertex AI provider.");
-
-          // Write bootstrap files (AGENTS.md etc)
-          await applyAgentNameAndBootstrap(choices);
-
-          // Write auth profile with gcloud access token
-          if (result.config.accessToken && !result.config.useAutomatedCredentials) {
-            const { resolveStateDir } = await import("../../config/paths.js");
-            const stateDir = resolveStateDir(process.env);
-            const agentName = (opts.agentName as string) || "main";
-            const authPath = path.join(stateDir, "agents", agentName, "agent/auth-profiles.json");
-            let existing: Record<string, unknown> = { version: 1, profiles: {} };
-            try {
-              existing = JSON.parse(fs.readFileSync(authPath, "utf-8"));
-            } catch {
-              /* first time */
-            }
-            const profiles = (existing.profiles ?? {}) as Record<string, unknown>;
-            profiles["google-vertex:gcloud"] = {
-              type: "token",
-              provider: "google-vertex",
-              token: result.config.accessToken,
-            };
-            existing.profiles = profiles;
-            fs.mkdirSync(path.dirname(authPath), { recursive: true });
-            fs.writeFileSync(authPath, JSON.stringify(existing, null, 2));
-            console.log("Auth profile saved (google-vertex:gcloud).");
-            console.log(
-              "\nNote: Access tokens expire in ~1 hour. " +
-                "Run 'gemmaclaw setup --vertex' again to refresh, " +
-                "or set GOOGLE_APPLICATION_CREDENTIALS for auto-refresh.",
-            );
-          }
-
-          console.log(
-            `\nVertex AI ready: ${result.config.model} on ${result.config.project} (${result.config.region})`,
+            {
+              project: opts.vertexProject as string | undefined,
+              region: opts.vertexRegion as string | undefined,
+              model: opts.vertexModel as string | undefined,
+              apiFormat: opts.vertexApiFormat as "native" | "openai" | undefined,
+              dedicatedUrl: opts.vertexDedicatedUrl as string | undefined,
+            },
+            defaultRuntime,
           );
-          console.log("Test it: gemmaclaw agent --local --message 'Hello'");
           return;
         }
 
@@ -209,6 +154,8 @@ export function registerSetupCommand(program: Command) {
           bootstrapRaw === "general" || bootstrapRaw === "coding" || bootstrapRaw === "minimal"
             ? bootstrapRaw
             : undefined;
+        const enhancementSelection =
+          opts.enhancements === false ? "none" : (opts.enhancements as string | undefined);
         await setupGemmaCommand(
           {
             advanced: Boolean(opts.advanced),
@@ -220,6 +167,7 @@ export function registerSetupCommand(program: Command) {
             model: opts.model as string | undefined,
             thinking,
             bootstrap,
+            enhancements: enhancementSelection,
           },
           defaultRuntime,
         );

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -1,11 +1,16 @@
 import type { Command } from "commander";
 import { setupWizardCommand } from "../../commands/onboard.js";
 import { setupCommand } from "../../commands/setup.js";
+import {
+  OnboardingBootstrap,
+  OnboardingThinking,
+} from "../../gemmaclaw/provision/onboarding-wizard.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
+import { getDefaultGemmaclawEnhancementIds } from "../../gemmaclaw/gemmaclaw_instructions.js";
 
 export function registerSetupCommand(program: Command) {
   program
@@ -34,6 +39,8 @@ export function registerSetupCommand(program: Command) {
     .option("--vertex-project <id>", "GCP project ID for Vertex AI")
     .option("--vertex-region <region>", "GCP region for Vertex AI (default: us-central1)")
     .option("--vertex-model <model>", "Gemma model on Vertex AI (e.g. gemma-3-27b-it)")
+    .option("--vertex-api-format <format>", "Vertex API format: native or openai")
+    .option("--vertex-dedicated-url <url>", "Dedicated vLLM / Model Garden endpoint URL")
     .option("--wizard", "Run interactive onboarding (workspace config)", false)
     .option("--non-interactive", "Run onboarding without prompts", false)
     .option(
@@ -52,11 +59,6 @@ export function registerSetupCommand(program: Command) {
     .option("--model <id>", "Model id (e.g. gemma3:4b, google/gemini-2.5-flash)")
     .option("--thinking <level>", "Thinking level: off|low|medium|high (default: medium)")
     .option("--bootstrap <profile>", "Bootstrap profile: general|coding|minimal (default: general)")
-    .option(
-      "--enhancements <selection>",
-      "Gemmaclaw enhancements: default|all|none|comma-separated ids (default: default)",
-    )
-    .option("--no-enhancements", "Disable all Gemmaclaw setup enhancements")
     .option("--dry-run", "Run wizard + write config without provisioning the backend", false)
     .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
@@ -77,11 +79,14 @@ export function registerSetupCommand(program: Command) {
           "agentName",
           "thinking",
           "bootstrap",
-          "enhancements",
           "dryRun",
           "model",
         ]);
-        if (!hasGemmaSetupFlags && (opts.workspaceOnly || opts.wizard || hasWorkspaceOnlyFlags)) {
+        if (
+          !opts.vertex &&
+          !hasGemmaSetupFlags &&
+          (opts.workspaceOnly || opts.wizard || hasWorkspaceOnlyFlags)
+        ) {
           if (opts.wizard || hasWorkspaceOnlyFlags) {
             await setupWizardCommand(
               {
@@ -104,7 +109,6 @@ export function registerSetupCommand(program: Command) {
         if (opts.vertex) {
           const { interactiveVertexSetup, buildVertexConfig } =
             await import("../../gemmaclaw/provision/vertex-setup.js");
-          const { writeConfigFile } = await import("../../config/config.js");
           const fs = await import("node:fs");
           const path = await import("node:path");
 
@@ -112,6 +116,8 @@ export function registerSetupCommand(program: Command) {
             project: opts.vertexProject as string | undefined,
             region: opts.vertexRegion as string | undefined,
             model: opts.vertexModel as string | undefined,
+            apiFormat: opts.vertexApiFormat as "native" | "openai" | undefined,
+            dedicatedUrl: opts.vertexDedicatedUrl as string | undefined,
             nonInteractive: Boolean(opts.nonInteractive),
           });
           if (!result.ok || !result.config) {
@@ -120,15 +126,39 @@ export function registerSetupCommand(program: Command) {
           }
 
           // Write config
+          const { mutateConfigFile } = await import("../../config/config.js");
+          const { applyMergePatch } = await import("../../config/merge-patch.js");
+          const { applySetupAgentConfig, applyAgentNameAndBootstrap } =
+            await import("../../commands/setup-gemma.js");
+
+          const choices = {
+            agentName: (opts.agentName as string) || "main",
+            useContainer: opts.container !== false,
+            backend: "vertex" as const,
+            model: result.config.model,
+            thinkingLevel: (opts.thinking as OnboardingThinking) || "medium",
+            bootstrap: (opts.bootstrap as OnboardingBootstrap) || "general",
+            enhancements: getDefaultGemmaclawEnhancementIds(),
+          };
+
           const vertexConfigPatch = buildVertexConfig(result.config);
-          await writeConfigFile(vertexConfigPatch);
+          await mutateConfigFile({
+            mutate: (draft) => {
+              Object.assign(draft, applyMergePatch(draft, vertexConfigPatch));
+              applySetupAgentConfig(draft, choices);
+            },
+          });
           console.log("\nConfig updated with Vertex AI provider.");
 
+          // Write bootstrap files (AGENTS.md etc)
+          await applyAgentNameAndBootstrap(choices);
+
           // Write auth profile with gcloud access token
-          if (result.config.accessToken) {
+          if (result.config.accessToken && !result.config.useAutomatedCredentials) {
             const { resolveStateDir } = await import("../../config/paths.js");
             const stateDir = resolveStateDir(process.env);
-            const authPath = path.join(stateDir, "agents/main/agent/auth-profiles.json");
+            const agentName = (opts.agentName as string) || "main";
+            const authPath = path.join(stateDir, "agents", agentName, "agent/auth-profiles.json");
             let existing: Record<string, unknown> = { version: 1, profiles: {} };
             try {
               existing = JSON.parse(fs.readFileSync(authPath, "utf-8"));
@@ -179,8 +209,6 @@ export function registerSetupCommand(program: Command) {
           bootstrapRaw === "general" || bootstrapRaw === "coding" || bootstrapRaw === "minimal"
             ? bootstrapRaw
             : undefined;
-        const enhancementSelection =
-          opts.enhancements === false ? "none" : (opts.enhancements as string | undefined);
         await setupGemmaCommand(
           {
             advanced: Boolean(opts.advanced),
@@ -192,7 +220,6 @@ export function registerSetupCommand(program: Command) {
             model: opts.model as string | undefined,
             thinking,
             bootstrap,
-            enhancements: enhancementSelection,
           },
           defaultRuntime,
         );

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.js";
-import {
-  COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
-  EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
-} from "../gemmaclaw/gemmaclaw_instructions.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   assertDockerForContainerMode,
@@ -73,6 +69,7 @@ vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   const mkdirSyncStub = vi.fn();
   const chmodSyncStub = vi.fn();
+  const statSyncStub = vi.fn().mockReturnValue({ mode: 0 });
   const writeFileSyncStub = vi.fn();
   const readFileSyncStub = vi.fn().mockImplementation(() => {
     throw Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
@@ -83,18 +80,19 @@ vi.mock("node:fs", async () => {
       ...actual,
       mkdirSync: mkdirSyncStub,
       chmodSync: chmodSyncStub,
+      statSync: statSyncStub,
       writeFileSync: writeFileSyncStub,
       readFileSync: readFileSyncStub,
     },
     mkdirSync: mkdirSyncStub,
     chmodSync: chmodSyncStub,
+    statSync: statSyncStub,
     writeFileSync: writeFileSyncStub,
     readFileSync: readFileSyncStub,
   };
 });
 
 const fsMock = await import("node:fs");
-const bootstrapProfilesMock = await import("../gemmaclaw/provision/bootstrap-profiles.js");
 
 function makeRuntime(): RuntimeEnv & { logs: string[]; errors: string[]; exitCodes: number[] } {
   const logs: string[] = [];
@@ -323,55 +321,6 @@ describe("setupGemmaCommand — agent creation", () => {
     expect(entry?.name).toBe("Steve");
   });
 
-  it("passes default enhancements into the bootstrap profile", async () => {
-    await setupGemmaCommand(
-      {
-        nonInteractive: true,
-        dryRun: true,
-        agentName: "EnhanceBot",
-        setupMode: "gemini",
-        model: "gemini-2.0-flash",
-        thinking: "medium",
-        noContainer: true,
-      },
-      runtime,
-    );
-
-    expect(bootstrapProfilesMock.applyBootstrapProfile).toHaveBeenCalledWith(
-      "general",
-      expect.stringContaining("EnhanceBot"),
-      expect.objectContaining({
-        useContainer: false,
-        enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID, COMMITMENT_FOLLOWTHROUGH_LOOP_ID],
-      }),
-    );
-  });
-
-  it("allows setup to disable enhancements explicitly", async () => {
-    await setupGemmaCommand(
-      {
-        nonInteractive: true,
-        dryRun: true,
-        agentName: "PlainBot",
-        setupMode: "gemini",
-        model: "gemini-2.0-flash",
-        thinking: "medium",
-        noContainer: true,
-        enhancements: "none",
-      },
-      runtime,
-    );
-
-    expect(bootstrapProfilesMock.applyBootstrapProfile).toHaveBeenCalledWith(
-      "general",
-      expect.stringContaining("PlainBot"),
-      expect.objectContaining({
-        useContainer: false,
-        enhancements: [],
-      }),
-    );
-  });
-
   it("produces an agents.list readable by listAgentEntries (same function used by gemmaclaw list)", async () => {
     await setupGemmaCommand(
       {
@@ -462,30 +411,19 @@ describe("setupGemmaCommand — agent creation", () => {
         readOnlyRoot: false,
         network: "bridge",
         capDrop: [],
-        setupCommand: expect.any(String),
+        setupCommand:
+          "apt-get -o APT::Sandbox::User=root update && " +
+          "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 && " +
+          "printf '\\numask 000\\n' >> /etc/profile && " +
+          "rm -rf /var/lib/apt/lists/*",
         user: "0:0",
       },
     });
     const docker = sandbox?.docker as Record<string, unknown> | undefined;
-    expect(docker?.setupCommand).toEqual(expect.any(String));
-    const setupCommand = docker?.setupCommand as string;
-    expect(setupCommand).toContain("/etc/apt/apt.conf.d/99gemmaclaw-network-retries");
-    expect(setupCommand).toContain('Acquire::Retries "5";');
-    expect(setupCommand).toContain("apt-get-retry");
-    expect(setupCommand).not.toContain("<<");
-    expect(setupCommand).toContain("Acquire::ForceIPv4=true");
-    expect(setupCommand).toContain(
-      "DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends bash ca-certificates curl wget git jq ripgrep python3 ffmpeg file unzip procps less",
-    );
-    for (const pkg of ["jq", "ripgrep", "file", "unzip", "wget", "procps", "less"]) {
-      expect(setupCommand).toContain(` ${pkg}`);
-    }
-    expect(setupCommand).toContain("printf '\\numask 000\\n' >> /etc/profile");
     expect(docker?.binds).toEqual([
       `${process.env.HOME ?? "/root"}/.gemmaclaw/shared:/workspace/shared:rw`,
     ]);
     expect(hoisted.capturedMutatedConfig.tools?.exec).toMatchObject({
-      host: "sandbox",
       security: "full",
       ask: "off",
     });

--- a/src/commands/setup-gemma.test.ts
+++ b/src/commands/setup-gemma.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.js";
+import {
+  COMMITMENT_FOLLOWTHROUGH_LOOP_ID,
+  EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID,
+} from "../gemmaclaw/gemmaclaw_instructions.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   assertDockerForContainerMode,
@@ -69,7 +73,6 @@ vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   const mkdirSyncStub = vi.fn();
   const chmodSyncStub = vi.fn();
-  const statSyncStub = vi.fn().mockReturnValue({ mode: 0 });
   const writeFileSyncStub = vi.fn();
   const readFileSyncStub = vi.fn().mockImplementation(() => {
     throw Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
@@ -80,19 +83,18 @@ vi.mock("node:fs", async () => {
       ...actual,
       mkdirSync: mkdirSyncStub,
       chmodSync: chmodSyncStub,
-      statSync: statSyncStub,
       writeFileSync: writeFileSyncStub,
       readFileSync: readFileSyncStub,
     },
     mkdirSync: mkdirSyncStub,
     chmodSync: chmodSyncStub,
-    statSync: statSyncStub,
     writeFileSync: writeFileSyncStub,
     readFileSync: readFileSyncStub,
   };
 });
 
 const fsMock = await import("node:fs");
+const bootstrapProfilesMock = await import("../gemmaclaw/provision/bootstrap-profiles.js");
 
 function makeRuntime(): RuntimeEnv & { logs: string[]; errors: string[]; exitCodes: number[] } {
   const logs: string[] = [];
@@ -321,6 +323,55 @@ describe("setupGemmaCommand — agent creation", () => {
     expect(entry?.name).toBe("Steve");
   });
 
+  it("passes default enhancements into the bootstrap profile", async () => {
+    await setupGemmaCommand(
+      {
+        nonInteractive: true,
+        dryRun: true,
+        agentName: "EnhanceBot",
+        setupMode: "gemini",
+        model: "gemini-2.0-flash",
+        thinking: "medium",
+        noContainer: true,
+      },
+      runtime,
+    );
+
+    expect(bootstrapProfilesMock.applyBootstrapProfile).toHaveBeenCalledWith(
+      "general",
+      expect.stringContaining("EnhanceBot"),
+      expect.objectContaining({
+        useContainer: false,
+        enhancements: [EXTERNAL_DELIVERY_RECEIPT_VERIFICATION_ID, COMMITMENT_FOLLOWTHROUGH_LOOP_ID],
+      }),
+    );
+  });
+
+  it("allows setup to disable enhancements explicitly", async () => {
+    await setupGemmaCommand(
+      {
+        nonInteractive: true,
+        dryRun: true,
+        agentName: "PlainBot",
+        setupMode: "gemini",
+        model: "gemini-2.0-flash",
+        thinking: "medium",
+        noContainer: true,
+        enhancements: "none",
+      },
+      runtime,
+    );
+
+    expect(bootstrapProfilesMock.applyBootstrapProfile).toHaveBeenCalledWith(
+      "general",
+      expect.stringContaining("PlainBot"),
+      expect.objectContaining({
+        useContainer: false,
+        enhancements: [],
+      }),
+    );
+  });
+
   it("produces an agents.list readable by listAgentEntries (same function used by gemmaclaw list)", async () => {
     await setupGemmaCommand(
       {
@@ -411,19 +462,30 @@ describe("setupGemmaCommand — agent creation", () => {
         readOnlyRoot: false,
         network: "bridge",
         capDrop: [],
-        setupCommand:
-          "apt-get -o APT::Sandbox::User=root update && " +
-          "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3 && " +
-          "printf '\\numask 000\\n' >> /etc/profile && " +
-          "rm -rf /var/lib/apt/lists/*",
+        setupCommand: expect.any(String),
         user: "0:0",
       },
     });
     const docker = sandbox?.docker as Record<string, unknown> | undefined;
+    expect(docker?.setupCommand).toEqual(expect.any(String));
+    const setupCommand = docker?.setupCommand as string;
+    expect(setupCommand).toContain("/etc/apt/apt.conf.d/99gemmaclaw-network-retries");
+    expect(setupCommand).toContain('Acquire::Retries "5";');
+    expect(setupCommand).toContain("apt-get-retry");
+    expect(setupCommand).not.toContain("<<");
+    expect(setupCommand).toContain("Acquire::ForceIPv4=true");
+    expect(setupCommand).toContain(
+      "DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends bash ca-certificates curl wget git jq ripgrep python3 ffmpeg file unzip procps less",
+    );
+    for (const pkg of ["jq", "ripgrep", "file", "unzip", "wget", "procps", "less"]) {
+      expect(setupCommand).toContain(` ${pkg}`);
+    }
+    expect(setupCommand).toContain("printf '\\numask 000\\n' >> /etc/profile");
     expect(docker?.binds).toEqual([
       `${process.env.HOME ?? "/root"}/.gemmaclaw/shared:/workspace/shared:rw`,
     ]);
     expect(hoisted.capturedMutatedConfig.tools?.exec).toMatchObject({
+      host: "sandbox",
       security: "full",
       ask: "off",
     });

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -1,8 +1,9 @@
-import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_process";
+import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveAgentDir } from "../agents/agent-scope.js";
+import { ensureDockerWritableHostDir } from "../config/io.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
@@ -39,7 +40,6 @@ export type SetupGemmaCommandOpts = {
   bootstrap?: OnboardingBootstrap;
   setupMode?: OnboardingBackend;
   model?: string;
-  enhancements?: string;
 };
 
 const HEALTH_POLL_INTERVAL_MS = 500;
@@ -51,66 +51,8 @@ const GEMMACLAW_DEFAULT_INTERNAL_HOOK_NAMES = [
   "session-memory",
 ] as const;
 
-function ensureDockerWritableHostDir(
-  fsModule: Pick<typeof import("node:fs"), "chmodSync" | "mkdirSync">,
-  dir: string,
-): void {
-  fsModule.mkdirSync(dir, { recursive: true });
-  fsModule.chmodSync(dir, 0o777);
-  try {
-    execFileSync("setfacl", ["-d", "-m", "u::rwx,g::rwx,o::rwx", dir], { stdio: "ignore" });
-  } catch {
-    // setfacl is not available on every host. chmod(777) keeps the directory
-    // writable, and the live Docker smoke catches hosts that need default ACLs.
-  }
-}
-
 function resolveGemmaclawSharedDir(): string {
   return path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
-}
-
-const GEMMACLAW_APT_NETWORK_RETRY_CONF = [
-  'Acquire::Retries "5";',
-  'Acquire::http::Timeout "30";',
-  'Acquire::https::Timeout "30";',
-].join("\n");
-
-const GEMMACLAW_DEFAULT_SANDBOX_PACKAGES = [
-  "bash",
-  "ca-certificates",
-  "curl",
-  "wget",
-  "git",
-  "jq",
-  "ripgrep",
-  "python3",
-  "ffmpeg",
-  "file",
-  "unzip",
-  "procps",
-  "less",
-].join(" ");
-
-function buildGemmaclawSandboxSetupCommand(): string {
-  return [
-    `printf '%s\\n' ${GEMMACLAW_APT_NETWORK_RETRY_CONF.split("\n")
-      .map((line) => `'${line}'`)
-      .join(" ")} > /etc/apt/apt.conf.d/99gemmaclaw-network-retries`,
-    [
-      "printf '%s\\n'",
-      "'#!/bin/sh'",
-      "'apt-get -o APT::Sandbox::User=root \"$@\"'",
-      "'status=$?'",
-      "'if [ \"$status\" -eq 0 ]; then exit 0; fi'",
-      "'exec apt-get -o APT::Sandbox::User=root -o Acquire::ForceIPv4=true \"$@\"'",
-      "> /usr/local/bin/apt-get-retry",
-    ].join(" "),
-    "chmod 755 /usr/local/bin/apt-get-retry",
-    "apt-get-retry update",
-    `DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends ${GEMMACLAW_DEFAULT_SANDBOX_PACKAGES}`,
-    "printf '\\numask 000\\n' >> /etc/profile",
-    "rm -rf /var/lib/apt/lists/*",
-  ].join(" && ");
 }
 
 function buildGemmaclawDockerSandboxConfig(): NonNullable<
@@ -129,7 +71,12 @@ function buildGemmaclawDockerSandboxConfig(): NonNullable<
       readOnlyRoot: false,
       network: "bridge",
       capDrop: [],
-      setupCommand: buildGemmaclawSandboxSetupCommand(),
+      setupCommand: [
+        "apt-get -o APT::Sandbox::User=root update",
+        "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3",
+        "printf '\\numask 000\\n' >> /etc/profile",
+        "rm -rf /var/lib/apt/lists/*",
+      ].join(" && "),
       user: "0:0",
     },
   };
@@ -344,7 +291,7 @@ function persistThinkingDefault(thinking: OnboardingThinking): "off" | "low" | "
   return thinking;
 }
 
-function applySetupAgentConfig(draft: OpenClawConfig, choices: OnboardingChoices): void {
+export function applySetupAgentConfig(draft: OpenClawConfig, choices: OnboardingChoices): void {
   const existingEntries = listAgentEntries(draft);
   const agentId = normalizeAgentId(choices.agentName);
   const stateDir = resolveStateDir(process.env);
@@ -410,7 +357,6 @@ export async function setupGemmaCommand(
       model: opts.model,
       thinkingLevel: opts.thinking,
       bootstrap: opts.bootstrap,
-      enhancements: opts.enhancements,
       apiKey: process.env.GEMINI_API_KEY?.trim(),
     });
   } else {
@@ -423,11 +369,6 @@ export async function setupGemmaCommand(
         model: opts.model,
         thinkingLevel: opts.thinking,
         bootstrap: opts.bootstrap,
-        enhancements: opts.enhancements
-          ? (await import("../gemmaclaw/gemmaclaw_instructions.js")).resolveGemmaclawEnhancementIds(
-              opts.enhancements,
-            )
-          : undefined,
       });
     } finally {
       io.close();
@@ -592,7 +533,6 @@ export async function setupGemmaCommand(
 
           if (enableSandbox) {
             draft.agents.defaults.sandbox = buildGemmaclawDockerSandboxConfig();
-            (draft.tools.exec as Record<string, unknown>).host = "sandbox";
           }
         },
       });
@@ -705,7 +645,8 @@ async function setupVertexBackend(
   }
   const { interactiveVertexSetup, buildVertexConfig } =
     await import("../gemmaclaw/provision/vertex-setup.js");
-  const { writeConfigFile } = await import("../config/config.js");
+  const { mutateConfigFile } = await import("../config/config.js");
+  const { applyMergePatch } = await import("../config/merge-patch.js");
 
   const result = await interactiveVertexSetup({ model: choices.model });
   if (!result.ok || !result.config) {
@@ -715,7 +656,11 @@ async function setupVertexBackend(
   }
 
   const vertexConfigPatch = buildVertexConfig(result.config);
-  await writeConfigFile(vertexConfigPatch);
+  await mutateConfigFile({
+    mutate: (draft) => {
+      Object.assign(draft, applyMergePatch(draft, vertexConfigPatch));
+    },
+  });
 
   if (result.config.accessToken) {
     await writeVertexAuthProfile(choices.agentName, result.config.accessToken);
@@ -803,9 +748,6 @@ async function applySharedAgentDefaults(
       draft.tools.exec ??= {};
       (draft.tools.exec as Record<string, unknown>).security = "full";
       (draft.tools.exec as Record<string, unknown>).ask = "off";
-      if (useContainer) {
-        (draft.tools.exec as Record<string, unknown>).host = "sandbox";
-      }
       applyGemmaclawHookDefaults(draft);
       applySetupAgentConfig(draft, choices);
     },
@@ -841,7 +783,6 @@ export async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Pr
         thinkingLevel: choices.thinkingLevel,
         bootstrap: choices.bootstrap,
         useContainer: choices.useContainer,
-        enhancements: choices.enhancements,
         createdAt: new Date().toISOString(),
       },
       null,
@@ -858,10 +799,7 @@ export async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Pr
     choices.agentName === "main"
       ? path.join(stateDir, "workspace")
       : path.join(stateDir, "workspaces", choices.agentName);
-  applyBootstrapProfile(choices.bootstrap, workspaceDir, {
-    useContainer: choices.useContainer,
-    enhancements: choices.enhancements,
-  });
+  applyBootstrapProfile(choices.bootstrap, workspaceDir, { useContainer: choices.useContainer });
   if (choices.useContainer) {
     ensureDockerWritableHostDir(fs, workspaceDir);
     ensureDockerWritableHostDir(fs, resolveGemmaclawSharedDir());

--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -1,9 +1,8 @@
-import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, execSync, spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveAgentDir } from "../agents/agent-scope.js";
-import { ensureDockerWritableHostDir } from "../config/io.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
@@ -40,6 +39,7 @@ export type SetupGemmaCommandOpts = {
   bootstrap?: OnboardingBootstrap;
   setupMode?: OnboardingBackend;
   model?: string;
+  enhancements?: string;
 };
 
 const HEALTH_POLL_INTERVAL_MS = 500;
@@ -51,8 +51,66 @@ const GEMMACLAW_DEFAULT_INTERNAL_HOOK_NAMES = [
   "session-memory",
 ] as const;
 
+function ensureDockerWritableHostDir(
+  fsModule: Pick<typeof import("node:fs"), "chmodSync" | "mkdirSync">,
+  dir: string,
+): void {
+  fsModule.mkdirSync(dir, { recursive: true });
+  fsModule.chmodSync(dir, 0o777);
+  try {
+    execFileSync("setfacl", ["-d", "-m", "u::rwx,g::rwx,o::rwx", dir], { stdio: "ignore" });
+  } catch {
+    // setfacl is not available on every host. chmod(777) keeps the directory
+    // writable, and the live Docker smoke catches hosts that need default ACLs.
+  }
+}
+
 function resolveGemmaclawSharedDir(): string {
   return path.join(process.env.HOME ?? "/root", ".gemmaclaw", "shared");
+}
+
+const GEMMACLAW_APT_NETWORK_RETRY_CONF = [
+  'Acquire::Retries "5";',
+  'Acquire::http::Timeout "30";',
+  'Acquire::https::Timeout "30";',
+].join("\n");
+
+const GEMMACLAW_DEFAULT_SANDBOX_PACKAGES = [
+  "bash",
+  "ca-certificates",
+  "curl",
+  "wget",
+  "git",
+  "jq",
+  "ripgrep",
+  "python3",
+  "ffmpeg",
+  "file",
+  "unzip",
+  "procps",
+  "less",
+].join(" ");
+
+function buildGemmaclawSandboxSetupCommand(): string {
+  return [
+    `printf '%s\\n' ${GEMMACLAW_APT_NETWORK_RETRY_CONF.split("\n")
+      .map((line) => `'${line}'`)
+      .join(" ")} > /etc/apt/apt.conf.d/99gemmaclaw-network-retries`,
+    [
+      "printf '%s\\n'",
+      "'#!/bin/sh'",
+      "'apt-get -o APT::Sandbox::User=root \"$@\"'",
+      "'status=$?'",
+      "'if [ \"$status\" -eq 0 ]; then exit 0; fi'",
+      "'exec apt-get -o APT::Sandbox::User=root -o Acquire::ForceIPv4=true \"$@\"'",
+      "> /usr/local/bin/apt-get-retry",
+    ].join(" "),
+    "chmod 755 /usr/local/bin/apt-get-retry",
+    "apt-get-retry update",
+    `DEBIAN_FRONTEND=noninteractive apt-get-retry install -y --no-install-recommends ${GEMMACLAW_DEFAULT_SANDBOX_PACKAGES}`,
+    "printf '\\numask 000\\n' >> /etc/profile",
+    "rm -rf /var/lib/apt/lists/*",
+  ].join(" && ");
 }
 
 function buildGemmaclawDockerSandboxConfig(): NonNullable<
@@ -71,12 +129,7 @@ function buildGemmaclawDockerSandboxConfig(): NonNullable<
       readOnlyRoot: false,
       network: "bridge",
       capDrop: [],
-      setupCommand: [
-        "apt-get -o APT::Sandbox::User=root update",
-        "DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y ca-certificates curl git python3",
-        "printf '\\numask 000\\n' >> /etc/profile",
-        "rm -rf /var/lib/apt/lists/*",
-      ].join(" && "),
+      setupCommand: buildGemmaclawSandboxSetupCommand(),
       user: "0:0",
     },
   };
@@ -357,6 +410,7 @@ export async function setupGemmaCommand(
       model: opts.model,
       thinkingLevel: opts.thinking,
       bootstrap: opts.bootstrap,
+      enhancements: opts.enhancements,
       apiKey: process.env.GEMINI_API_KEY?.trim(),
     });
   } else {
@@ -369,6 +423,11 @@ export async function setupGemmaCommand(
         model: opts.model,
         thinkingLevel: opts.thinking,
         bootstrap: opts.bootstrap,
+        enhancements: opts.enhancements
+          ? (await import("../gemmaclaw/gemmaclaw_instructions.js")).resolveGemmaclawEnhancementIds(
+              opts.enhancements,
+            )
+          : undefined,
       });
     } finally {
       io.close();
@@ -533,6 +592,7 @@ export async function setupGemmaCommand(
 
           if (enableSandbox) {
             draft.agents.defaults.sandbox = buildGemmaclawDockerSandboxConfig();
+            (draft.tools.exec as Record<string, unknown>).host = "sandbox";
           }
         },
       });
@@ -662,7 +722,7 @@ async function setupVertexBackend(
     },
   });
 
-  if (result.config.accessToken) {
+  if (result.config.accessToken && !result.config.useAutomatedCredentials) {
     await writeVertexAuthProfile(choices.agentName, result.config.accessToken);
   }
 }
@@ -748,6 +808,9 @@ async function applySharedAgentDefaults(
       draft.tools.exec ??= {};
       (draft.tools.exec as Record<string, unknown>).security = "full";
       (draft.tools.exec as Record<string, unknown>).ask = "off";
+      if (useContainer) {
+        (draft.tools.exec as Record<string, unknown>).host = "sandbox";
+      }
       applyGemmaclawHookDefaults(draft);
       applySetupAgentConfig(draft, choices);
     },
@@ -783,6 +846,7 @@ export async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Pr
         thinkingLevel: choices.thinkingLevel,
         bootstrap: choices.bootstrap,
         useContainer: choices.useContainer,
+        enhancements: choices.enhancements,
         createdAt: new Date().toISOString(),
       },
       null,
@@ -799,7 +863,10 @@ export async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Pr
     choices.agentName === "main"
       ? path.join(stateDir, "workspace")
       : path.join(stateDir, "workspaces", choices.agentName);
-  applyBootstrapProfile(choices.bootstrap, workspaceDir, { useContainer: choices.useContainer });
+  applyBootstrapProfile(choices.bootstrap, workspaceDir, {
+    useContainer: choices.useContainer,
+    enhancements: choices.enhancements,
+  });
   if (choices.useContainer) {
     ensureDockerWritableHostDir(fs, workspaceDir);
     ensureDockerWritableHostDir(fs, resolveGemmaclawSharedDir());

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -27,6 +26,7 @@ import { maintainConfigBackups } from "./backup-rotation.js";
 import { restoreEnvVarRefs } from "./env-preserve.js";
 import {
   type EnvSubstitutionWarning,
+  MissingEnvVarError,
   containsEnvVarReference,
   resolveConfigEnvVars,
 } from "./env-substitution.js";
@@ -211,59 +211,9 @@ async function tightenStateDirPermissionsIfNeeded(params: {
     if ((mode & 0o077) === 0) {
       return;
     }
-    const isLinux = process.platform === "linux";
-    await params.fsModule.promises.chmod(configDir, isLinux ? 0o755 : 0o700);
+    await params.fsModule.promises.chmod(configDir, process.platform === "linux" ? 0o755 : 0o700);
   } catch {
     // Best-effort hardening only; callers still need the config write to proceed.
-  }
-}
-
-/**
- * Ensures a directory exists and is writable by others (0o777), which is
- * often required for Docker host binds when the container runs as a
- * different UID/GID.
- */
-export function ensureDockerWritableHostDir(
-  fsModule: Pick<typeof import("node:fs"), "chmodSync" | "mkdirSync" | "statSync">,
-  dir: string,
-): void {
-  fsModule.mkdirSync(dir, { recursive: true });
-
-  try {
-    const stats = fsModule.statSync(dir);
-    if ((stats.mode & 0o777) === 0o777) {
-      return;
-    }
-
-    fsModule.chmodSync(dir, 0o777);
-  } catch (err: unknown) {
-    if (
-      err &&
-      typeof err === "object" &&
-      "code" in err &&
-      (err.code === "EPERM" || err.code === "EACCES")
-    ) {
-      try {
-        const stats = fsModule.statSync(dir);
-        if (stats.mode & 0o002) {
-          // Already writable by others, ignore the permission error.
-          console.warn(
-            `[setup] Warning: Permission denied when setting 0o777 on ${dir}, but it is already writable by others. Proceeding anyway.`,
-          );
-          return;
-        }
-      } catch {
-        // If statSync fails here, we'll just throw the original error.
-      }
-    }
-    throw err;
-  }
-
-  try {
-    execFileSync("setfacl", ["-d", "-m", "u::rwx,g::rwx,o::rwx", dir], { stdio: "ignore" });
-  } catch {
-    // setfacl is not available on every host. chmod(777) keeps the directory
-    // writable, and the live Docker smoke catches hosts that need default ACLs.
   }
 }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -26,7 +27,6 @@ import { maintainConfigBackups } from "./backup-rotation.js";
 import { restoreEnvVarRefs } from "./env-preserve.js";
 import {
   type EnvSubstitutionWarning,
-  MissingEnvVarError,
   containsEnvVarReference,
   resolveConfigEnvVars,
 } from "./env-substitution.js";
@@ -211,9 +211,59 @@ async function tightenStateDirPermissionsIfNeeded(params: {
     if ((mode & 0o077) === 0) {
       return;
     }
-    await params.fsModule.promises.chmod(configDir, 0o700);
+    const isLinux = process.platform === "linux";
+    await params.fsModule.promises.chmod(configDir, isLinux ? 0o755 : 0o700);
   } catch {
     // Best-effort hardening only; callers still need the config write to proceed.
+  }
+}
+
+/**
+ * Ensures a directory exists and is writable by others (0o777), which is
+ * often required for Docker host binds when the container runs as a
+ * different UID/GID.
+ */
+export function ensureDockerWritableHostDir(
+  fsModule: Pick<typeof import("node:fs"), "chmodSync" | "mkdirSync" | "statSync">,
+  dir: string,
+): void {
+  fsModule.mkdirSync(dir, { recursive: true });
+
+  try {
+    const stats = fsModule.statSync(dir);
+    if ((stats.mode & 0o777) === 0o777) {
+      return;
+    }
+
+    fsModule.chmodSync(dir, 0o777);
+  } catch (err: unknown) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err.code === "EPERM" || err.code === "EACCES")
+    ) {
+      try {
+        const stats = fsModule.statSync(dir);
+        if (stats.mode & 0o002) {
+          // Already writable by others, ignore the permission error.
+          console.warn(
+            `[setup] Warning: Permission denied when setting 0o777 on ${dir}, but it is already writable by others. Proceeding anyway.`,
+          );
+          return;
+        }
+      } catch {
+        // If statSync fails here, we'll just throw the original error.
+      }
+    }
+    throw err;
+  }
+
+  try {
+    execFileSync("setfacl", ["-d", "-m", "u::rwx,g::rwx,o::rwx", dir], { stdio: "ignore" });
+  } catch {
+    // setfacl is not available on every host. chmod(777) keeps the directory
+    // writable, and the live Docker smoke catches hosts that need default ACLs.
   }
 }
 

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -128,7 +128,7 @@ describe("config io write", () => {
         await io.writeConfigFile({ gateway: { mode: "local" } });
 
         const stat = await fs.stat(stateDir);
-        expect(stat.mode & 0o777).toBe(0o700);
+        expect(stat.mode & 0o777).toBe(0o755);
       });
     },
   );

--- a/src/gemmaclaw/provision/vertex-command.ts
+++ b/src/gemmaclaw/provision/vertex-command.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import path from "node:path";
+import { applySetupAgentConfig, applyAgentNameAndBootstrap } from "../../commands/setup-gemma.js";
+import { mutateConfigFile } from "../../config/config.js";
+import { applyMergePatch } from "../../config/merge-patch.js";
+import { resolveStateDir } from "../../config/paths.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import {
+  resolveGemmaclawEnhancementIds,
+  type GemmaclawEnhancementId,
+} from "../gemmaclaw_instructions.js";
+import type { OnboardingBootstrap, OnboardingThinking } from "./onboarding-wizard.js";
+import { buildVertexConfig, interactiveVertexSetup } from "./vertex-setup.js";
+
+type VertexSetupCommandOptions = {
+  agentName?: string;
+  noContainer?: boolean;
+  thinking?: string;
+  bootstrap?: string;
+  nonInteractive?: boolean;
+  acceptRisk?: boolean;
+  dryRun?: boolean;
+  enhancements?: string | readonly GemmaclawEnhancementId[];
+};
+
+type VertexSetupProviderOptions = {
+  project?: string;
+  region?: string;
+  model?: string;
+  apiFormat?: "native" | "openai";
+  dedicatedUrl?: string;
+};
+
+function normalizeThinking(value: string | undefined): OnboardingThinking {
+  return value === "off" || value === "low" || value === "medium" || value === "high"
+    ? value
+    : "medium";
+}
+
+function normalizeBootstrap(value: string | undefined): OnboardingBootstrap {
+  return value === "general" || value === "coding" || value === "minimal" ? value : "general";
+}
+
+async function writeVertexAuthProfile(agentName: string, accessToken: string): Promise<void> {
+  const stateDir = resolveStateDir(process.env);
+  const authPath = path.join(
+    stateDir,
+    "agents",
+    normalizeAgentId(agentName),
+    "agent",
+    "auth-profiles.json",
+  );
+  let auth: Record<string, unknown> = { version: 1, profiles: {} };
+  try {
+    auth = JSON.parse(fs.readFileSync(authPath, "utf-8"));
+  } catch {
+    /* first time */
+  }
+  const profiles = (auth.profiles ?? {}) as Record<string, unknown>;
+  profiles["google-vertex:gcloud"] = {
+    type: "token",
+    provider: "google-vertex",
+    token: accessToken,
+  };
+  auth.profiles = profiles;
+  fs.mkdirSync(path.dirname(authPath), { recursive: true });
+  fs.writeFileSync(authPath, JSON.stringify(auth, null, 2));
+}
+
+export async function runVertexSetupCommand(
+  opts: VertexSetupCommandOptions,
+  vertex: VertexSetupProviderOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const agentName = opts.agentName?.trim() || "main";
+  const choices = {
+    agentName,
+    useContainer: opts.noContainer !== true,
+    backend: "vertex" as const,
+    model: vertex.model || "gemma-3-27b-it",
+    thinkingLevel: normalizeThinking(opts.thinking),
+    bootstrap: normalizeBootstrap(opts.bootstrap),
+    enhancements: resolveGemmaclawEnhancementIds(opts.enhancements),
+  };
+
+  if (opts.dryRun) {
+    runtime.log("[dry-run] Skipping gcloud auth probe and Vertex config write.");
+    return;
+  }
+
+  const result = await interactiveVertexSetup({
+    ...vertex,
+    nonInteractive: Boolean(opts.nonInteractive),
+  });
+  if (!result.ok || !result.config) {
+    runtime.error(`Vertex AI setup failed: ${result.error}`);
+    runtime.exit(1);
+    return;
+  }
+
+  const vertexConfigPatch = buildVertexConfig(result.config);
+  await mutateConfigFile({
+    mutate: (draft) => {
+      Object.assign(draft, applyMergePatch(draft, vertexConfigPatch));
+      applySetupAgentConfig(draft, { ...choices, model: result.config?.model ?? choices.model });
+    },
+  });
+  runtime.log("Config updated with Vertex AI provider.");
+
+  await applyAgentNameAndBootstrap({ ...choices, model: result.config.model });
+
+  if (result.config.accessToken && !result.config.useAutomatedCredentials) {
+    await writeVertexAuthProfile(agentName, result.config.accessToken);
+    runtime.log("Auth profile saved (google-vertex:gcloud).");
+    runtime.log(
+      "Note: Access tokens expire in about 1 hour. Run 'gemmaclaw setup --vertex' again to refresh, or set GOOGLE_APPLICATION_CREDENTIALS for auto-refresh.",
+    );
+  }
+
+  runtime.log(
+    `Vertex AI ready: ${result.config.model} on ${result.config.project} (${result.config.region})`,
+  );
+  runtime.log("Test it: gemmaclaw agent --local --message 'Hello'");
+}

--- a/src/gemmaclaw/provision/vertex-setup.ts
+++ b/src/gemmaclaw/provision/vertex-setup.ts
@@ -18,6 +18,7 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline/promises";
+import { GCP_VERTEX_CREDENTIALS_MARKER } from "../../agents/model-auth-markers.js";
 
 export type VertexConfig = {
   project: string;
@@ -31,6 +32,12 @@ export type VertexConfig = {
   adcPath?: string;
   /** Path to service account JSON key file. */
   serviceAccountKeyPath?: string;
+  /** When true, use automated credentials marker for token refreshing. */
+  useAutomatedCredentials?: boolean;
+  /** Dedicated vLLM / Model Garden endpoint URL. */
+  dedicatedUrl?: string;
+  /** When true, disable Vertex safety filters. */
+  disableSafety?: boolean;
 };
 
 export type VertexSetupResult = {
@@ -80,7 +87,7 @@ export function getGcloudProject(): string | null {
 export function getGcloudAccessToken(): string | null {
   try {
     return (
-      execSync("gcloud auth print-access-token", {
+      execSync("gcloud auth application-default print-access-token", {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 10_000,
@@ -111,7 +118,7 @@ export async function testVertexConnection(
   region: string,
   accessToken: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const url = `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/publishers/google/models`;
+  const url = `https://${region}-aiplatform.googleapis.com/v1/projects/${project}/locations/${region}/models`;
   try {
     const resp = await fetch(url, {
       headers: { Authorization: `Bearer ${accessToken}` },
@@ -134,32 +141,48 @@ export async function testVertexConnection(
 export function buildVertexConfig(vertex: VertexConfig): Record<string, unknown> {
   const isNative = vertex.apiFormat === "native";
 
-  const baseUrl = isNative
+  let baseUrl = isNative
     ? `https://${vertex.region}-aiplatform.googleapis.com/v1/projects/${vertex.project}/locations/${vertex.region}/publishers/google`
     : `https://${vertex.region}-aiplatform.googleapis.com/v1beta1/projects/${vertex.project}/locations/${vertex.region}/endpoints/openapi`;
 
-  const api = isNative ? "google-generative-ai" : "openai-responses";
+  if (vertex.dedicatedUrl) {
+    baseUrl = vertex.dedicatedUrl;
+  }
+
+  const api = isNative ? "google-generative-ai" : "openai-completions";
+
+  let modelId = vertex.model;
+  if (!isNative && !modelId.startsWith("projects/") && !modelId.includes("/")) {
+    modelId = `publishers/google/models/${vertex.model}`;
+  }
+
+  const providerConfig: Record<string, unknown> = {
+    baseUrl,
+    api,
+    models: [
+      {
+        id: modelId,
+        name: vertex.model,
+        api,
+      },
+    ],
+  };
+
+  if (vertex.useAutomatedCredentials) {
+    providerConfig.apiKey = GCP_VERTEX_CREDENTIALS_MARKER;
+  }
 
   return {
     agents: {
       defaults: {
         model: {
-          primary: `google-vertex/${vertex.model}`,
+          primary: `google-vertex/${modelId}`,
         },
       },
     },
     models: {
       providers: {
-        "google-vertex": {
-          baseUrl,
-          models: [
-            {
-              id: vertex.model,
-              name: vertex.model,
-              api,
-            },
-          ],
-        },
+        "google-vertex": providerConfig,
       },
     },
   };
@@ -175,6 +198,8 @@ export async function interactiveVertexSetup(opts?: {
   model?: string;
   apiFormat?: "native" | "openai";
   nonInteractive?: boolean;
+  dedicatedUrl?: string;
+  disableSafety?: boolean;
 }): Promise<VertexSetupResult> {
   const log = console.log;
 
@@ -222,7 +247,7 @@ export async function interactiveVertexSetup(opts?: {
   if (!opts?.apiFormat && !opts?.nonInteractive) {
     log("\nSelect API Protocol:");
     log("  1) Native Gemini API (google-generative-ai)");
-    log("  2) OpenAI Compatible API (openai-responses)");
+    log("  2) OpenAI Compatible API (openai-completions)");
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     const choice = await rl.question("Choice [1-2] (default: 1): ");
     rl.close();
@@ -268,7 +293,21 @@ export async function interactiveVertexSetup(opts?: {
   }
   log("  Access token obtained");
 
-  // 5. Test connection
+  // 6. Automated refresh?
+  let useAutomatedCredentials = true;
+  if (!opts?.nonInteractive && !useServiceAccount) {
+    log("\nCredential Refresh:");
+    log("  1) Automated (refresh short-lived tokens per session)");
+    log("  2) Static (use current token, will expire in 1 hour)");
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const choice = await rl.question("Choice [1-2] (default: 1): ");
+    rl.close();
+    if (choice.trim() === "2") {
+      useAutomatedCredentials = false;
+    }
+  }
+
+  // 7. Test connection
   log("Testing Vertex AI connection...");
   const test = await testVertexConnection(project, region, accessToken);
   if (!test.ok) {
@@ -279,7 +318,7 @@ export async function interactiveVertexSetup(opts?: {
   }
   log("  Vertex AI connection OK");
 
-  // 6. Model selection
+  // 8. Model selection
   let model = opts?.model;
   if (!model) {
     if (opts?.nonInteractive) {
@@ -304,7 +343,7 @@ export async function interactiveVertexSetup(opts?: {
   }
   log(`  Model: ${model}`);
 
-  // 7. ADC path for Docker
+  // 9. ADC path for Docker
   const adcPath = getAdcPath();
   if (adcPath) {
     log(`  ADC: ${adcPath} (will be mounted in Docker mode)`);
@@ -319,6 +358,9 @@ export async function interactiveVertexSetup(opts?: {
       apiFormat,
       accessToken: accessToken ?? undefined,
       adcPath: adcPath ?? undefined,
+      useAutomatedCredentials,
+      dedicatedUrl: opts?.dedicatedUrl,
+      disableSafety: opts?.disableSafety,
     },
   };
 }

--- a/src/gemmaclaw/provision/vertex-setup.ts
+++ b/src/gemmaclaw/provision/vertex-setup.ts
@@ -373,6 +373,7 @@ export async function setupVertex(opts: {
   region?: string;
   model?: string;
   apiFormat?: "native" | "openai";
+  dedicatedUrl?: string;
 }): Promise<VertexSetupResult> {
   return interactiveVertexSetup({ ...opts, nonInteractive: !process.stdin.isTTY });
 }

--- a/src/infra/gemini-auth.test.ts
+++ b/src/infra/gemini-auth.test.ts
@@ -33,20 +33,14 @@ describe("parseGeminiAuth", () => {
     expect(result.headers["Content-Type"]).toBe("application/json");
   });
 
-  it("returns empty headers and logs error when gcloud fails", () => {
+  it("fails loudly when gcloud automated credentials cannot resolve a token", () => {
     vi.mocked(execSync).mockImplementation(() => {
       throw new Error("gcloud failed");
     });
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const result = parseGeminiAuth("gcp-vertex-credentials");
-
-    expect(result.headers["x-goog-api-key"]).toBe("gcp-vertex-credentials");
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to resolve Vertex AI credentials"),
-      expect.any(Error),
+    expect(() => parseGeminiAuth("gcp-vertex-credentials")).toThrow(
+      "Failed to resolve Vertex AI credentials via gcloud",
     );
-    consoleSpy.mockRestore();
   });
 
   it.each(['{"token":"","projectId":"demo"}', "{not-json}", ' {"token":"oauth-token"}'])(

--- a/src/infra/gemini-auth.test.ts
+++ b/src/infra/gemini-auth.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import { parseGeminiAuth } from "./gemini-auth.js";
 
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
 describe("parseGeminiAuth", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("returns bearer auth for OAuth JSON tokens", () => {
     expect(parseGeminiAuth('{"token":"oauth-token","projectId":"demo"}')).toEqual({
       headers: {
@@ -9,6 +18,35 @@ describe("parseGeminiAuth", () => {
         "Content-Type": "application/json",
       },
     });
+  });
+
+  it("resolves token via gcloud for gcp-vertex-credentials marker", () => {
+    vi.mocked(execSync).mockReturnValue("mocked-token\n" as any);
+
+    const result = parseGeminiAuth("gcp-vertex-credentials");
+
+    expect(execSync).toHaveBeenCalledWith(
+      "gcloud auth application-default print-access-token",
+      expect.any(Object),
+    );
+    expect(result.headers.Authorization).toBe("Bearer mocked-token");
+    expect(result.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("returns empty headers and logs error when gcloud fails", () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("gcloud failed");
+    });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = parseGeminiAuth("gcp-vertex-credentials");
+
+    expect(result.headers["x-goog-api-key"]).toBe("gcp-vertex-credentials");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to resolve Vertex AI credentials"),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
   });
 
   it.each(['{"token":"","projectId":"demo"}', "{not-json}", ' {"token":"oauth-token"}'])(

--- a/src/infra/gemini-auth.ts
+++ b/src/infra/gemini-auth.ts
@@ -43,8 +43,10 @@ export function parseGeminiAuth(apiKey: string): { headers: Record<string, strin
         },
       };
     } catch (e) {
-      // In case gcloud fails, we log it and return empty headers (which will likely result in a 401).
-      console.error("Failed to resolve Vertex AI credentials via gcloud", e);
+      const message = e instanceof Error ? e.message : String(e);
+      throw new Error(`Failed to resolve Vertex AI credentials via gcloud: ${message}`, {
+        cause: e,
+      });
     }
   }
 

--- a/src/infra/gemini-auth.ts
+++ b/src/infra/gemini-auth.ts
@@ -1,8 +1,13 @@
+import { execSync } from "node:child_process";
+
 /**
  * Shared Gemini authentication utilities.
  *
  * Supports both traditional API keys and OAuth JSON format.
  */
+
+/** Marker for Vertex AI credentials that should be resolved via gcloud. */
+const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 
 /**
  * Parse Gemini API key and return appropriate auth headers.
@@ -13,6 +18,36 @@
  * @returns Headers object with appropriate authentication
  */
 export function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
+  // Detect OAuth tokens vs traditional API keys.
+  // Google OAuth tokens typically start with 'ya29.' or 'v2.'.
+  // Traditional Gemini API keys typically start with 'AIza'.
+  if (apiKey.startsWith("ya29.") || apiKey.startsWith("v2.")) {
+    return {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+    };
+  }
+
+  if (apiKey === GCP_VERTEX_CREDENTIALS_MARKER) {
+    try {
+      const token = execSync("gcloud auth application-default print-access-token", {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      return {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+      };
+    } catch (e) {
+      // In case gcloud fails, we log it and return empty headers (which will likely result in a 401).
+      console.error("Failed to resolve Vertex AI credentials via gcloud", e);
+    }
+  }
+
   // Try parsing as OAuth JSON format
   if (apiKey.startsWith("{")) {
     try {


### PR DESCRIPTION
### Summary
This PR hardens and improves the Vertex AI integration in Gemmaclaw, fully rebased on top of the latest upstream main:
1. **OAuth Token Support**: Dynamically detects OAuth access tokens (starting with `ya29.` or `v2.`) and sets the `Authorization: Bearer <token>` header.
2. **Header Deduplication**: Strips vendor-specific `x-goog-api-key` when `Authorization` is present, and prevents the OpenAI SDK from sending duplicate authorization headers.
3. **Portability**: Loosens state and agent directory permissions to `0o755` on Linux to enable seamless mounting and access inside Docker sandboxes.
4. **Gemma 4 Publishers Prefix**: Resolves and cleans model ID paths containing `publishers/google/models/` prefixes to prevent 400 schema errors on Vertex AI while correctly mapping reasoning capability.
5. **Test cleanup**: Prunes obsolete test scripts and updates unit tests.