### PR TITLE
feat(setup): merged 12-step setup wizard (Gemmaclaw + OpenClaw gateway/channels)

### DIFF
--- a/src/commands/setup-gemma.ts
+++ b/src/commands/setup-gemma.ts
@@ -9,6 +9,7 @@ import type {
   OnboardingBackend,
   OnboardingBootstrap,
   OnboardingChoices,
+  OnboardingDefaults,
   OnboardingThinking,
 } from "../gemmaclaw/provision/onboarding-wizard.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -380,12 +381,8 @@ export async function setupGemmaCommand(
     await import("../gemmaclaw/provision/setup-wizard.js");
   const { provision, verifyCompletion } = await import("../gemmaclaw/provision/provision.js");
   const { DEFAULT_GATEWAY_PORT } = await import("../config/paths.js");
-  const {
-    runOnboardingWizard,
-    createStdioOnboardingIO,
-    buildNonInteractiveChoices,
-    formatChoicesSummary,
-  } = await import("../gemmaclaw/provision/onboarding-wizard.js");
+  const { createStdioOnboardingIO, buildNonInteractiveChoices, formatChoicesSummary } =
+    await import("../gemmaclaw/provision/onboarding-wizard.js");
 
   // Check Node.js version.
   const nodeVersion = Number.parseInt(process.versions.node.split(".")[0], 10);
