### PR TITLE
chore: upstream sync openclaw -> gemmaclaw 2026-06-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Upstream sync 2026-06-06: reviewed the recent openclaw/openclaw slice (15,722 commits ahead of the fork). Applied one compatible runtime fix to single-provider cooldown recovery; the other recent high-value upstream fixes (streaming content-type tolerance, context-engine heartbeat forwarding, compaction prompt-fence/thinking-signature handling) were assessed and found inapplicable to the fork's older/refactored baseline (transport lacks the content-type assertion that regressed; context-engine `afterTurn` is a no-op; `embedded-agent-runner` was replaced by `pi-embedded-runner`).
 - Upstream sync 2026-06-02: reviewed openclaw/openclaw 2026.6.2 release (14,286 commits). Applied compatible fixes: bootstrap-token rate-limit scope for gateway security hardening, and Gemini 3.1 model ID normalization corrections (Flash Lite GA endpoint, Pro preview alias, google/ prefix handling).
 
 ### Fixes
 
+- Agents/model-fallback: a single-provider primary (no fallback chain configured — the common local-model setup) now re-probes through the existing cooldown throttle instead of staying suspended until a far-future provider-reported reset, so rate/subscription-cap recovery resumes without a restart. The 30s probe throttle still gates recovery probes. (upstream `6da3b1f6a3`, #90717, fixes #90702)
 - Gateway/security: add `AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN` rate-limit scope to prevent DoS on the bootstrap-token verify path, preserving device-token fallback. (upstream ecbd97e9)
 - Google/providers: fix Gemini model ID normalization — `gemini-3.1-flash-lite` no longer maps to the deprecated preview endpoint (shutdown 2026-05-25), `gemini-3-pro-preview` now normalizes to `gemini-3.1-pro-preview`, and `google/` prefix is handled recursively. (upstream fix)
 
@@ -143,20 +145,18 @@ Docs: https://docs.openclaw.ai
 
 ## [2026.7.0](https://github.com/gemmaclaw/gemmaclaw/compare/gemmaclaw-v2026.6.0...gemmaclaw-v2026.7.0) (2026-06-04)
 
-
 ### Features
 
-* **benchmark:** add q4-loop benchmark suite with E2BIG transport fix ([c5f3af9](https://github.com/gemmaclaw/gemmaclaw/commit/c5f3af9f9c79c4e3604399ad41176f2c4e3a65c2))
-
+- **benchmark:** add q4-loop benchmark suite with E2BIG transport fix ([c5f3af9](https://github.com/gemmaclaw/gemmaclaw/commit/c5f3af9f9c79c4e3604399ad41176f2c4e3a65c2))
 
 ### Bug Fixes
 
-* **auth:** harden Vertex AI authentication, dedicated URL support, and Gemma 4 model routing ([a553c3c](https://github.com/gemmaclaw/gemmaclaw/commit/a553c3cff2bc5678de51799a73edb0cce091a3a2))
-* **benchmark:** rejudge public runs via CC ACP + publish only measured generation TPS ([#265](https://github.com/gemmaclaw/gemmaclaw/issues/265)) ([2e8d65f](https://github.com/gemmaclaw/gemmaclaw/commit/2e8d65f7a1dbd6e772afd62cc37c66d780d7e6f5))
-* **site:** merge metadata.json gpu fields for VRAM and llama build display ([4f3d7de](https://github.com/gemmaclaw/gemmaclaw/commit/4f3d7de0d4270d16ecf132c8efdc93ec18dde860))
-* **tests:** update google-antigravity normalization tests for GA flash-lite endpoint ([7bfe23d](https://github.com/gemmaclaw/gemmaclaw/commit/7bfe23dafb4098ccb985db41d72a8a400cc68af6))
-* **vertex:** harden Vertex AI authentication, dedicated URL support, and Gemma 4 model routing ([f19fbac](https://github.com/gemmaclaw/gemmaclaw/commit/f19fbac3924cae75ab4ab84c13756ee8e9586e5c))
-* **vertex:** isolate setup wiring and harden auth ([7b536c3](https://github.com/gemmaclaw/gemmaclaw/commit/7b536c36eddcab0506ec29dccb98ba58dfb4d900))
+- **auth:** harden Vertex AI authentication, dedicated URL support, and Gemma 4 model routing ([a553c3c](https://github.com/gemmaclaw/gemmaclaw/commit/a553c3cff2bc5678de51799a73edb0cce091a3a2))
+- **benchmark:** rejudge public runs via CC ACP + publish only measured generation TPS ([#265](https://github.com/gemmaclaw/gemmaclaw/issues/265)) ([2e8d65f](https://github.com/gemmaclaw/gemmaclaw/commit/2e8d65f7a1dbd6e772afd62cc37c66d780d7e6f5))
+- **site:** merge metadata.json gpu fields for VRAM and llama build display ([4f3d7de](https://github.com/gemmaclaw/gemmaclaw/commit/4f3d7de0d4270d16ecf132c8efdc93ec18dde860))
+- **tests:** update google-antigravity normalization tests for GA flash-lite endpoint ([7bfe23d](https://github.com/gemmaclaw/gemmaclaw/commit/7bfe23dafb4098ccb985db41d72a8a400cc68af6))
+- **vertex:** harden Vertex AI authentication, dedicated URL support, and Gemma 4 model routing ([f19fbac](https://github.com/gemmaclaw/gemmaclaw/commit/f19fbac3924cae75ab4ab84c13756ee8e9586e5c))
+- **vertex:** isolate setup wiring and harden auth ([7b536c3](https://github.com/gemmaclaw/gemmaclaw/commit/7b536c36eddcab0506ec29dccb98ba58dfb4d900))
 
 ## 2026.5.25
 

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -601,7 +601,7 @@ describe("runWithModelFallback – probe logic", () => {
     expectPrimaryProbeSuccess(result, run, "ok-null");
   });
 
-  it("single candidate skips with rate_limit and exhausts candidates", async () => {
+  it("re-probes a single-provider rate-limited primary instead of suspending", async () => {
     const cfg = makeCfg({
       agents: {
         defaults: {
@@ -613,22 +613,26 @@ describe("runWithModelFallback – probe logic", () => {
       },
     } as Partial<OpenClawConfig>);
 
-    const almostExpired = NOW + 30 * 1000;
-    mockedGetSoonestCooldownExpiry.mockReturnValue(almostExpired);
+    // Far-future cooldown with no fallback chain: the primary must still be
+    // probed so a recovered rolling cap resumes work instead of staying silent
+    // until blockedUntil arrives. See #90702.
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 6 * 24 * 60 * 60 * 1000);
 
-    const run = vi.fn().mockResolvedValue("unreachable");
+    const run = vi.fn().mockResolvedValue("probed-ok");
 
-    await expect(
-      runWithModelFallback({
-        cfg,
-        provider: "openai",
-        model: "gpt-4.1-mini",
-        fallbacksOverride: [],
-        run,
-      }),
-    ).rejects.toThrow("All models failed");
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      fallbacksOverride: [],
+      run,
+    });
 
-    expect(run).not.toHaveBeenCalled();
+    expect(result.result).toBe("probed-ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
+      allowTransientCooldownProbe: true,
+    });
   });
 
   it("scopes probe throttling by agentDir to avoid cross-agent suppression", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -531,12 +531,22 @@ function shouldProbePrimaryDuringCooldown(params: {
   profileIds: string[];
   model: string;
 }): boolean {
-  if (!params.isPrimary || !params.hasFallbackCandidates) {
+  if (!params.isPrimary) {
     return false;
   }
 
   if (!isProbeThrottleOpen(params.now, params.throttleKey)) {
     return false;
+  }
+
+  // A single-provider primary has no fallback chain to prefer, so every open
+  // throttle slot is a recovery probe: "is the primary callable yet?" is a
+  // recovery question independent of fallback configuration. Without this, a
+  // fallbacks:[] setup that hits a rate/subscription cap stays suspended until
+  // the provider-reported reset (which can be days out) even though the rolling
+  // cap usually recovers earlier. See #90702.
+  if (!params.hasFallbackCandidates) {
+    return true;
   }
 
   const soonest = params.authRuntime.getSoonestCooldownExpiry(params.authStore, params.profileIds, {
@@ -614,15 +624,11 @@ function resolveCooldownDecision(params: {
   }
 
   // Billing is semi-persistent: the user may fix their balance, or a transient
-  // 402 might have been misclassified. Probe single-provider setups on the
-  // standard throttle so they can recover without a restart; when fallbacks
-  // exist, only probe near cooldown expiry so the fallback chain stays preferred.
+  // 402 might have been misclassified. shouldProbe already re-probes
+  // single-provider setups on the throttle (no fallback chain to prefer) and
+  // multi-fallback setups near cooldown expiry, so both recover without a restart.
   if (inferredReason === "billing") {
-    const shouldProbeSingleProviderBilling =
-      params.isPrimary &&
-      !params.hasFallbackCandidates &&
-      isProbeThrottleOpen(params.now, params.probeThrottleKey);
-    if (params.isPrimary && (shouldProbe || shouldProbeSingleProviderBilling)) {
+    if (params.isPrimary && shouldProbe) {
       return { type: "attempt", reason: inferredReason, markProbe: true };
     }
     return {


### PR DESCRIPTION
## Summary

Selective upstream sync from `openclaw/openclaw` as of 2026-06-06. The fork is **15,722 commits** behind full upstream (a deliberately-large strategic backlog; the fork tracks upstream selectively, not commit-for-commit). This PR applies **one** self-contained, high-value runtime fix and documents why the other recent high-value upstream fixes were assessed as **inapplicable** to the fork's older/refactored baseline.

- **Merge base (origin/main at branch cut):** `207a49990013f7e9012d276c4d07e1fed249fcc9`
- **Watched upstream HEAD at scan:** `bbfe8ccaf60e87e84a3c695e56f4bee7c687c5b0` (was `a4f7e4cbb9` when the task was filed)
- **Branch:** `maintenance/upstream-openclaw-20260606`

## Applied fix

**Agents / model-fallback — re-probe single-provider primary during cooldown** (upstream `6da3b1f6a3`, #90717, fixes #90702)

A single-provider primary (no fallback chain configured — the common local-model / Gemma-on-llama.cpp configuration) previously would **not** re-probe during cooldown, so a `fallbacks:[]` setup that hit a rate or subscription cap stayed suspended until the provider-reported reset timestamp (which can be days out), even though the rolling cap usually recovers earlier. The fix lets a single-provider primary probe through the existing throttle on every open slot. The 30s probe throttle still gates recovery probes (no hammering).

Because the fork is ~15.7k commits behind, `src/agents/model-fallback.ts` has diverged from upstream (996 vs 1776 lines), so this was applied as a **targeted hand-reimplementation** of the upstream diff at the fork's line numbers (not a cherry-pick), exactly mirroring the upstream semantic change in `shouldProbePrimaryDuringCooldown` and the billing branch of `resolveCooldownDecision`. The existing `single candidate skips with rate_limit…` test was updated to the new behavior to match the upstream test change.

## Assessed but NOT applied (inapplicable to fork baseline)

A parallel triage of the 5 most relevant recent upstream fixes (security/runtime/provider/crash) found the following moot for the fork:

| Upstream | Why skipped |
|---|---|
| `ab0a633ab9` tolerate missing streamed response content-type | Fork's transport (`provider-transport-fetch.ts`, 205 lines) **never had** the `assertOpenAISdkStreamContentType` content-type rejection that upstream's regression+fix concern — there is nothing to fix. |
| `d896a4c7a3` context-engine forward `isHeartbeat` to `afterTurn` | Fork's only context engine is `legacy.ts`, whose `afterTurn` is a documented **no-op** ("legacy flow persists context directly in SessionManager") and already accepts `isHeartbeat?` but ignores it. Threading it would be a zero-benefit no-op touching the heartbeat path. |
| `bbfe8ccaf6` refresh prompt fence after compaction writes | Targets `embedded-agent-runner/run/attempt.session-lock.*` — the fork replaced `embedded-agent-runner` with `pi-embedded-runner`; the targeted files do not exist. |
| `6c259af759` strip stale compaction thinking signatures before Anthropic replay | Same `embedded-agent-runner` → `pi-embedded-runner` refactor; Anthropic-cloud-specific signature replay path absent in the fork's `thinking.ts`/`replay-history.ts`. |

## Preserved Gemmaclaw seams

This change touches **only** `src/agents/model-fallback.ts` (model-provider cooldown logic) + its test + CHANGELOG. It does **not** touch: setup/onboarding wizard, Gemma model defaults, local-model provider setup, Docker sandbox, shared-folder mounts, backup/restore, benchmark harnesses, site generation, branding, generated config schema, or **session-store performance infrastructure** (`store-cache.ts`/`store.ts`/`store-load.ts`, `SESSION_STORE_SNAPSHOT_CACHE`, `STRING_INTERN_POOL`). No escalation needed.

## Test plan

- [x] `pnpm install --lockfile-only` — lockfile unchanged (no dep changes)
- [x] `pnpm install` + `pnpm build` (Node 22.22.2) — build EXIT=0
- [x] `pnpm check:changed` — EXIT=0: tsgo core+test typecheck clean, lint:core 0 warnings/0 errors (7000 files), 0 import cycles, webhook/pairing guards pass, **vitest.agents 393 files / 4205 passed | 5 skipped**
- [x] Focused: `model-fallback.probe.test.ts` + `model-fallback.test.ts` + `model-fallback.image-provider.test.ts` — 73/73 pass (incl. updated single-provider re-probe test)
- [x] CLI smoke: `gemmaclaw --version` = OpenClaw 2026.7.0; `setup`/`backup`/`backup restore --help` render with Gemmaclaw branding and correct subcommands
- [ ] CI: Onboard Gemma E2E (Docker) live setup smoke (runs on PR; change is orthogonal to setup/sandbox/backup so the cooldown path is not exercised by the smoke, but the lane confirms no setup/runtime regression)

The change is covered behaviorally by the focused unit tests; the Docker live-setup smoke is delegated to CI rather than run locally on the shared build host.
