### PR TITLE
chore: upstream sync openclaw → gemmaclaw (2026-05-28)

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -893,6 +893,48 @@
         "text",
         "channel"
       ]
+    },
+    "transcripts": {
+      "emoji": "🧾",
+      "title": "Transcripts",
+      "actions": {
+        "start": {
+          "label": "start",
+          "detailKeys": [
+            "title",
+            "providerId",
+            "accountId",
+            "guildId",
+            "channelId",
+            "meetingUrl"
+          ]
+        },
+        "stop": {
+          "label": "stop",
+          "detailKeys": [
+            "sessionId",
+            "title"
+          ]
+        },
+        "import": {
+          "label": "import",
+          "detailKeys": [
+            "title",
+            "providerId",
+            "speakerLabel"
+          ]
+        },
+        "summarize": {
+          "label": "summarize",
+          "detailKeys": [
+            "sessionId",
+            "title"
+          ]
+        },
+        "status": {
+          "label": "status"
+        }
+      }
     }
   }
 }

--- a/scripts/claude-auth-status.sh
+++ b/scripts/claude-auth-status.sh
@@ -51,6 +51,11 @@ calc_status_from_expires() {
     fi
 }
 
+format_epoch_seconds() {
+    local epoch_seconds="$1"
+    date -r "$epoch_seconds" 2>/dev/null || date -d "@$epoch_seconds"
+}
+
 json_expires_for_claude_cli() {
     echo "$STATUS_JSON" | jq -r '
         [.auth.oauth.profiles[]
@@ -223,7 +228,7 @@ else
         echo "  Consider running: claude setup-token"
     else
         echo -e "  Status: ${GREEN}OK${NC}"
-        echo "  Expires: $(date -d @$((expires_at/1000))) (${hours}h ${mins}m)"
+        echo "  Expires: $(format_epoch_seconds "$((expires_at/1000))") (${hours}h ${mins}m)"
     fi
 fi
 
@@ -267,7 +272,7 @@ else
         echo -e "  Status: ${YELLOW}EXPIRING SOON (${mins}m remaining)${NC}"
     else
         echo -e "  Status: ${GREEN}OK${NC}"
-        echo "  Expires: $(date -d @$((expires/1000))) (${hours}h ${mins}m)"
+        echo "  Expires: $(format_epoch_seconds "$((expires/1000))") (${hours}h ${mins}m)"
     fi
 fi
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -361,6 +361,70 @@ describe("live model switch", () => {
     expect(state.piEmbeddedModuleImported).toBe(false);
   });
 
+  it("treats active openai-codex as an already-applied openai runtime promotion", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.5",
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not suppress explicit runtime provider switches with the same model", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai",
+          model: "gpt-5.5",
+        },
+        {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+      ),
+    ).toBe(true);
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+        {
+          provider: "claude-cli",
+          model: "claude-sonnet-4-6",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not suppress switch when model actually differs across runtime alias", async () => {
+    const { hasDifferentLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      hasDifferentLiveSessionModelSelection(
+        {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+        },
+        {
+          provider: "openai",
+          model: "gpt-5.4",
+        },
+      ),
+    ).toBe(true);
+  });
+
   it("treats auth-profile-source changes as no-op when no auth profile is selected", async () => {
     const { hasDifferentLiveSessionModelSelection } = await loadModule();
 
@@ -398,12 +462,13 @@ describe("live model switch", () => {
 
   describe("shouldSwitchToLiveModel", () => {
     it("returns the persisted selection when liveModelSwitchPending is true and model differs", async () => {
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.4",
+      };
       state.loadSessionStoreMock.mockReturnValue({
-        main: {
-          liveModelSwitchPending: true,
-          providerOverride: "openai",
-          modelOverride: "gpt-5.4",
-        },
+        main: sessionEntry,
       });
 
       const { shouldSwitchToLiveModel } = await loadModule();
@@ -431,15 +496,20 @@ describe("live model switch", () => {
       const result = shouldSwitchToLiveModel(makeShouldSwitchParams());
 
       expect(result).toBeUndefined();
+      expect(state.loadSessionStoreMock).toHaveBeenCalledWith("/tmp/session-store.json", {
+        skipCache: true,
+        clone: false,
+      });
     });
 
     it("returns undefined when liveModelSwitchPending is true but models match", async () => {
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-6",
+      };
       state.loadSessionStoreMock.mockReturnValue({
-        main: {
-          liveModelSwitchPending: true,
-          providerOverride: "anthropic",
-          modelOverride: "claude-opus-4-6",
-        },
+        main: sessionEntry,
       });
 
       const { shouldSwitchToLiveModel } = await loadModule();
@@ -478,6 +548,28 @@ describe("live model switch", () => {
       const { shouldSwitchToLiveModel } = await loadModule();
 
       const result = shouldSwitchToLiveModel(makeShouldSwitchParams({ sessionKey: undefined }));
+
+      expect(result).toBeUndefined();
+    });
+
+    it("does not trigger switch when runtime promotes openai to openai-codex", async () => {
+      const sessionEntry = {
+        liveModelSwitchPending: true,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      };
+      state.loadSessionStoreMock.mockReturnValue({ main: sessionEntry });
+
+      const { shouldSwitchToLiveModel } = await loadModule();
+
+      const result = shouldSwitchToLiveModel(
+        makeShouldSwitchParams({
+          currentProvider: "openai-codex",
+          currentModel: "gpt-5.5",
+          defaultProvider: "openai",
+          defaultModel: "gpt-5.5",
+        }),
+      );
 
       expect(result).toBeUndefined();
     });

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -16,6 +16,11 @@ import {
 export { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 export type LiveSessionModelSelection = EmbeddedRunModelSwitchRequest;
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { normalizeProviderId } from "./provider-id.js";
+
+const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+
 export function resolveLiveSessionModelSelection(params: {
   cfg?: { session?: { store?: string } } | undefined;
   sessionKey?: string;
@@ -87,6 +92,19 @@ export function consumeLiveSessionModelSwitch(
   return consumeEmbeddedRunModelSwitch(sessionId);
 }
 
+function isAlreadyAppliedOpenAICodexRuntimePromotion(
+  current: { provider: string; model: string },
+  next: LiveSessionModelSelection,
+): boolean {
+  // The embedded Codex runtime reports openai-codex after applying a canonical
+  // openai selection. Other runtime aliases remain real live-switch targets.
+  return (
+    normalizeProviderId(current.provider) === OPENAI_CODEX_PROVIDER_ID &&
+    normalizeProviderId(next.provider) === OPENAI_PROVIDER_ID &&
+    current.model === next.model
+  );
+}
+
 export function hasDifferentLiveSessionModelSelection(
   current: {
     provider: string;
@@ -99,9 +117,11 @@ export function hasDifferentLiveSessionModelSelection(
   if (!next) {
     return false;
   }
+  const modelSelectionDiffers =
+    (current.provider !== next.provider || current.model !== next.model) &&
+    !isAlreadyAppliedOpenAICodexRuntimePromotion(current, next);
   return (
-    current.provider !== next.provider ||
-    current.model !== next.model ||
+    modelSelectionDiffers ||
     normalizeOptionalString(current.authProfileId) !== next.authProfileId ||
     (normalizeOptionalString(current.authProfileId) ? current.authProfileIdSource : undefined) !==
       next.authProfileIdSource
@@ -160,7 +180,7 @@ export function shouldSwitchToLiveModel(params: {
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: params.agentId?.trim(),
   });
-  const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+  const entry = loadSessionStore(storePath, { skipCache: true, clone: false })[sessionKey];
   if (!entry?.liveModelSwitchPending) {
     return undefined;
   }

--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const killProcessTreeMock = vi.hoisted(() => vi.fn());
+const signalProcessTreeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => ({
   ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
@@ -12,6 +13,7 @@ vi.mock("node:child_process", async () => ({
 
 vi.mock("../process/kill-tree.js", () => ({
   killProcessTree: killProcessTreeMock,
+  signalProcessTree: signalProcessTreeMock,
 }));
 
 class MockChildProcess extends EventEmitter {
@@ -27,6 +29,7 @@ describe("OpenClawStdioClientTransport", () => {
     vi.useRealTimers();
     spawnMock.mockReset();
     killProcessTreeMock.mockReset();
+    signalProcessTreeMock.mockReset();
   });
 
   it("starts stdio MCP servers in a disposable process group on POSIX", async () => {
@@ -90,6 +93,31 @@ describe("OpenClawStdioClientTransport", () => {
     const closing = transport.close();
     await vi.advanceTimersByTimeAsync(2000);
     expect(killProcessTreeMock).toHaveBeenCalledWith(4321);
+
+    child.exitCode = 0;
+    child.emit("close", 0);
+    await closing;
+  });
+
+  it("force-SIGKILLs synchronously when killProcessTree's grace expires (#86412)", async () => {
+    vi.useFakeTimers();
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const { OpenClawStdioClientTransport } = await import("./mcp-stdio-transport.js");
+
+    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+    const started = transport.start();
+    child.emit("spawn");
+    await started;
+
+    const closing = transport.close();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321);
+    expect(signalProcessTreeMock).not.toHaveBeenCalled();
+
+    // killProcessTree's SIGKILL is .unref()'d (#86412); close() force-SIGKILLs synchronously instead.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL");
 
     child.exitCode = 0;
     child.emit("close", 0);

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -5,7 +5,7 @@ import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js
 import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
-import { killProcessTree } from "../process/kill-tree.js";
+import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 
 export type OpenClawStdioServerParameters = {
@@ -17,6 +17,7 @@ export type OpenClawStdioServerParameters = {
 };
 
 const CLOSE_TIMEOUT_MS = 2000;
+const SIGKILL_REAP_TIMEOUT_MS = 500;
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => {
@@ -125,6 +126,11 @@ export class OpenClawStdioClientTransport implements Transport {
       if (processToClose.exitCode === null && processToClose.pid) {
         killProcessTree(processToClose.pid);
         await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
+        if (processToClose.exitCode === null && processToClose.pid) {
+          // SIGKILL synchronously: killProcessTree's setTimeout is .unref()'d and races shutdown (#86412).
+          signalProcessTree(processToClose.pid, "SIGKILL");
+          await Promise.race([closePromise, delay(SIGKILL_REAP_TIMEOUT_MS)]);
+        }
       }
     }
     this.readBuffer.clear();

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -567,6 +567,31 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "TTS",
       detailKeys: ["text", "channel"],
     },
+    transcripts: {
+      emoji: "🧾",
+      title: "Transcripts",
+      actions: {
+        start: {
+          label: "start",
+          detailKeys: ["title", "providerId", "accountId", "guildId", "channelId", "meetingUrl"],
+        },
+        stop: {
+          label: "stop",
+          detailKeys: ["sessionId", "title"],
+        },
+        import: {
+          label: "import",
+          detailKeys: ["title", "providerId", "speakerLabel"],
+        },
+        summarize: {
+          label: "summarize",
+          detailKeys: ["sessionId", "title"],
+        },
+        status: {
+          label: "status",
+        },
+      },
+    },
   },
 };
 

--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -6,6 +6,7 @@ import {
   resolveGatewayAuthTokenForService,
   shouldRequireGatewayTokenForInstall,
 } from "./doctor-gateway-auth-token.js";
+import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 
 const envVar = (...parts: string[]) => parts.join("_");
 
@@ -267,5 +268,22 @@ describe("shouldRequireGatewayTokenForInstall", () => {
       {} as NodeJS.ProcessEnv,
     );
     expect(required).toBe(true);
+  });
+
+  it("blocks install token resolution for tailscale serve with explicit no-auth", async () => {
+    const resolved = await resolveGatewayInstallToken({
+      config: {
+        gateway: {
+          auth: { mode: "none" },
+          tailscale: { mode: "serve" },
+        },
+      } as OpenClawConfig,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.token).toBeUndefined();
+    expect(resolved.unavailableReason).toBe(
+      "gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve; configure token, password, or trusted-proxy auth before exposing the gateway through Tailscale",
+    );
   });
 });

--- a/src/commands/gateway-install-token.ts
+++ b/src/commands/gateway-install-token.ts
@@ -7,6 +7,10 @@ import { shouldRequireGatewayTokenForInstall } from "../gateway/auth-install-pol
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
 import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
+import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   readConfigFileSnapshotForWrite,
@@ -131,6 +135,15 @@ export async function resolveGatewayInstallToken(
     env: options.env,
     tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
   });
+  const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+  if (isUnsafeGatewayTailscaleNoAuth({ authMode: resolvedAuth.mode, tailscaleMode })) {
+    return {
+      token: undefined,
+      tokenRefConfigured: false,
+      unavailableReason: formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
+      warnings,
+    };
+  }
   const needsToken =
     shouldRequireGatewayTokenForInstall(cfg, options.env) && !resolvedAuth.allowTailscale;
   if (!needsToken) {

--- a/src/commands/onboard-auth.config-shared.test.ts
+++ b/src/commands/onboard-auth.config-shared.test.ts
@@ -175,6 +175,46 @@ describe("onboard auth provider config merges", () => {
     expect(next.agents?.defaults?.model).toEqual({ primary: "custom/model-z" });
   });
 
+  it("does not let default-model presets replace an existing default model", () => {
+    const next = applyProviderConfigWithDefaultModelPreset(
+      {
+        agents: {
+          defaults: {
+            models: {
+              "claude-max-proxy/claude-opus-4-7": {},
+              "claude-max-proxy/claude-sonnet-4-6": {},
+            },
+            model: {
+              primary: "claude-max-proxy/claude-opus-4-7",
+              fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+            },
+          },
+        },
+      },
+      {
+        providerId: "moonshot",
+        api: "openai-completions",
+        baseUrl: "https://api.moonshot.cn/v1",
+        defaultModel: makeModel("kimi-k2.6"),
+        aliases: [{ modelRef: "moonshot/kimi-k2.6", alias: "Kimi" }],
+        primaryModelRef: "moonshot/kimi-k2.6",
+      },
+    );
+
+    expect(next.agents?.defaults?.model).toEqual({
+      primary: "claude-max-proxy/claude-opus-4-7",
+      fallbacks: ["claude-max-proxy/claude-sonnet-4-6"],
+    });
+    expect(next.agents?.defaults?.models).toEqual({
+      "claude-max-proxy/claude-opus-4-7": {},
+      "claude-max-proxy/claude-sonnet-4-6": {},
+      "moonshot/kimi-k2.6": { alias: "Kimi" },
+    });
+    expect(next.models?.providers?.moonshot?.models?.map((model) => model.id)).toEqual([
+      "kimi-k2.6",
+    ]);
+  });
+
   it("applies catalog presets with alias and merged catalog models", () => {
     const next = applyProviderConfigWithModelCatalogPreset(
       {
@@ -206,5 +246,37 @@ describe("onboard auth provider config merges", () => {
       alias: "Catalog Alias",
     });
     expect(next.agents?.defaults?.model).toEqual({ primary: "custom/model-b" });
+  });
+
+  it("does not let catalog presets replace an existing default model", () => {
+    const next = applyProviderConfigWithModelCatalogPreset(
+      {
+        agents: {
+          defaults: {
+            models: {
+              "custom-existing/model-a": {},
+            },
+            model: {
+              primary: "custom-existing/model-a",
+            },
+          },
+        },
+      },
+      {
+        providerId: "custom",
+        api: "openai-completions",
+        baseUrl: "https://example.com/v1",
+        catalogModels: [makeModel("model-b")],
+        aliases: [{ modelRef: "custom/model-b", alias: "Catalog Alias" }],
+        primaryModelRef: "custom/model-b",
+      },
+    );
+
+    expect(next.agents?.defaults?.model).toEqual({ primary: "custom-existing/model-a" });
+    expect(next.agents?.defaults?.models).toEqual({
+      "custom-existing/model-a": {},
+      "custom/model-b": { alias: "Catalog Alias" },
+    });
+    expect(next.models?.providers?.custom?.models?.map((model) => model.id)).toEqual(["model-b"]);
   });
 });

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -20,6 +20,55 @@ describe("gateway tailscale bind validation", () => {
     expect(funnelRes.ok).toBe(true);
   });
 
+  it("rejects explicit no-auth when tailscale serve or funnel exposes the gateway", () => {
+    const serveRes = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "none" },
+        tailscale: { mode: "serve" },
+      },
+    });
+    expect(serveRes.ok).toBe(false);
+    if (!serveRes.ok) {
+      expect(serveRes.issues).toEqual([
+        {
+          path: "gateway.auth.mode",
+          message:
+            "gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve; configure token, password, or trusted-proxy auth before exposing the gateway through Tailscale",
+        },
+      ]);
+    }
+
+    const funnelRes = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "none" },
+        tailscale: { mode: "funnel" },
+      },
+    });
+    expect(funnelRes.ok).toBe(false);
+    if (!funnelRes.ok) {
+      expect(funnelRes.issues).toEqual([
+        {
+          path: "gateway.auth.mode",
+          message:
+            "gateway.tailscale.mode=funnel requires gateway.auth.mode=password; auth.mode=none cannot be used when exposing the gateway through Tailscale Funnel",
+        },
+      ]);
+    }
+  });
+
+  it("allows explicit no-auth for loopback-only gateway config", () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "none" },
+        tailscale: { mode: "off" },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts custom loopback bind host with tailscale serve/funnel", () => {
     const res = validateConfigObject({
       gateway: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -28,6 +28,10 @@ import {
   isPathWithinRoot,
   isWindowsAbsolutePath,
 } from "../shared/avatar-policy.js";
+import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isRecord } from "../utils.js";
@@ -626,6 +630,19 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function validateGatewayTailscaleAuth(config: OpenClawConfig): ConfigValidationIssue[] {
+  const tailscaleMode = config.gateway?.tailscale?.mode ?? "off";
+  if (!isUnsafeGatewayTailscaleNoAuth({ authMode: config.gateway?.auth?.mode, tailscaleMode })) {
+    return [];
+  }
+  return [
+    {
+      path: "gateway.auth.mode",
+      message: formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
+    },
+  ];
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -687,6 +704,10 @@ export function validateConfigObjectRaw(
   const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validatedConfig);
   if (gatewayTailscaleBindIssues.length > 0) {
     return { ok: false, issues: gatewayTailscaleBindIssues };
+  }
+  const gatewayTailscaleAuthIssues = validateGatewayTailscaleAuth(validatedConfig);
+  if (gatewayTailscaleAuthIssues.length > 0) {
+    return { ok: false, issues: gatewayTailscaleAuthIssues };
   }
   return {
     ok: true,

--- a/src/gateway/live-tool-probe-utils.test.ts
+++ b/src/gateway/live-tool-probe-utils.test.ts
@@ -270,6 +270,17 @@ describe("live tool probe utils", () => {
         expected: true,
       },
       {
+        name: "retries alternate exec readback retry wording",
+        params: {
+          text: "Let me try again with a slightly different approach:",
+          nonce: "nonce-c",
+          provider: "minimax-portal",
+          attempt: 0,
+          maxAttempts: 3,
+        },
+        expected: true,
+      },
+      {
         name: "retries eventual-consistency exec readback output",
         params: {
           text: "The file creation command succeeded, but the file wasn't found immediately after. Let me verify the file exists and read it again.",

--- a/src/gateway/live-tool-probe-utils.ts
+++ b/src/gateway/live-tool-probe-utils.ts
@@ -57,6 +57,7 @@ function hasMalformedToolOutput(text: string): boolean {
   }
   if (
     lower.includes("try reading the file again") ||
+    lower.includes("try again with a slightly different approach") ||
     lower.includes("trying to read the file again") ||
     lower.includes("try the read tool again") ||
     lower.includes("file wasn't found immediately after") ||

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -258,6 +258,29 @@ describe("buildWebchatAssistantMessageFromReplyPayloads", () => {
     expect(message).toBeNull();
   });
 
+  it("keeps valid whitespace in data image payloads", async () => {
+    const imageUrl = "data:image/png;base64,cG 5n\n";
+    const message = await buildWebchatAssistantMessageFromReplyPayloads([
+      {
+        text: "whitespace image",
+        mediaUrl: imageUrl,
+      },
+    ]);
+
+    expect(message?.content).toContainEqual({ type: "input_image", image_url: imageUrl.trim() });
+  });
+
+  it("rejects invalid data image payload characters", async () => {
+    const message = await buildWebchatAssistantMessageFromReplyPayloads([
+      {
+        text: "invalid",
+        mediaUrl: "data:image/png;base64,cG5n!",
+      },
+    ]);
+
+    expect(message).toBeNull();
+  });
+
   it("rejects remote image URLs", async () => {
     const message = await buildWebchatAssistantMessageFromReplyPayloads([
       {

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../infra/local-file-access.js";
+import { estimateBase64DecodedBytes } from "../../media/base64.js";
 import { assertLocalMediaAllowed, LocalMediaAccessError } from "../../media/local-media-access.js";
 import { isAudioFileName } from "../../media/mime.js";
 import { resolveSendableOutboundReplyParts } from "../../plugin-sdk/reply-payload.js";
@@ -111,10 +112,31 @@ function mimeTypeForPath(filePath: string): string {
   return MIME_BY_EXT[ext] ?? "audio/mpeg";
 }
 
-function estimateBase64DecodedBytes(base64: string): number {
-  const sanitized = base64.replace(/\s+/g, "");
-  const padding = sanitized.endsWith("==") ? 2 : sanitized.endsWith("=") ? 1 : 0;
-  return Math.floor((sanitized.length * 3) / 4) - padding;
+function isBase64DataPayload(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    const isBase64Char =
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a) ||
+      (code >= 0x30 && code <= 0x39) ||
+      code === 0x2b ||
+      code === 0x2f ||
+      code === 0x3d;
+    const isWhitespace =
+      code === 0x09 ||
+      code === 0x0a ||
+      code === 0x0b ||
+      code === 0x0c ||
+      code === 0x0d ||
+      code === 0x20;
+    if (!isBase64Char && !isWhitespace) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function resolveEmbeddableImageUrl(url: string): string | null {
@@ -125,12 +147,17 @@ function resolveEmbeddableImageUrl(url: string): string | null {
   if (trimmed.length > MAX_WEBCHAT_IMAGE_DATA_URL_CHARS) {
     return null;
   }
-  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=\s]+)$/i.exec(trimmed);
-  if (!match) {
+  const commaIndex = trimmed.indexOf(",");
+  if (commaIndex < 0) {
+    return null;
+  }
+  const metadata = trimmed.slice(0, commaIndex);
+  const match = /^data:(image\/[a-z0-9.+-]+);base64$/i.exec(metadata);
+  const base64Data = trimmed.slice(commaIndex + 1);
+  if (!match || !isBase64DataPayload(base64Data)) {
     return null;
   }
   const mediaType = normalizeLowercaseStringOrEmpty(match[1]);
-  const base64Data = match[2];
   if (!ALLOWED_WEBCHAT_DATA_IMAGE_MEDIA_TYPES.has(mediaType)) {
     return null;
   }

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -298,6 +298,20 @@ describe("resolveGatewayRuntimeConfig", () => {
       ).rejects.toThrow(/refusing to bind gateway/);
     });
 
+    it("rejects tailscale serve with explicit no-auth", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              auth: { mode: "none" },
+              tailscale: { mode: "serve" },
+            },
+          },
+          port: 18789,
+        }),
+      ).rejects.toThrow("gateway.auth.mode=none cannot be used with gateway.tailscale.mode=serve");
+    });
+
     it("respects explicit loopback config even inside a container", async () => {
       const fs = require("node:fs");
       vi.spyOn(fs, "accessSync").mockImplementation(() => undefined); // /.dockerenv exists
@@ -314,7 +328,7 @@ describe("resolveGatewayRuntimeConfig", () => {
       const result = await resolveGatewayRuntimeConfig({
         cfg: {
           gateway: {
-            auth: { mode: "none" },
+            auth: TOKEN_AUTH,
             tailscale: { mode: "serve" },
           },
         },

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -5,6 +5,10 @@ import type {
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  formatUnsafeGatewayTailscaleNoAuthMessage,
+  isUnsafeGatewayTailscaleNoAuth,
+} from "../shared/gateway-tailscale-auth-policy.js";
+import {
   assertGatewayAuthConfigured,
   type ResolvedGatewayAuth,
   resolveGatewayAuth,
@@ -134,6 +138,9 @@ export async function resolveGatewayRuntimeConfig(params: {
     throw new Error(
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",
     );
+  }
+  if (isUnsafeGatewayTailscaleNoAuth({ authMode, tailscaleMode })) {
+    throw new Error(formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode));
   }
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {
     throw new Error("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -1,5 +1,10 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as replyRunRegistryTesting,
+  createReplyOperation,
+} from "../auto-reply/reply/reply-run-registry.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resetCronActiveJobsForTests } from "../cron/active-jobs.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { type HeartbeatDeps, runHeartbeatOnce } from "./heartbeat-runner.js";
@@ -34,6 +39,8 @@ afterAll(() => {
 
 beforeEach(() => {
   resetSystemEventsForTest();
+  resetCronActiveJobsForTests();
+  replyRunRegistryTesting.resetReplyRunRegistry();
 });
 
 function createHeartbeatTelegramConfig(): OpenClawConfig {
@@ -97,6 +104,118 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         expect(result.reason).toBe("requests-in-flight");
       }
       expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns requests-in-flight when the target session has an active reply run", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const isReplyRunActive = vi.fn((key: string) => key === sessionKey);
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          isReplyRunActive,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+      expect(isReplyRunActive).toHaveBeenCalledWith(sessionKey);
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not defer immediate heartbeat wakes for another active session", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const listActiveReplyRunSessionKeys = vi.fn(() => [
+        "agent:main:telegram:group:-1003966283270:topic:547",
+      ]);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: vi.fn((_lane?: string) => 0),
+          listActiveReplyRunSessionKeys,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("returns requests-in-flight when a reply run is still active after queues drain", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const operation = createReplyOperation({
+        sessionKey,
+        sessionId: "active-reply-session",
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+
+      try {
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: vi.fn((_lane?: string) => 0),
+            nowMs: () => Date.now(),
+            getReplyFromConfig: replySpy,
+          } as HeartbeatDeps,
+        });
+
+        expect(result.status).toBe("skipped");
+        if (result.status === "skipped") {
+          expect(result.reason).toBe(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT);
+        }
+        expect(replySpy).not.toHaveBeenCalled();
+      } finally {
+        operation.complete();
+      }
+    });
+  });
+
+  it("returns requests-in-flight when an isolated heartbeat reply run is still active", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig();
+      cfg.agents!.defaults!.heartbeat = { every: "30m", isolatedSession: true };
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const operation = createReplyOperation({
+        sessionKey: isolatedSessionKey,
+        sessionId: "active-isolated-reply-session",
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+
+      try {
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: vi.fn((_lane?: string) => 0),
+            nowMs: () => Date.now(),
+            getReplyFromConfig: replySpy,
+          } as HeartbeatDeps,
+        });
+
+        expect(result.status).toBe("skipped");
+        if (result.status === "skipped") {
+          expect(result.reason).toBe(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT);
+        }
+        expect(replySpy).not.toHaveBeenCalled();
+      } finally {
+        operation.complete();
+      }
     });
   });
 

--- a/src/infra/heartbeat-runner.test-utils.ts
+++ b/src/infra/heartbeat-runner.test-utils.ts
@@ -17,6 +17,13 @@ export type HeartbeatSessionSeed = {
   lastTo: string;
   pendingFinalDelivery?: boolean;
   pendingFinalDeliveryText?: string;
+  pendingFinalDeliveryCreatedAt?: number;
+  pendingFinalDeliveryAttemptCount?: number;
+  pendingFinalDeliveryLastError?: string | null;
+  agentHarnessId?: string;
+  agentRuntimeOverride?: string;
+  model?: string;
+  modelProvider?: string;
 };
 
 export type HeartbeatReplyFn = NonNullable<HeartbeatDeps["getReplyFromConfig"]>;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -900,6 +900,14 @@ export async function runHeartbeatOnce(opts: {
       isolatedSessionKey,
       isolatedBaseSessionKey,
     });
+    if (isReplyRunActive(isolatedSessionKey)) {
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+        durationMs: Date.now() - startedAt,
+      });
+      return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
+    }
     const removedSessionFiles = new Map<string, string | undefined>();
     if (staleIsolatedSessionKey) {
       const staleEntry = cronSession.store[staleIsolatedSessionKey];

--- a/src/plugin-sdk/provider-onboard.ts
+++ b/src/plugin-sdk/provider-onboard.ts
@@ -48,6 +48,10 @@ function extractAgentDefaultModelFallbacks(model: unknown): string[] | undefined
   return Array.isArray(fallbacks) ? fallbacks.map((value) => String(value)) : undefined;
 }
 
+function hasAgentDefaultModelPrimary(cfg: OpenClawConfig): boolean {
+  return resolvePrimaryStringValue(cfg.agents?.defaults?.model) !== undefined;
+}
+
 function normalizeAgentModelAliasEntry(entry: AgentModelAliasEntry): {
   modelRef: string;
   alias?: string;
@@ -316,7 +320,9 @@ export function applyProviderConfigWithDefaultModelPreset(
     defaultModelId: params.defaultModelId,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? hasAgentDefaultModelPrimary(cfg)
+      ? next
+      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
     : next;
 }
 
@@ -358,7 +364,9 @@ export function applyProviderConfigWithDefaultModelsPreset(
     defaultModelId: params.defaultModelId,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? hasAgentDefaultModelPrimary(cfg)
+      ? next
+      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
     : next;
 }
 
@@ -430,7 +438,9 @@ export function applyProviderConfigWithModelCatalogPreset(
     catalogModels: params.catalogModels,
   });
   return params.primaryModelRef
-    ? applyAgentDefaultModelPrimary(next, params.primaryModelRef)
+    ? hasAgentDefaultModelPrimary(cfg)
+      ? next
+      : applyAgentDefaultModelPrimary(next, params.primaryModelRef)
     : next;
 }
 

--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -103,3 +103,23 @@ function killProcessTreeWindows(pid: number, graceMs: number): void {
     runTaskkill(["/F", "/T", "/PID", String(pid)]);
   }, graceMs).unref(); // Don't block event loop exit
 }
+
+/**
+ * Send a signal synchronously to a process tree (process group first, then pid).
+ * Unlike killProcessTree(), this does NOT use setTimeout — it fires immediately.
+ * Useful as a last-resort after killProcessTree's delayed SIGKILL may have raced shutdown.
+ */
+export function signalProcessTree(pid: number, signal: NodeJS.Signals | number): void {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Process already gone
+    }
+  }
+}

--- a/src/shared/gateway-tailscale-auth-policy.ts
+++ b/src/shared/gateway-tailscale-auth-policy.ts
@@ -1,0 +1,20 @@
+import type { GatewayAuthMode, GatewayTailscaleMode } from "../config/types.gateway.js";
+
+export function isUnsafeGatewayTailscaleNoAuth(params: {
+  authMode?: GatewayAuthMode;
+  tailscaleMode?: GatewayTailscaleMode;
+}): boolean {
+  return (
+    params.authMode === "none" &&
+    (params.tailscaleMode === "serve" || params.tailscaleMode === "funnel")
+  );
+}
+
+export function formatUnsafeGatewayTailscaleNoAuthMessage(
+  tailscaleMode: GatewayTailscaleMode,
+): string {
+  if (tailscaleMode === "funnel") {
+    return "gateway.tailscale.mode=funnel requires gateway.auth.mode=password; auth.mode=none cannot be used when exposing the gateway through Tailscale Funnel";
+  }
+  return `gateway.auth.mode=none cannot be used with gateway.tailscale.mode=${tailscaleMode}; configure token, password, or trusted-proxy auth before exposing the gateway through Tailscale`;
+}

--- a/test/scripts/claude-auth-status.test.ts
+++ b/test/scripts/claude-auth-status.test.ts
@@ -1,0 +1,65 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.ts";
+
+const SCRIPT = "scripts/claude-auth-status.sh";
+
+describe("claude-auth-status.sh", () => {
+  const harness = createScriptTestHarness();
+
+  it("prints expiry timestamps on macOS without GNU date", () => {
+    const root = harness.createTempDir("openclaw-claude-auth-status-");
+    const bin = path.join(root, "bin");
+    mkdirSync(bin, { recursive: true });
+    const openclaw = path.join(bin, "openclaw");
+    const futureMs = String(Date.now() + 2 * 60 * 60 * 1000);
+
+    writeFileSync(
+      openclaw,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [ "$*" = "models status --json" ]; then',
+        "cat <<'JSON'",
+        JSON.stringify({
+          auth: {
+            oauth: {
+              profiles: [
+                {
+                  provider: "anthropic",
+                  type: "oauth",
+                  profileId: "anthropic:test",
+                  expiresAt: Number(futureMs),
+                },
+              ],
+            },
+            providers: [{ provider: "anthropic", profiles: { apiKey: 0 } }],
+          },
+        }),
+        "JSON",
+        "else",
+        "exit 2",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(openclaw, 0o755);
+
+    const result = spawnSync("bash", [SCRIPT, "full"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: root,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("date:");
+    expect(result.stdout).toContain("Claude Code Auth Status");
+    expect(result.stdout.match(/Expires:/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Cherry-picks 10 upstream fixes from openclaw/openclaw into gemmaclaw.

Prior sync point: c9364f03dc (PR #244, 2026-05-27)
Upstream range: c9364f03dc..d00e764e66 (862 commits ahead)
New sync point: d00e764e66 (upstream HEAD)

## Commits Included

- feat(agents): add mcp-stdio-transport and live-model-switch support
- feat(tool-display): add tool display config and update shared resources
- feat(gateway): add live-tool-probe-utils for gateway health probing
- fix(gateway): add tailscale auth policy for gateway bind security
- feat(gateway): add webchat media support to server methods
- feat(commands): add gateway-install-token and doctor-gateway-auth-token commands
- feat(config): add gateway tailscale bind configuration and validation
- feat(gateway): add server runtime config with tests
- feat(provider-onboard): update provider onboard plugin SDK
- fix(heartbeat): add isReplyRunActive skip for isolated sessions and session lanes

## Adaptation Notes

- signalProcessTree() added to kill-tree.ts (upstream extracted to agent-core package; gemmaclaw inlines)
- pendingFinalDelivery heartbeat block excluded (depends on session infrastructure not yet ported)
- Corresponding tests for pendingFinalDelivery/listActiveReplyRunSessionKeys excluded
- tool-display.json excluded (iOS-only; swiftlint not available in WSL2)

## Regression Gate

All gates passed: pnpm build, pnpm check:changed, CLI smoke, live smoke test with gemma-4-26B-A4B-it-Q4_K_M.