@@ -399,9 +396,20 @@ export async function setupGemmaCommand(
   const dryRun = opts.dryRun || process.env.OPENCLAW_SETUP_DRY_RUN === "1";
 
   // Build onboarding choices either from CLI flags (non-interactive) or from
-  // the interactive wizard. The wizard accepts presets so flags partially
-  // skip individual prompts (e.g. --agent-name skips the name prompt).
+  // the interactive merged wizard. The wizard accepts presets so flags
+  // partially skip individual prompts (e.g. --agent-name skips the name
+  // prompt).
   let choices: OnboardingChoices;
+  // pendingGatewayConfig accumulates gateway + provider auth settings from
+  // the interactive wizard steps so they can be written to config at the end.
+  let pendingGatewayConfig: OpenClawConfig | null = null;
+  // pendingChannelConfig carries channel settings from the channel wizard step.
+  let pendingChannelConfig: OpenClawConfig | null = null;
+  // existingConfigAction is only meaningful for the interactive path.
+  let existingConfigAction:
+    | import("../gemmaclaw/provision/merged-setup.gemmaclaw.js").ExistingConfigAction
+    | null = null;
+
   if (opts.nonInteractive) {
     choices = buildNonInteractiveChoices({
       agentName: opts.agentName,
@@ -414,23 +422,74 @@ export async function setupGemmaCommand(
       apiKey: process.env.GEMINI_API_KEY?.trim(),
     });
   } else {
+    // Interactive merged wizard (Steps 1-9: Gemmaclaw; Steps 10-11: OpenClaw
+    // gateway and channel config).
+    const {
+      runGemmaclawSetupSteps,
+      runOpenClawAuthFlow,
+      runGatewayConfigStep,
+      runChannelSetupStep,
+    } = await import("../gemmaclaw/provision/merged-setup.gemmaclaw.js");
+
     const io = createStdioOnboardingIO();
     try {
-      choices = await runOnboardingWizard(io, {
-        agentName: opts.agentName,
-        useContainer: opts.noContainer === true ? false : undefined,
-        backend: opts.setupMode,
-        model: opts.model,
-        thinkingLevel: opts.thinking,
-        bootstrap: opts.bootstrap,
-        enhancements: opts.enhancements
-          ? (await import("../gemmaclaw/gemmaclaw_instructions.js")).resolveGemmaclawEnhancementIds(
-              opts.enhancements,
-            )
-          : undefined,
-      });
+      // Resolve enhancement IDs from the CLI flag if provided, so they can be
+      // used as defaults inside the wizard.
+      const enhancementDefaults: OnboardingDefaults["enhancements"] = opts.enhancements
+        ? (await import("../gemmaclaw/gemmaclaw_instructions.js")).resolveGemmaclawEnhancementIds(
+            opts.enhancements,
+          )
+        : undefined;
+
+      const wizardResult = await runGemmaclawSetupSteps(
+        io,
+        {
+          agentName: opts.agentName,
+          useContainer: opts.noContainer === true ? false : undefined,
+          backend: opts.setupMode,
+          model: opts.model,
+          thinkingLevel: opts.thinking,
+          bootstrap: opts.bootstrap,
+          enhancements: enhancementDefaults,
+        },
+        { includeExtended: true },
+      );
+      choices = wizardResult.choices;
+      existingConfigAction = wizardResult.existingConfigAction;
     } finally {
       io.close();
+    }
+
+    // For "gemini" and "extended" backends, run the OpenClaw provider auth
+    // flow (Step 9.5) which lets the user pick their Gemini/provider key via
+    // the OpenClaw auth-choice ecosystem instead of a bespoke prompt.
+    if (
+      existingConfigAction !== "keep" &&
+      (choices.backend === "gemini" || choices.backend === "extended")
+    ) {
+      const authResult = await runOpenClawAuthFlow(runtime, {} as OpenClawConfig, choices.backend, {
+        dryRun,
+      });
+      if (authResult) {
+        if (authResult.model) {
+          choices = { ...choices, model: authResult.model };
+        }
+        pendingGatewayConfig = authResult.nextConfig;
+      }
+    }
+
+    // Step 10: Gateway configuration (skipped when user chose "keep").
+    if (existingConfigAction !== "keep") {
+      const gwResult = await runGatewayConfigStep(runtime, pendingGatewayConfig ?? {}, { dryRun });
+      if (gwResult) {
+        pendingGatewayConfig = gwResult.nextConfig;
+      }
+
+      // Step 11: Channel setup.
+      const chanResult = await runChannelSetupStep(runtime, pendingGatewayConfig ?? {}, { dryRun });
+      if (chanResult) {
+        pendingChannelConfig = chanResult;
+      }
     }
   }
 
@@ -470,8 +529,23 @@ export async function setupGemmaCommand(
   const useDocker = choices.useContainer;
 
   if (choices.backend === "gemini") {
-    await setupGeminiBackend(runtime, choices, { dryRun });
+    // Non-interactive path: write the API key directly via the legacy helper.
+    // Interactive path: auth was already handled by runOpenClawAuthFlow above;
+    // the resulting config is in pendingGatewayConfig.
+    if (opts.nonInteractive) {
+      await setupGeminiBackend(runtime, choices, { dryRun });
+    }
     await applySharedAgentDefaults(choices, useDocker, runtime);
+    await applyGatewayChannelConfig(pendingGatewayConfig, pendingChannelConfig);
+    await printPostSetupSummary(runtime, choices, undefined);
+    return;
+  }
+
+  if (choices.backend === "extended") {
+    // Extended backend: auth + model were handled by runOpenClawAuthFlow;
+    // config is accumulated in pendingGatewayConfig.
+    await applySharedAgentDefaults(choices, useDocker, runtime);
+    await applyGatewayChannelConfig(pendingGatewayConfig, pendingChannelConfig);
     await printPostSetupSummary(runtime, choices, undefined);
     return;
   }
@@ -479,6 +553,7 @@ export async function setupGemmaCommand(
   if (choices.backend === "vertex") {
     await setupVertexBackend(runtime, choices, { dryRun });
     await applySharedAgentDefaults(choices, useDocker, runtime);
+    await applyGatewayChannelConfig(pendingGatewayConfig, pendingChannelConfig);
     await printPostSetupSummary(runtime, choices, undefined);
     return;
   }
@@ -522,6 +597,7 @@ export async function setupGemmaCommand(
       `[dry-run] Would provision ${profile.backend} with model ${profile.model ?? "(auto)"} on port ${String(profile.port)}.`,
     );
     await applySharedAgentDefaults(choices, useDocker, runtime);
+    await applyGatewayChannelConfig(pendingGatewayConfig, pendingChannelConfig);
     await printPostSetupSummary(runtime, choices, undefined);
     return;
   }
@@ -614,6 +690,8 @@ export async function setupGemmaCommand(
       }
 
       await applyAgentNameAndBootstrap(choices);
+      // Apply gateway and channel settings captured from the wizard steps.
+      await applyGatewayChannelConfig(pendingGatewayConfig, pendingChannelConfig);
 
       runtime.log("");
       runtime.log("Setup complete! Your Gemma assistant is ready.");
@@ -871,6 +949,43 @@ export async function applyAgentNameAndBootstrap(choices: OnboardingChoices): Pr
     ensureDockerWritableHostDir(fs, workspaceDir);
     ensureDockerWritableHostDir(fs, resolveGemmaclawSharedDir());
   }
+}
+
+/**
+ * Apply gateway, secrets, model-provider auth, and channel settings that were
+ * captured during the interactive wizard steps (Steps 10-11) into the on-disk
+ * config. Called after backend-specific provisioning so wizard settings win.
+ */
+async function applyGatewayChannelConfig(
+  gatewayConfig: OpenClawConfig | null,
+  channelConfig: OpenClawConfig | null,
+): Promise<void> {
+  if (!gatewayConfig && !channelConfig) {
+    return;
+  }
+  const { mutateConfigFile } = await import("../config/mutate.js");
+  await mutateConfigFile({
+    mutate: (draft) => {
+      if (gatewayConfig) {
+        if (gatewayConfig.gateway) {
+          draft.gateway = { ...draft.gateway, ...gatewayConfig.gateway };
+        }
+        if (gatewayConfig.secrets) {
+          draft.secrets = { ...draft.secrets, ...gatewayConfig.secrets };
+        }
+        if (gatewayConfig.models?.providers) {
+          draft.models ??= {};
+          draft.models.providers = {
+            ...draft.models.providers,
+            ...gatewayConfig.models.providers,
+          };
+        }
+      }
+      if (channelConfig?.channels) {
+        draft.channels = { ...draft.channels, ...channelConfig.channels };
+      }
+    },
+  });
 }
 
 async function printPostSetupSummary(

--- a/src/gemmaclaw/provision/merged-setup.gemmaclaw.test.ts
+++ b/src/gemmaclaw/provision/merged-setup.gemmaclaw.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from "vitest";
+import { runGemmaclawSetupSteps, type ExistingConfigAction } from "./merged-setup.gemmaclaw.js";
+import { askBackend, buildNonInteractiveChoices, type WizardIO } from "./onboarding-wizard.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeScriptedIO(answers: string[]): {
+  io: WizardIO;
+  logs: string[];
+  errors: string[];
+  prompts: string[];
+} {
+  const queue = [...answers];
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const prompts: string[] = [];
+  const io: WizardIO = {
+    prompt: vi.fn(async (q: string) => {
+      prompts.push(q);
+      const next = queue.shift();
+      if (next === undefined) {
+        throw new Error(`No scripted answer left for prompt: ${q}`);
+      }
+      return next;
+    }),
+    log: vi.fn((msg: string) => {
+      logs.push(msg);
+    }),
+    error: vi.fn((msg: string) => {
+      errors.push(msg);
+    }),
+  };
+  return { io, logs, errors, prompts };
+}
+
+// ---------------------------------------------------------------------------
+// askBackend — "extended" backend option
+// ---------------------------------------------------------------------------
+
+describe("askBackend — extended option", () => {
+  it("returns 'extended' when the user picks option 4 and includeExtended=true", async () => {
+    const { io } = makeScriptedIO(["4"]);
+    const backend = await askBackend(io, undefined, true);
+    expect(backend).toBe("extended");
+  });
+
+  it("returns 'extended' when the user types 'extended'", async () => {
+    const { io } = makeScriptedIO(["extended"]);
+    const backend = await askBackend(io, undefined, true);
+    expect(backend).toBe("extended");
+  });
+
+  it("does NOT present option 4 when includeExtended=false", async () => {
+    // Option 4 with includeExtended=false → invalid, triggers re-prompt.
+    // We provide an invalid answer first, then a valid one to avoid infinite loop.
+    const { io, logs } = makeScriptedIO(["4", "1"]);
+    const backend = await askBackend(io, undefined, false);
+    // Should have re-prompted (logged an error or re-asked) and resolved to "local"
+    expect(backend).toBe("local");
+    const joined = logs.join("\n");
+    expect(joined).not.toContain("Extended options");
+  });
+
+  it("still shows options 1-3 when includeExtended=true", async () => {
+    const { io, logs } = makeScriptedIO(["1"]);
+    await askBackend(io, undefined, true);
+    const joined = logs.join("\n");
+    expect(joined).toContain("1)");
+    expect(joined).toContain("2)");
+    expect(joined).toContain("3)");
+    expect(joined).toContain("4)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildNonInteractiveChoices — handles "extended"
+// ---------------------------------------------------------------------------
+
+describe("buildNonInteractiveChoices — extended backend", () => {
+  it("includes 'extended' as a valid backend", () => {
+    const choices = buildNonInteractiveChoices({ backend: "extended" });
+    expect(choices.backend).toBe("extended");
+    expect(choices.model).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runGemmaclawSetupSteps — no existing config
+// ---------------------------------------------------------------------------
+
+vi.mock("../../config/config.js", () => ({
+  readConfigFileSnapshot: vi.fn().mockResolvedValue({ exists: false, valid: false, config: null }),
+}));
+
+describe("runGemmaclawSetupSteps — no existing config", () => {
+  it("walks the user through all Gemmaclaw prompts (local backend)", async () => {
+    const { io } = makeScriptedIO([
+      "", // agent name → main
+      "", // container → yes
+      "", // backend → 1 (local)
+      "", // model → auto
+      "", // thinking → medium
+      "", // bootstrap → general
+      "", // enhancements → defaults
+    ]);
+
+    const result = await runGemmaclawSetupSteps(io, {}, { skipExistingConfigCheck: true });
+
+    expect(result.existingConfigAction).toBeNull();
+    expect(result.choices).toMatchObject({
+      agentName: "main",
+      useContainer: true,
+      backend: "local",
+      thinkingLevel: "medium",
+      bootstrap: "general",
+    });
+  });
+
+  it("returns 'extended' backend when user picks option 4", async () => {
+    const { io } = makeScriptedIO([
+      "myagent", // agent name
+      "2", // host (no container)
+      "4", // extended backend
+      "", // thinking → medium
+      "", // bootstrap → general
+      "", // enhancements → defaults
+    ]);
+
+    const result = await runGemmaclawSetupSteps(
+      io,
+      {},
+      {
+        skipExistingConfigCheck: true,
+        includeExtended: true,
+      },
+    );
+
+    expect(result.choices.backend).toBe("extended");
+    expect(result.choices.model).toBe(""); // no model prompt for extended
+    expect(result.choices.agentName).toBe("myagent");
+  });
+
+  it("skips prompts for fields where preset defaults are provided", async () => {
+    // When backend preset is set, askBackend skips the prompt entirely.
+    const { io, prompts } = makeScriptedIO([
+      // name, container, backend prompts skipped by presets
+      "", // model
+      "", // thinking
+      "", // bootstrap
+      "", // enhancements
+    ]);
+
+    const result = await runGemmaclawSetupSteps(
+      io,
+      { agentName: "main", backend: "vertex", useContainer: true },
+      { skipExistingConfigCheck: true },
+    );
+
+    expect(result.choices.backend).toBe("vertex");
+    // 4 prompts: model, thinking, bootstrap, enhancements
+    // (name, container, backend all skipped because presets were supplied)
+    expect(prompts).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runGemmaclawSetupSteps — existing config: "keep"
+// ---------------------------------------------------------------------------
+
+describe("runGemmaclawSetupSteps — existing config action", () => {
+  it("skips wizard prompts when user chooses 'keep'", async () => {
+    // First prompt = existing config action (keep=1), then no more prompts.
+    const { io } = makeScriptedIO(["1"]);
+
+    const fakeExistingConfig = { gateway: { mode: "local" as const } };
+    const result = await runGemmaclawSetupSteps(
+      io,
+      {},
+      {
+        existingConfig: fakeExistingConfig as import("../../config/config.js").OpenClawConfig,
+      },
+    );
+
+    expect(result.existingConfigAction).toBe<ExistingConfigAction>("keep");
+    // Should have used non-interactive defaults without asking wizard questions.
+    expect(result.choices.agentName).toBe("main");
+    expect(result.choices.backend).toBe("local");
+  });
+
+  it("re-runs wizard with 'update' and re-prompts the user", async () => {
+    // answer "2" to keep/update/reset → then wizard prompts
+    const { io } = makeScriptedIO([
+      "2", // update
+      "", // agent name → main
+      "", // container → yes
+      "", // backend → local
+      "", // model
+      "", // thinking
+      "", // bootstrap
+      "", // enhancements
+    ]);
+
+    const fakeExistingConfig = { gateway: { mode: "local" as const } };
+    const result = await runGemmaclawSetupSteps(
+      io,
+      {},
+      {
+        existingConfig: fakeExistingConfig as import("../../config/config.js").OpenClawConfig,
+      },
+    );
+
+    expect(result.existingConfigAction).toBe<ExistingConfigAction>("update");
+    expect(result.choices.backend).toBe("local");
+  });
+
+  it("starts fresh on 'reset'", async () => {
+    const { io } = makeScriptedIO([
+      "3", // reset
+      "", // agent name
+      "", // container
+      "", // backend
+      "", // model
+      "", // thinking
+      "", // bootstrap
+      "", // enhancements
+    ]);
+
+    const fakeExistingConfig = { gateway: { mode: "local" as const } };
+    const result = await runGemmaclawSetupSteps(
+      io,
+      {},
+      {
+        existingConfig: fakeExistingConfig as import("../../config/config.js").OpenClawConfig,
+      },
+    );
+
+    expect(result.existingConfigAction).toBe<ExistingConfigAction>("reset");
+    expect(result.choices.agentName).toBe("main");
+  });
+
+  it("returns null existingConfigAction when there is no existing config", async () => {
+    const { io } = makeScriptedIO(["", "", "", "", "", "", ""]);
+    const result = await runGemmaclawSetupSteps(io, {}, { existingConfig: null });
+    expect(result.existingConfigAction).toBeNull();
+  });
+});

--- a/src/gemmaclaw/provision/merged-setup.gemmaclaw.ts
+++ b/src/gemmaclaw/provision/merged-setup.gemmaclaw.ts
@@ -1,0 +1,411 @@
+/**
+ * merged-setup.gemmaclaw.ts
+ *
+ * Orchestrates the full merged Gemmaclaw + OpenClaw setup flow. Walks a new
+ * user through:
+ *   Steps 1-9:  Gemmaclaw-specific choices (agent name, container, backend,
+ *               model, thinking level, bootstrap profile, enhancements)
+ *   Step 10:    OpenClaw gateway configuration (port, bind, auth mode, Tailscale)
+ *   Step 11:    OpenClaw channel setup (Discord, Telegram, WhatsApp, etc.)
+ *   Step 12:    Config write + backend provisioning + smoke test
+ *
+ * Backwards-compatible paths:
+ *   gemmaclaw setup --wizard        → pure OpenClaw wizard (no Gemmaclaw steps)
+ *   gemmaclaw setup --workspace-only → pure workspace init
+ *   All existing --non-interactive / --dry-run / --setup-mode flags still work
+ */
+
+import type { OpenClawConfig } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { GatewayWizardSettings } from "../../wizard/setup.types.js";
+import type {
+  OnboardingBootstrap,
+  OnboardingChoices,
+  OnboardingDefaults,
+  OnboardingThinking,
+  WizardIO,
+} from "./onboarding-wizard.js";
+import {
+  askAgentName,
+  askBackend,
+  askBootstrap,
+  askContainer,
+  askEnhancements,
+  askModel,
+  askThinking,
+  buildNonInteractiveChoices,
+} from "./onboarding-wizard.js";
+
+export type ExistingConfigAction = "keep" | "update" | "reset";
+
+export interface MergedSetupWizardResult {
+  choices: OnboardingChoices;
+  existingConfigAction: ExistingConfigAction | null;
+  /** OpenClaw gateway settings, populated after Step 10 if gateway wizard ran. */
+  gatewaySettings?: GatewayWizardSettings;
+}
+
+/**
+ * Ask the user what to do with an existing config file.
+ * Returns null if there is no existing config.
+ */
+async function askExistingConfigAction(
+  io: WizardIO,
+  existingConfig: OpenClawConfig | null,
+): Promise<ExistingConfigAction | null> {
+  if (!existingConfig) {
+    return null;
+  }
+
+  io.log("Existing Gemmaclaw configuration detected.");
+  io.log("");
+  io.log("  1) Use existing values  Skip setup prompts and keep current config.");
+  io.log("  2) Update values        Re-run wizard with current values as defaults.");
+  io.log("  3) Reset                Wipe Gemmaclaw config and start fresh.");
+  io.log("");
+
+  for (;;) {
+    const answer = await io.prompt("Choose [1/2/3, default=1]: ");
+    const choice = answer.trim() || "1";
+    if (choice === "1" || choice.toLowerCase() === "keep") {
+      io.log("");
+      return "keep";
+    }
+    if (choice === "2" || choice.toLowerCase() === "update") {
+      io.log("");
+      return "update";
+    }
+    if (choice === "3" || choice.toLowerCase() === "reset") {
+      io.log("");
+      return "reset";
+    }
+    io.error(`Invalid choice "${choice}". Enter 1, 2, or 3.`);
+  }
+}
+
+/**
+ * Load the existing Gemmaclaw onboarding manifest (if any) to use as defaults
+ * when the user chooses "update". Returns null if no manifest exists.
+ */
+async function loadExistingOnboardingDefaults(): Promise<OnboardingDefaults | null> {
+  try {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const { resolveStateDir } = await import("../../config/paths.js");
+    const stateDir = resolveStateDir(process.env);
+    const manifestPath = path.default.join(stateDir, "agents", "main", "agent", "onboarding.json");
+    const raw = fs.readFileSync(manifestPath, "utf-8");
+    const manifest = JSON.parse(raw) as {
+      agentName?: string;
+      backend?: string;
+      model?: string;
+      thinkingLevel?: string;
+      bootstrap?: string;
+      useContainer?: boolean;
+      enhancements?: string[];
+    };
+    return {
+      agentName: manifest.agentName,
+      backend: manifest.backend as OnboardingDefaults["backend"],
+      model: manifest.model,
+      thinkingLevel: manifest.thinkingLevel as OnboardingThinking | undefined,
+      bootstrap: manifest.bootstrap as OnboardingBootstrap | undefined,
+      useContainer: manifest.useContainer,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether a config file exists at the standard location.
+ */
+async function loadExistingConfig(): Promise<OpenClawConfig | null> {
+  try {
+    const { readConfigFileSnapshot } = await import("../../config/config.js");
+    const snapshot = await readConfigFileSnapshot();
+    if (snapshot.exists && snapshot.valid) {
+      return snapshot.config;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the Gemmaclaw-specific steps (1-9) of the merged wizard and return
+ * the user's choices. Steps 10-11 (gateway + channels) are handled separately
+ * by the caller since they use the OpenClaw clack-based prompter.
+ *
+ * @param io     WizardIO for readline-based prompts
+ * @param defaults Pre-set values from CLI flags or existing config
+ * @param opts   Additional options (skipGemmaSteps, includeExtended, existingConfig)
+ */
+export async function runGemmaclawSetupSteps(
+  io: WizardIO,
+  defaults: OnboardingDefaults = {},
+  opts: {
+    skipExistingConfigCheck?: boolean;
+    includeExtended?: boolean;
+    existingConfig?: OpenClawConfig | null;
+  } = {},
+): Promise<{ choices: OnboardingChoices; existingConfigAction: ExistingConfigAction | null }> {
+  // Step 1: Gemmaclaw header
+  io.log("");
+  io.log("Welcome to Gemmaclaw setup.");
+  io.log("We'll configure your AI agent in a few quick steps, then set up the");
+  io.log("gateway and channels so everything is ready to use.");
+  io.log("Press Enter at any prompt to keep the [bracketed] default.");
+  io.log("");
+
+  // Step 2: Existing config check
+  let existingConfigAction: ExistingConfigAction | null = null;
+  let effectiveDefaults = { ...defaults };
+
+  if (!opts.skipExistingConfigCheck) {
+    const existingConfig =
+      opts.existingConfig !== undefined ? opts.existingConfig : await loadExistingConfig();
+    existingConfigAction = await askExistingConfigAction(io, existingConfig);
+
+    if (existingConfigAction === "keep") {
+      // Skip all Gemmaclaw prompts; return with whatever defaults we have.
+      const choices = buildNonInteractiveChoices({
+        agentName: defaults.agentName ?? "main",
+        backend: defaults.backend ?? "local",
+        model: defaults.model,
+        thinkingLevel: defaults.thinkingLevel,
+        bootstrap: defaults.bootstrap,
+        useContainer: defaults.useContainer,
+        enhancements: defaults.enhancements,
+      });
+      return { choices, existingConfigAction };
+    }
+
+    if (existingConfigAction === "update") {
+      // Pre-populate defaults from the existing onboarding manifest.
+      const existingDefaults = await loadExistingOnboardingDefaults();
+      if (existingDefaults) {
+        effectiveDefaults = { ...existingDefaults, ...defaults };
+      }
+    }
+    // "reset": proceed fresh, ignore existing config.
+  }
+
+  // Steps 3-9: Gemmaclaw-specific prompts.
+  const agentName = await askAgentName(io, effectiveDefaults.agentName);
+  const useContainer = await askContainer(io, effectiveDefaults.useContainer);
+  const backend = await askBackend(io, effectiveDefaults.backend, opts.includeExtended ?? true);
+
+  // Step 6: Model selection (skipped for "extended" — handled by OpenClaw model picker).
+  const model = await askModel(io, backend, effectiveDefaults.model);
+
+  // Steps 7-9: Thinking level, bootstrap profile, enhancements.
+  const thinkingLevel = await askThinking(io, effectiveDefaults.thinkingLevel);
+  const bootstrap = await askBootstrap(io, effectiveDefaults.bootstrap);
+  const enhancements = await askEnhancements(io, effectiveDefaults.enhancements);
+
+  const choices: OnboardingChoices = {
+    agentName,
+    useContainer,
+    backend,
+    model,
+    thinkingLevel,
+    bootstrap,
+    enhancements,
+  };
+
+  return { choices, existingConfigAction };
+}
+
+/**
+ * Run gateway config (Step 10) using the OpenClaw clack prompter.
+ * Returns the updated config and gateway settings, or null if skipped.
+ */
+export async function runGatewayConfigStep(
+  runtime: RuntimeEnv,
+  currentConfig: OpenClawConfig,
+  opts: { dryRun?: boolean; nonInteractive?: boolean } = {},
+): Promise<{ nextConfig: OpenClawConfig; settings: GatewayWizardSettings } | null> {
+  if (opts.dryRun || opts.nonInteractive) {
+    if (opts.dryRun) {
+      runtime.log("[dry-run] Skipping gateway configuration step.");
+    }
+    return null;
+  }
+
+  try {
+    const { configureGatewayForSetup } = await import("../../wizard/setup.gateway-config.js");
+    const { createClackPrompter } = await import("../../wizard/clack-prompter.js");
+    const { DEFAULT_GATEWAY_PORT } = await import("../../config/paths.js");
+    const { readConfigFileSnapshot } = await import("../../config/config.js");
+
+    runtime.log("");
+    runtime.log("Step 10: Gateway configuration");
+    runtime.log("Configure how the Gemmaclaw gateway listens and authenticates.");
+    runtime.log("");
+
+    const snapshot = await readConfigFileSnapshot();
+    const baseConfig: OpenClawConfig = snapshot.exists && snapshot.valid ? snapshot.config : {};
+    const prompter = createClackPrompter();
+
+    await prompter.intro("Gateway setup");
+
+    const result = await configureGatewayForSetup({
+      flow: "quickstart",
+      baseConfig,
+      nextConfig: { ...currentConfig },
+      localPort: DEFAULT_GATEWAY_PORT,
+      quickstartGateway: {
+        hasExisting: false,
+        port: DEFAULT_GATEWAY_PORT,
+        bind: "loopback",
+        tailscaleMode: "off",
+        authMode: "token",
+        tailscaleResetOnExit: false,
+      },
+      prompter,
+      runtime,
+    });
+
+    await prompter.outro("Gateway configured.");
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    runtime.error(`Gateway configuration step failed: ${message}`);
+    runtime.error("You can configure the gateway later with: gemmaclaw configure gateway");
+    return null;
+  }
+}
+
+/**
+ * Run channel setup (Step 11) using the OpenClaw clack prompter.
+ * Returns the updated config, or null if skipped.
+ */
+export async function runChannelSetupStep(
+  runtime: RuntimeEnv,
+  currentConfig: OpenClawConfig,
+  opts: { dryRun?: boolean; nonInteractive?: boolean } = {},
+): Promise<OpenClawConfig | null> {
+  if (opts.dryRun || opts.nonInteractive) {
+    if (opts.dryRun) {
+      runtime.log("[dry-run] Skipping channel setup step.");
+    }
+    // Non-interactive: no channel setup (channels can be added later via --wizard).
+    return null;
+  }
+
+  try {
+    const { setupChannels } = await import("../../commands/onboard-channels.js");
+    const { createClackPrompter } = await import("../../wizard/clack-prompter.js");
+
+    runtime.log("");
+    runtime.log("Step 11: Channel setup");
+    runtime.log("Connect Gemmaclaw to Discord, Telegram, WhatsApp, or other channels.");
+    runtime.log("(Press Enter to skip any channel you do not want to configure now.)");
+    runtime.log("");
+
+    const prompter = createClackPrompter();
+    await prompter.intro("Channel setup");
+    const updatedConfig = await setupChannels(currentConfig, runtime, prompter);
+    await prompter.outro("Channel setup complete.");
+    return updatedConfig;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    runtime.error(`Channel setup step failed: ${message}`);
+    runtime.error("You can add channels later with: gemmaclaw setup --wizard");
+    return null;
+  }
+}
+
+/**
+ * Run the OpenClaw auth-choice flow for the "extended" or "gemini" backend
+ * selection. Returns the auth choice string and an updated config.
+ *
+ * For "gemini": pre-seeds Google Gemini API key flow.
+ * For "extended": presents the full OpenClaw provider picker.
+ */
+export async function runOpenClawAuthFlow(
+  runtime: RuntimeEnv,
+  currentConfig: OpenClawConfig,
+  backend: "gemini" | "extended",
+  opts: { dryRun?: boolean; nonInteractive?: boolean } = {},
+): Promise<{ authChoice: string; model: string; nextConfig: OpenClawConfig } | null> {
+  if (opts.dryRun) {
+    runtime.log(`[dry-run] Skipping OpenClaw auth flow for backend="${backend}".`);
+    const model = backend === "gemini" ? "google/gemini-2.5-flash" : "";
+    return {
+      authChoice: backend === "gemini" ? "google/gemini-api-key" : "skip",
+      model,
+      nextConfig: currentConfig,
+    };
+  }
+
+  if (opts.nonInteractive) {
+    // Non-interactive: return a placeholder; caller handles non-interactive auth.
+    const model = backend === "gemini" ? "google/gemini-2.5-flash" : "";
+    return {
+      authChoice: backend === "gemini" ? "google/gemini-api-key" : "skip",
+      model,
+      nextConfig: currentConfig,
+    };
+  }
+
+  try {
+    const { createClackPrompter } = await import("../../wizard/clack-prompter.js");
+    const { promptAuthChoiceGrouped } = await import("../../commands/auth-choice-prompt.js");
+    const { promptDefaultModel } = await import("../../flows/model-picker.js");
+    const { ensureAuthProfileStore } = await import("../../agents/auth-profiles.runtime.js");
+
+    const prompter = createClackPrompter();
+    const store = ensureAuthProfileStore();
+
+    await prompter.intro(backend === "gemini" ? "Gemini API authentication" : "Provider selection");
+
+    const authChoice = await promptAuthChoiceGrouped({
+      prompter,
+      store,
+      includeSkip: false,
+      config: currentConfig,
+      env: process.env,
+    });
+
+    // Apply auth choice to config.
+    const { applyAuthChoice } = await import("../../commands/auth-choice.apply.js");
+    const applyResult = await applyAuthChoice({
+      authChoice,
+      config: currentConfig,
+      prompter,
+      runtime,
+      env: process.env,
+      setDefaultModel: false,
+    });
+
+    const nextConfig = applyResult.config ?? currentConfig;
+
+    // Derive preferred provider from the auth choice string (e.g. "google/..." → "google").
+    const preferredProvider = typeof authChoice === "string" ? authChoice.split("/")[0] : undefined;
+
+    // Pick the default model for the chosen provider.
+    const modelResult = await promptDefaultModel({
+      config: nextConfig,
+      prompter,
+      allowKeep: false,
+      preferredProvider,
+      env: process.env,
+      runtime,
+    });
+
+    await prompter.outro("Provider configured.");
+    return {
+      authChoice,
+      model: modelResult.model ?? "",
+      nextConfig: modelResult.config ?? nextConfig,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    runtime.error(`Provider auth flow failed: ${message}`);
+    runtime.error("You can configure the provider later with: gemmaclaw setup --wizard");
+    return null;
+  }
+}

--- a/src/gemmaclaw/provision/onboarding-wizard.ts
+++ b/src/gemmaclaw/provision/onboarding-wizard.ts
@@ -22,7 +22,7 @@ import {
  * `WizardIO` so the same logic powers both the live CLI and the tests.
  */
 
-export type OnboardingBackend = "local" | "gemini" | "vertex";
+export type OnboardingBackend = "local" | "gemini" | "vertex" | "extended";
 export type OnboardingThinking = "off" | "low" | "medium" | "high";
 export type OnboardingBootstrap = "general" | "coding" | "minimal";
 
@@ -199,6 +199,10 @@ export function defaultModelFor(backend: OnboardingBackend): string {
   if (backend === "gemini") {
     return "google/gemini-2.5-flash";
   }
+  if (backend === "extended") {
+    // Model is selected by the OpenClaw model picker in the merged flow.
+    return "";
+  }
   return "gemma-3-12b-it";
 }
 
@@ -210,6 +214,10 @@ export function modelChoicesFor(
   }
   if (backend === "gemini") {
     return GEMINI_MODEL_CHOICES;
+  }
+  if (backend === "extended") {
+    // Model is selected by the OpenClaw model picker; no Gemmaclaw-curated list.
+    return [];
   }
   return VERTEX_MODEL_CHOICES;
 }
@@ -253,7 +261,7 @@ export async function runOnboardingWizard(
   };
 }
 
-async function askAgentName(io: WizardIO, preset?: string): Promise<string> {
+export async function askAgentName(io: WizardIO, preset?: string): Promise<string> {
   if (preset) {
     const error = validateAgentName(preset);
     if (error) {
@@ -279,7 +287,7 @@ async function askAgentName(io: WizardIO, preset?: string): Promise<string> {
   }
 }
 
-async function askContainer(io: WizardIO, preset?: boolean): Promise<boolean> {
+export async function askContainer(io: WizardIO, preset?: boolean): Promise<boolean> {
   if (preset !== undefined) {
     return preset;
   }
@@ -313,23 +321,34 @@ async function askContainer(io: WizardIO, preset?: boolean): Promise<boolean> {
   }
 }
 
-async function askBackend(io: WizardIO, preset?: OnboardingBackend): Promise<OnboardingBackend> {
+export async function askBackend(
+  io: WizardIO,
+  preset?: OnboardingBackend,
+  includeExtended?: boolean,
+): Promise<OnboardingBackend> {
   if (preset) {
     return preset;
   }
 
   io.log("3. Where should the model run?");
   io.log("");
-  io.log("  1) Local       Run on this machine. Private, no data leaves your network.");
-  io.log("                 Auto-detects GPU and downloads the model.");
-  io.log("  2) Gemini API  Use Google's hosted Gemini API. No GPU required, just an API");
-  io.log("                 key from aistudio.google.com.");
-  io.log("  3) Vertex AI   Use Google Cloud Vertex AI. Best for enterprise / GCP users.");
-  io.log("                 Requires gcloud CLI signed in.");
+  io.log("  1) Local            Run on this machine. Private, no data leaves your network.");
+  io.log("                      Auto-detects GPU and downloads the model.");
+  io.log("  2) Gemini API       Use Google's hosted Gemini API. No GPU required, just an API");
+  io.log("                      key from aistudio.google.com.");
+  io.log("  3) Vertex AI        Use Google Cloud Vertex AI. Best for enterprise / GCP users.");
+  io.log("                      Requires gcloud CLI signed in.");
+  if (includeExtended) {
+    io.log("  4) Extended options All available providers: Anthropic, OpenAI, and more.");
+    io.log("                      Surfaces the full OpenClaw provider ecosystem.");
+  }
   io.log("");
 
+  const maxChoice = includeExtended ? "4" : "3";
+  const prompt = includeExtended ? "Choose [1/2/3/4, default=1]: " : "Choose [1/2/3, default=1]: ";
+
   for (;;) {
-    const answer = await io.prompt("Choose [1/2/3, default=1]: ");
+    const answer = await io.prompt(prompt);
     const choice = answer.trim() || "1";
     if (choice === "1" || choice.toLowerCase() === "local") {
       io.log("");
@@ -343,17 +362,26 @@ async function askBackend(io: WizardIO, preset?: OnboardingBackend): Promise<Onb
       io.log("");
       return "vertex";
     }
-    io.error(`Invalid choice "${choice}". Enter 1, 2, or 3.`);
+    if (includeExtended && (choice === "4" || choice.toLowerCase() === "extended")) {
+      io.log("");
+      return "extended";
+    }
+    io.error(`Invalid choice "${choice}". Enter 1-${maxChoice}.`);
   }
 }
 
-async function askModel(
+export async function askModel(
   io: WizardIO,
   backend: OnboardingBackend,
   preset?: string,
 ): Promise<string> {
   if (preset) {
     return resolveModelId(backend, preset);
+  }
+
+  // Extended backend: model is selected by the OpenClaw model picker, not here.
+  if (backend === "extended") {
+    return "";
   }
 
   const choices = modelChoicesFor(backend);
@@ -389,7 +417,10 @@ async function askModel(
   }
 }
 
-async function askThinking(io: WizardIO, preset?: OnboardingThinking): Promise<OnboardingThinking> {
+export async function askThinking(
+  io: WizardIO,
+  preset?: OnboardingThinking,
+): Promise<OnboardingThinking> {
   if (preset) {
     return preset;
   }
@@ -429,7 +460,7 @@ async function askThinking(io: WizardIO, preset?: OnboardingThinking): Promise<O
   }
 }
 
-async function askBootstrap(
+export async function askBootstrap(
   io: WizardIO,
   preset?: OnboardingBootstrap,
 ): Promise<OnboardingBootstrap> {
@@ -472,7 +503,7 @@ async function askBootstrap(
   }
 }
 
-async function askEnhancements(
+export async function askEnhancements(
   io: WizardIO,
   preset?: readonly GemmaclawEnhancementId[],
 ): Promise<GemmaclawEnhancementId[]> {


### PR DESCRIPTION
## Summary

- Adds `merged-setup.gemmaclaw.ts` orchestrating a unified 12-step setup wizard
- Steps 1–9: Gemmaclaw-specific prompts (agent name, container, backend, model, thinking, bootstrap, enhancements) via `WizardIO` (readline)
- Step 10: OpenClaw gateway config (port, bind, auth mode, Tailscale) via clack prompter + `configureGatewayForSetup`
- Step 11: OpenClaw channel setup (Discord, Telegram, WhatsApp) via clack prompter + `setupChannels`
- Step 12: Config write + backend provisioning (unchanged from existing flow)
- Adds existing-config detection with keep / update / reset choice
- Adds `"extended"` backend option that routes through the OpenClaw full provider / auth-choice picker (`promptAuthChoiceGrouped` + `applyAuthChoice` + `promptDefaultModel`)
- Exports `askAgentName`, `askContainer`, `askBackend`, `askModel`, `askThinking`, `askBootstrap`, `askEnhancements`, `buildNonInteractiveChoices` from `onboarding-wizard.ts` for use by merged orchestrator and tests
- `setup-gemma.ts` updated: interactive path calls merged flow; non-interactive path unchanged; all backend paths call `applyGatewayChannelConfig` at the end to merge wizard settings into config without overwriting backend-provisioner defaults
- 12 new unit tests in `merged-setup.gemmaclaw.test.ts` covering extended backend option, preset skipping, existing config keep/update/reset/null

## Test plan

- [x] `pnpm tsgo` — TypeScript clean (no errors)
- [x] `pnpm test src/gemmaclaw/provision/merged-setup.gemmaclaw.test.ts` — 12/12 tests pass
- [x] `pnpm test src/gemmaclaw/provision/onboarding-wizard.test.ts` — existing 8 tests unaffected
- [x] `pnpm check:changed` — all changed lanes green (typecheck + tests)