### PR TITLE
chore: upstream sync openclaw -> gemmaclaw 2026-06-16

### DIFF
--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -21,6 +21,7 @@ import type {
 import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
+  resolveMissingProviderApiKey,
 } from "./models-config.providers.secrets.js";
 import { findNormalizedProviderValue } from "./provider-id.js";
 
@@ -164,6 +165,19 @@ function mergeImplicitProviderConfig(params: {
   };
 }
 
+function resolveImplicitProviderAuthMarker(params: {
+  ctx: ImplicitProviderContext;
+  providerId: string;
+  provider: ProviderConfig;
+}): ProviderConfig {
+  return resolveMissingProviderApiKey({
+    providerKey: params.providerId,
+    provider: params.provider,
+    env: params.ctx.env,
+    profileApiKey: undefined,
+  });
+}
+
 function resolveConfiguredImplicitProvider(params: {
   configuredProviders?: Record<string, ProviderConfig> | null;
   providerIds: readonly string[];
@@ -262,7 +276,7 @@ async function resolvePluginImplicitProviders(
       result,
     });
     for (const [providerId, implicitProvider] of Object.entries(normalizedResult)) {
-      discovered[providerId] = mergeImplicitProviderConfig({
+      const mergedProvider = mergeImplicitProviderConfig({
         providerId,
         existing:
           discovered[providerId] ??
@@ -276,6 +290,11 @@ async function resolvePluginImplicitProviders(
             ],
           }),
         implicit: implicitProvider,
+      });
+      discovered[providerId] = resolveImplicitProviderAuthMarker({
+        ctx,
+        providerId,
+        provider: mergedProvider,
       });
     }
   }

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -78,6 +78,19 @@ export function resolveAwsSdkApiKeyVarName(
   return resolveAwsSdkEnvVarName(env);
 }
 
+function resolveEnvAuthEvidenceApiKeyMarker(
+  provider: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const resolved = resolveEnvApiKey(provider, env);
+  const apiKey = resolved?.apiKey?.trim();
+  if (!apiKey || !isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })) {
+    return undefined;
+  }
+  return apiKey;
+}
+
+/** Rewrites secret-backed provider headers to stable marker values. */
 export function normalizeHeaderValues(params: {
   headers: ProviderConfig["headers"] | undefined;
   secretDefaults: SecretDefaults | undefined;
@@ -306,7 +319,10 @@ export function resolveMissingProviderApiKey(params: {
   }
 
   const fromEnv = resolveEnvApiKeyVarName(params.providerKey, params.env);
-  const apiKey = fromEnv ?? params.profileApiKey?.apiKey;
+  const fromAuthEvidence = fromEnv
+    ? undefined
+    : resolveEnvAuthEvidenceApiKeyMarker(params.providerKey, params.env);
+  const apiKey = fromEnv ?? fromAuthEvidence ?? params.profileApiKey?.apiKey;
   if (!apiKey?.trim()) {
     return params.provider;
   }

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -30,6 +30,10 @@ export function guardSessionManager(
     inputProvenance?: InputProvenance;
     allowSyntheticToolResults?: boolean;
     allowedToolNames?: Iterable<string>;
+    withCompactionPersistence?: (
+      append: () => string,
+      validateAppend: (entryId: string, appendedText: string) => boolean,
+    ) => string;
   },
 ): GuardedSessionManager {
   if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
@@ -76,6 +80,7 @@ export function guardSessionManager(
     transformToolResultForPersistence: transform,
     allowSyntheticToolResults: opts?.allowSyntheticToolResults,
     allowedToolNames: opts?.allowedToolNames,
+    withCompactionPersistence: opts?.withCompactionPersistence,
     beforeMessageWriteHook: beforeMessageWrite,
     maxToolResultChars:
       typeof opts?.contextWindowTokens === "number"

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -68,6 +68,24 @@ function normalizePersistedToolResultName(
 
 export { getRawSessionAppendMessage };
 
+type CompactionAppendValidator = (entryId: string, appendedText: string) => boolean;
+
+function isExpectedCompactionAppend(entryId: string, appendedText: string): boolean {
+  const lines = appendedText
+    .trimEnd()
+    .split("\n")
+    .filter((line) => line.length > 0);
+  if (lines.length !== 1) {
+    return false;
+  }
+  try {
+    const entry = JSON.parse(lines[0]) as { type?: unknown; id?: unknown };
+    return entry.type === "compaction" && entry.id === entryId;
+  } catch {
+    return false;
+  }
+}
+
 export function installSessionToolResultGuard(
   sessionManager: SessionManager,
   opts?: {
@@ -104,6 +122,10 @@ export function installSessionToolResultGuard(
       event: PluginHookBeforeMessageWriteEvent,
     ) => PluginHookBeforeMessageWriteResult | undefined;
     maxToolResultChars?: number;
+    withCompactionPersistence?: (
+      append: () => string,
+      validateAppend: CompactionAppendValidator,
+    ) => string;
   },
 ): {
   flushPendingToolResults: () => void;
@@ -267,6 +289,17 @@ export function installSessionToolResultGuard(
 
   // Monkey-patch appendMessage with our guarded version.
   sessionManager.appendMessage = guardedAppend as SessionManager["appendMessage"];
+
+  const originalAppendCompaction = sessionManager.appendCompaction.bind(sessionManager);
+  const guardedAppendCompaction = ((
+    ...args: Parameters<SessionManager["appendCompaction"]>
+  ): string => {
+    const append = () => originalAppendCompaction(...args);
+    return opts?.withCompactionPersistence
+      ? opts.withCompactionPersistence(append, isExpectedCompactionAppend)
+      : append();
+  }) as SessionManager["appendCompaction"];
+  sessionManager.appendCompaction = guardedAppendCompaction;
 
   return {
     flushPendingToolResults,


### PR DESCRIPTION
## Summary

Selective upstream sync from `openclaw/openclaw` for 2026-06-16, picking up 2 new commits since last sync (`maintenance/upstream-openclaw-20260616` which merged `6da3b1f6a3`):

- `bbfe8ccaf6` — session tool result guard: add `appendCompaction` wrapping with `withCompactionPersistence` hook
- `a4f7e4cbb9` — provider auth: add `resolveEnvAuthEvidenceApiKeyMarker` + `resolveImplicitProviderAuthMarker` for ADC-style auth markers

### Files changed
- `src/agents/session-tool-result-guard.ts` — added `CompactionAppendValidator` type, `isExpectedCompactionAppend`, `withCompactionPersistence` opt, and `appendCompaction` monkey-patch
- `src/agents/session-tool-result-guard-wrapper.ts` — plumbed `withCompactionPersistence` through `guardSessionManager`
- `src/agents/models-config.providers.secret-helpers.ts` — added `resolveEnvAuthEvidenceApiKeyMarker`; updated `resolveMissingProviderApiKey` to use it as a fallback
- `src/agents/models-config.providers.implicit.ts` — added `resolveImplicitProviderAuthMarker`; applied it after `mergeImplicitProviderConfig` in provider discovery loop

### Skipped
- `extensions/google/provider-registration.ts` — requires `vertex-adc.ts` not present in Gemmaclaw
- `extensions/google/index.test.ts` — requires `provider-discovery.ts` not present in Gemmaclaw
- `src/agents/pi-embedded-runner/` files — Gemmaclaw uses its own `pi-embedded-runner`, not upstream's

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check:changed --staged` passes (393 test files, 4205 tests, 0 errors)
- [x] `pnpm test src/agents/model-selection.test.ts` passes (89 tests)