### PR TITLE
upstream sync 2026-06-16 (batch 1): faithful framework fixes — memory -journal, ReDoS, ollama stop-reason, blank-baseUrl catalog

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -1,8 +1,16 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 
+// SQLite keeps WAL/SHM sidecars under journal_mode=WAL, but stores that fall
+// back to journal_mode=DELETE (the node:sqlite default when WAL is not enabled)
+// leave a rollback-journal (-journal) sidecar instead. Index file operations
+// must cover all three so a swap never strands a stale -journal next to the
+// freshly published database, which would trigger an erroneous rollback the
+// next time SQLite opens the index.
+const memoryIndexFileSuffixes = ["", "-wal", "-shm", "-journal"] as const;
+
 export async function moveMemoryIndexFiles(sourceBase: string, targetBase: string): Promise<void> {
-  const suffixes = ["", "-wal", "-shm"];
+  const suffixes = memoryIndexFileSuffixes;
   for (const suffix of suffixes) {
     const source = `${sourceBase}${suffix}`;
     const target = `${targetBase}${suffix}`;
@@ -17,7 +25,7 @@ export async function moveMemoryIndexFiles(sourceBase: string, targetBase: strin
 }
 
 export async function removeMemoryIndexFiles(basePath: string): Promise<void> {
-  const suffixes = ["", "-wal", "-shm"];
+  const suffixes = memoryIndexFileSuffixes;
   await Promise.all(suffixes.map((suffix) => fs.rm(`${basePath}${suffix}`, { force: true })));
 }
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -516,6 +516,13 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
   return result;
 }
 
+function resolveOllamaStopReason(response: OllamaChatResponse) {
+  if (response.message.tool_calls?.length) {
+    return "toolUse" as const;
+  }
+  return response.done_reason === "length" ? ("length" as const) : ("stop" as const);
+}
+
 export function buildAssistantMessage(
   response: OllamaChatResponse,
   modelInfo: StreamModelDescriptor,
@@ -545,7 +552,7 @@ export function buildAssistantMessage(
   return buildStreamAssistantMessage({
     model: modelInfo,
     content,
-    stopReason: toolCalls && toolCalls.length > 0 ? "toolUse" : "stop",
+    stopReason: resolveOllamaStopReason(response),
     usage: buildUsageWithNoCost({
       input: response.prompt_eval_count ?? 0,
       output: response.eval_count ?? 0,
@@ -845,7 +852,7 @@ export function createOllamaStreamFn(
 
           stream.push({
             type: "done",
-            reason: assistantMessage.stopReason === "toolUse" ? "toolUse" : "stop",
+            reason: resolveOllamaStopReason(finalResponse),
             message: assistantMessage,
           });
         } finally {

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -278,7 +278,7 @@ export function deriveSessionName(command: string): string | undefined {
 }
 
 function tokenizeCommand(command: string): string[] {
-  const matches = command.match(/(?:[^\s"']+|"(?:\\.|[^"])*"|'(?:\\.|[^'])*')+/g) ?? [];
+  const matches = command.match(/(?:[^\s"']+|"(?:\\.|[^"\\])*"|'[^']*')+/g) ?? [];
   return matches.map((token) => stripQuotes(token)).filter(Boolean);
 }
 

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -43,8 +43,11 @@ export async function resolveProvidersForModelsJsonWithDeps(
     resolveImplicitProviders?: ResolveImplicitProvidersForModelsJson;
   },
 ): Promise<Record<string, ProviderConfig>> {
-  const { cfg, agentDir, env } = params;
-  const explicitProviders = cfg.models?.providers ?? {};
+  const { agentDir, env } = params;
+  const explicitProviders = stripBlankProviderBaseUrls(params.cfg.models?.providers ?? {});
+  const cfg = params.cfg.models?.providers
+    ? { ...params.cfg, models: { ...params.cfg.models, providers: explicitProviders } }
+    : params.cfg;
   const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,
@@ -56,6 +59,27 @@ export async function resolveProvidersForModelsJsonWithDeps(
     implicit: implicitProviders,
     explicit: explicitProviders,
   });
+}
+
+// A provider entry with a blank baseUrl ("" or whitespace) would otherwise
+// override the bundled transport URL, fail the writable-provider check, and get
+// dropped from models.json — erasing bundled catalogs (e.g. the Gemini catalog).
+// Strip blank baseUrl so the bundled default URL is preserved.
+function stripBlankProviderBaseUrls(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const next: Record<string, ProviderConfig> = {};
+  for (const [key, provider] of Object.entries(providers)) {
+    if (typeof provider?.baseUrl === "string" && provider.baseUrl.trim() === "") {
+      const { baseUrl: _blank, ...rest } = provider;
+      next[key] = rest as ProviderConfig;
+      mutated = true;
+      continue;
+    }
+    next[key] = provider;
+  }
+  return mutated ? next : providers;
 }
 
 function resolveProvidersForMode(params: {


### PR DESCRIPTION
## Upstream OpenClaw selective sync — 2026-06-16 (Batch 1, faithful ports)

Faithful, adversarially-verified selective sync of high-value framework fixes from upstream OpenClaw `bbfe8ccaf6..9dbf8f718f`, adapted to Gemmaclaw's divergent layout. Layered on top of the prior same-day sync (#291) with **zero file overlap**.

### Merge base / range
- Base: `origin/main` @ `7be73053c2a8` (includes #291)
- Upstream range surveyed: `bbfe8ccaf6..upstream/main 9dbf8f718f` (1511 new commits → 294 candidates → 49 adversarially-confirmed PORT; this PR is Batch 1 of that list)

### Changes (4 files, +46/-7)
| Upstream | Category | File | What |
|---|---|---|---|
| `0d50ec77de6d` | correctness | `extensions/memory-core/src/memory/manager-atomic-reindex.ts` | Cover the `-journal` rollback sidecar in atomic reindex file ops (journal_mode=DELETE is the node:sqlite default) so an index swap never strands a stale `-journal`, which would trigger an erroneous rollback / index corruption. |
| `98e239d01201` | correctness | `src/agents/models-config.plan.ts` | Strip blank provider `baseUrl` before discovery/merge so a whitespace baseUrl no longer overrides the bundled transport URL and erases bundled catalogs (protects local Gemma/Google model defaults). |
| `e498d39bedaa` | security | `src/agents/bash-tools.shared.ts` | Eliminate catastrophic regex backtracking (ReDoS) in background-session name derivation tokenizer. |
| `81924cfd5e61` | correctness | `extensions/ollama/src/stream.ts` | Preserve `length`-limited stop reason (`resolveOllamaStopReason`) instead of collapsing to `stop`. |

### Validation (Node 22)
- `pnpm install` ✓ · `pnpm build` ✓ (exit 0)
- `pnpm check:changed` ✓ exit 0 — agents 393 files / 4205 tests + 5 skipped; ext-memory 33/259+3; ext-providers 7/100
- CLI feature survival ✓ — `--version` 2026.7.0 (1c84c3d); `setup --help` shows Gemmaclaw branding + `--no-container` + `~/.gemmaclaw` + enhancements; `backup` create/restore/verify present; `backup restore` targets Gemmaclaw state dir
- **Dual-path Docker live smoke** (`GEMMACLAW_LOCAL_AGENT_SMOKE_REQUIRED=1`, model `gemma-4-26B-A4B-it-Q4_K_M`, backend `100.69.102.71:8080`) ✓ `SMOKE_EXIT=0`:
  - Container flow: capability probe + isolation + backup/restore round-trip OK
  - Non-container outer-Docker flow: live-model exec probe (cowsay/workspace/shared/move writes, git clone) OK; host sentinel NOT visible + external write blocked (sandbox isolation intact); backup/restore round-trip OK

### Gemmaclaw surfaces protected
No changes to setup/onboarding, Gemma defaults, Docker sandbox/shared-folder, backup/restore, benchmark harness, site generator, branding, bundled-runtime-deps, or session-store infra. The blank-baseUrl fix explicitly *protects* bundled provider catalogs (local model defaults).

### CI
gemmaclaw `CI` workflow (`checks-node-core*`, `checks-node-extensions*`, `security-dependency-audit`, `security-fast`) is chronically RED on `main` (pre-existing per gemmaclaw-testing.md). Proof recorded against the immediately prior merged commit #291.
