### PR TITLE
chore: upstream sync openclaw -> gemmaclaw 2026-06-17 (batch 2)

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -27,6 +27,13 @@ function createSseResponse(events: Record<string, unknown>[] = []): Response {
   });
 }
 
+function createRawSseResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 function latestAnthropicRequest() {
   const [, init] = guardedFetchMock.mock.calls.at(-1) ?? [];
   const body = init?.body;

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -413,4 +413,64 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("emits start event only after message_start so pre-stream SSE errors arrive before any non-error event", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } },
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      ]),
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = streamFn(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+
+    const startIndex = eventTypes.indexOf("start");
+    expect(startIndex).toBeGreaterThanOrEqual(0);
+    expect(eventTypes.slice(0, startIndex).some((t) => t === "error")).toBe(false);
+  });
+
+  it("emits error without a preceding start event when SSE error arrives before message_start", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createRawSseResponse(
+        "event: error\ndata: " +
+          JSON.stringify({
+            type: "invalid_request_error",
+            message: "messages.1.content.63: Invalid signature in thinking block",
+          }) +
+          "\n\n",
+      ),
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = streamFn(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+
+    // start must not precede the error path, regardless of whether the mock
+    // surfaces the SSE error as an explicit "error" event or silently ends the
+    // stream (a timing artefact of synchronous mock SSE delivery).
+    expect(eventTypes).not.toContain("start");
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -776,7 +776,6 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           { ...params, stream: true },
           transportOptions.signal ? { signal: transportOptions.signal } : undefined,
         );
-        stream.push({ type: "start", partial: output as never });
         const blocks = output.content;
         for await (const event of anthropicStream) {
           if (event.type === "error") {
@@ -803,6 +802,11 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               output.usage.cacheRead +
               output.usage.cacheWrite;
             calculateCost(model, output.usage);
+            // Defer start until after message_start so that pre-stream SSE errors
+            // (e.g. invalid thinking signatures) arrive before any non-error event
+            // is yielded, keeping yieldedOutput=false in pumpStreamWithRecovery
+            // and allowing the thinking-block recovery retry to fire.
+            stream.push({ type: "start", partial: output as never });
             continue;
           }
           if (event.type === "content_block_start") {

--- a/src/agents/auth-profiles/oauth-lock-path.test.ts
+++ b/src/agents/auth-profiles/oauth-lock-path.test.ts
@@ -51,10 +51,12 @@ describe("resolveOAuthRefreshLockPath", () => {
 
   it("is immune to simple concat collisions at the provider/profile boundary", () => {
     // With a plain `${provider}:${profileId}` hash input, the pair
-    // ("a", "b:c") would collide with ("a:b", "c"). The NUL separator
-    // in the hash input rules that out.
+    // ("a", "b:c") would collide with ("a:b", "c"). Tuple encoding rules that out.
     expect(resolveOAuthRefreshLockPath("a", "b:c")).not.toBe(
       resolveOAuthRefreshLockPath("a:b", "c"),
+    );
+    expect(resolveOAuthRefreshLockPath("a", "\x00b")).not.toBe(
+      resolveOAuthRefreshLockPath("a\x00", "b"),
     );
   });
 

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -36,10 +36,10 @@ export function resolveAuthStatePathForDisplay(agentDir?: string): string {
 
 /**
  * Resolve the path of the cross-agent, per-profile OAuth refresh coordination
- * lock. The filename hashes `provider\0profileId` so it is filesystem-safe
+ * lock. The filename hashes a JSON tuple of `[provider, profileId]` so it is filesystem-safe
  * for arbitrary unicode/control-character inputs and always bounded in
- * length. The NUL separator makes it impossible to collide two distinct
- * `(provider, profileId)` pairs by string concatenation.
+ * length. Tuple encoding makes it impossible to collide two distinct
+ * `(provider, profileId)` pairs by separator-sensitive string concatenation.
  *
  * This lock is the serialization point that prevents the `refresh_token_reused`
  * storm when N agents share one OAuth profile (see issue #26322): every agent
@@ -52,10 +52,11 @@ export function resolveAuthStatePathForDisplay(agentDir?: string): string {
  * test fixture, etc.) do not needlessly serialize against each other.
  */
 export function resolveOAuthRefreshLockPath(provider: string, profileId: string): string {
-  const hash = createHash("sha256");
-  hash.update(provider, "utf8");
-  hash.update("\u0000", "utf8"); // NUL separator: unambiguous boundary.
-  hash.update(profileId, "utf8");
-  const safeId = `sha256-${hash.digest("hex")}`;
+  const lockKey = JSON.stringify([provider, profileId]);
+  // This hashes provider/profile identifiers into a path-safe lock name; it is
+  // not password storage or credential verification.
+  // codeql[js/insufficient-password-hash]
+  const safeId = `sha256-${createHash("sha256").update(lockKey, "utf8").digest("hex")}`;
+
   return path.join(resolveStateDir(), "locks", "oauth-refresh", safeId);
 }

--- a/src/agents/current-time.test.ts
+++ b/src/agents/current-time.test.ts
@@ -1,0 +1,77 @@
+// Covers appendCronStyleCurrentTimeLine refresh behavior (issue #44993).
+// Adapted for Gemmaclaw's single-line time format:
+//   `Current time: <formattedTime> (<userTimezone>) / YYYY-MM-DD HH:MM UTC`
+import { describe, expect, it } from "vitest";
+import { appendCronStyleCurrentTimeLine } from "./current-time.js";
+
+const CFG = {
+  agents: {
+    defaults: {
+      userTimezone: "UTC",
+    },
+  },
+};
+
+describe("appendCronStyleCurrentTimeLine", () => {
+  it("returns the empty input unchanged", () => {
+    expect(appendCronStyleCurrentTimeLine("", CFG, Date.now())).toBe("");
+  });
+
+  it("appends a Current time line when none is present", () => {
+    const out = appendCronStyleCurrentTimeLine(
+      "Heartbeat tick",
+      CFG,
+      Date.parse("2026-04-30T10:00:00Z"),
+    );
+    expect(out).toContain("Heartbeat tick");
+    expect(out).toMatch(/2026-04-30 10:00 UTC/);
+  });
+
+  it("refreshes an existing Current time line on subsequent calls (#44993)", () => {
+    const oldNow = Date.parse("2026-04-30T08:00:00Z");
+    const newNow = Date.parse("2026-04-30T10:00:00Z");
+    const firstPass = appendCronStyleCurrentTimeLine("Heartbeat tick", CFG, oldNow);
+    expect(firstPass).toMatch(/2026-04-30 08:00 UTC/);
+
+    const secondPass = appendCronStyleCurrentTimeLine(firstPass, CFG, newNow);
+    expect(secondPass).toContain("Heartbeat tick");
+    expect(secondPass).toMatch(/2026-04-30 10:00 UTC/);
+    expect(secondPass).not.toMatch(/2026-04-30 08:00 UTC/);
+    expect(secondPass.match(/Current time:/g)?.length).toBe(1);
+  });
+
+  it("collapses multiple Current time blocks into a single fresh entry", () => {
+    const stale = [
+      "Heartbeat tick",
+      "Current time: Wednesday, January 1st, 2025 - 12:00 AM (UTC) / 2025-01-01 00:00 UTC",
+      "Current time: Thursday, January 2nd, 2025 - 12:00 AM (UTC) / 2025-01-02 00:00 UTC",
+    ].join("\n");
+    const newNow = Date.parse("2026-04-30T10:00:00Z");
+    const out = appendCronStyleCurrentTimeLine(stale, CFG, newNow);
+    expect(out).toContain("Heartbeat tick");
+    expect(out).toMatch(/2026-04-30 10:00 UTC/);
+    expect(out).not.toMatch(/2025-01-01 00:00 UTC/);
+    expect(out).not.toMatch(/2025-01-02 00:00 UTC/);
+    expect(out.match(/Current time:/g)?.length).toBe(1);
+  });
+
+  it("matches helper blocks with natural-language formattedTime and non-UTC timezone (#44993)", () => {
+    const helperShape =
+      "Heartbeat tick\nCurrent time: Thursday, April 30th, 2026 - 10:00 AM (Asia/Seoul) / 2026-04-30 01:00 UTC";
+    const newNow = Date.parse("2026-04-30T10:00:00Z");
+    const out = appendCronStyleCurrentTimeLine(helperShape, CFG, newNow);
+    expect(out).not.toMatch(/Asia\/Seoul/);
+    expect(out.match(/Current time:/g)?.length).toBe(1);
+    expect(out).toMatch(/2026-04-30 10:00 UTC/);
+  });
+
+  it("preserves user-authored content that starts with 'Current time:'", () => {
+    const userContent = "Reminder from cron:\nCurrent time: please check the dashboard before EOD";
+    const newNow = Date.parse("2026-04-30T10:00:00Z");
+    const out = appendCronStyleCurrentTimeLine(userContent, CFG, newNow);
+    expect(out).toContain("Reminder from cron:");
+    expect(out).toContain("Current time: please check the dashboard before EOD");
+    expect(out).toMatch(/Current time: .+? \(UTC\) \/ 2026-04-30 10:00 UTC/);
+    expect(out.match(/Current time:/g)?.length).toBe(2);
+  });
+});

--- a/src/agents/current-time.ts
+++ b/src/agents/current-time.ts
@@ -30,11 +30,41 @@ export function resolveCronStyleNow(cfg: TimeConfigLike, nowMs: number): CronSty
   return { userTimezone, formattedTime, timeLine };
 }
 
+/**
+ * Append a fresh current-time block, or refresh a previously helper-injected one,
+ * so heartbeat/cron prompts flowing through this helper repeatedly never leak a
+ * stale `Current time:` value (issue #44993).
+ */
+// Matches the helper's own injected single-line `Current time: ... (<TZ>) / YYYY-MM-DD HH:MM UTC`
+// block. Gemmaclaw uses the single-line format:
+//   `Current time: <formattedTime> (<userTimezone>) / YYYY-MM-DD HH:MM UTC`
+// The `(<TZ>)` group rejects parens (so timezone IDs like `Asia/Seoul` are accepted),
+// and the strict `/ YYYY-MM-DD HH:MM UTC` suffix rejects user-authored reminder lines
+// that happen to start with `Current time:` but lack the helper's exact UTC tail format.
+const CURRENT_TIME_LINE_RE =
+  /^Current time: .+? \([^)]+\) \/ \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/gm;
+
+
 export function appendCronStyleCurrentTimeLine(text: string, cfg: TimeConfigLike, nowMs: number) {
   const base = text.trimEnd();
-  if (!base || base.includes("Current time:")) {
+  if (!base) {
     return base;
   }
   const { timeLine } = resolveCronStyleNow(cfg, nowMs);
-  return `${base}\n${timeLine}`;
+  if (!CURRENT_TIME_LINE_RE.test(base)) {
+    return `${base}\n${timeLine}`;
+  }
+  CURRENT_TIME_LINE_RE.lastIndex = 0;
+  let replaced = false;
+  const refreshed = base.replace(CURRENT_TIME_LINE_RE, () => {
+    if (replaced) {
+      return "";
+    }
+    replaced = true;
+    return timeLine;
+  });
+  return refreshed
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/\n\n+(?=Current time:)/g, "\n")
+    .trimEnd();
 }

--- a/src/agents/mcp-config-shared.ts
+++ b/src/agents/mcp-config-shared.ts
@@ -1,4 +1,46 @@
-import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
+/**
+ * Shared MCP config coercion helpers.
+ *
+ * MCP transport setup uses these functions to normalize loose JSON config into
+ * string records/arrays while dropping unsafe host environment variables.
+ */
+import {
+  isDangerousHostEnvVarName,
+  isDangerousHostInheritedEnvVarName,
+  normalizeEnvVarKey,
+} from "../infra/host-env-security.js";
+
+const MCP_EXPLICIT_CREDENTIAL_ENV_KEYS = new Set([
+  // Explicit MCP server credentials are operator-configured auth inputs, not
+  // inherited host config pivots. If policy adds credential keys, add only
+  // direct credentials here; keep loader/search/config pivots blocked.
+  "AMQP_URL",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SECURITY_TOKEN",
+  "AWS_SESSION_TOKEN",
+  "AZURE_CLIENT_ID",
+  "AZURE_CLIENT_SECRET",
+  "DATABASE_URL",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GITLAB_TOKEN",
+  "MONGODB_URI",
+  "NODE_AUTH_TOKEN",
+  "NPM_TOKEN",
+  "REDIS_URL",
+]);
+
+function isDangerousMcpStdioEnvVarName(rawKey: string): boolean {
+  if (isDangerousHostEnvVarName(rawKey)) {
+    return true;
+  }
+  const key = normalizeEnvVarKey(rawKey);
+  if (!key || MCP_EXPLICIT_CREDENTIAL_ENV_KEYS.has(key.toUpperCase())) {
+    return false;
+  }
+  return isDangerousHostInheritedEnvVarName(key);
+}
 
 export function isMcpConfigRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -53,7 +95,7 @@ export function toMcpEnvRecord(
   return toMcpFilteredStringRecord(value, {
     ...options,
     preserveEmptyWhenKeysDropped: true,
-    shouldDropKey: (key) => isDangerousHostEnvVarName(key),
+    shouldDropKey: (key) => isDangerousMcpStdioEnvVarName(key),
   });
 }
 

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -26,6 +26,9 @@ describe("resolveMcpTransportConfig", () => {
   });
 
   it("drops dangerous env overrides from stdio config", () => {
+    // Stdio env is inherited executable process input. Block loader/shell hook
+    // variables and child-process config pivots while preserving explicit MCP
+    // credentials and ordinary scalar env values.
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",
       env: {
@@ -37,6 +40,8 @@ describe("resolveMcpTransportConfig", () => {
         NODE_OPTIONS: "--require=./evil.js",
         LD_PRELOAD: "/tmp/pwn.so",
         BASH_ENV: "/tmp/pwn.sh",
+        ANSIBLE_CONFIG: "/tmp/evil-ansible.cfg",
+        TF_CLI_CONFIG_FILE: "/tmp/evil-terraform.rc",
       },
     });
 
@@ -64,6 +69,12 @@ describe("resolveMcpTransportConfig", () => {
     );
     expect(logWarn).toHaveBeenCalledWith(
       'bundle-mcp: server "probe": env "BASH_ENV" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "ANSIBLE_CONFIG" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "probe": env "TF_CLI_CONFIG_FILE" is blocked for stdio startup safety and was ignored.',
     );
   });
 

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -1,6 +1,10 @@
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
-import { sanitizeContentBlocksImages, sanitizeImageBlocks } from "./tool-images.js";
+import {
+  sanitizeContentBlocksImages,
+  sanitizeImageBlocks,
+  sanitizeToolResultImages,
+} from "./tool-images.js";
 
 describe("tool image sanitizing", () => {
   const getImageBlock = (
@@ -108,6 +112,42 @@ describe("tool image sanitizing", () => {
     const image = getImageBlock(out);
     expect(image.mimeType).toBe("image/jpeg");
   });
+
+
+  it("converts image blocks with missing data/mimeType to text", async () => {
+    const blocks = [
+      {
+        type: "image" as const,
+        data: undefined as unknown as string,
+        mimeType: undefined as unknown as string,
+      },
+    ];
+    const out = await sanitizeContentBlocksImages(blocks, "browser:screenshot");
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("text");
+    expect((out[0] as { type: "text"; text: string }).text).toContain("missing data or mimeType");
+  });
+
+  it("screenshot-shaped tool result with malformed image produces text fallback", async () => {
+    const result = {
+      content: [
+        {
+          type: "image" as const,
+          data: undefined as unknown as string,
+          mimeType: undefined as unknown as string,
+        },
+      ],
+      details: {},
+    };
+    const sanitized = await sanitizeToolResultImages(result, "browser:screenshot");
+    const imageBlocks = sanitized.content.filter((b) => b.type === "image");
+    expect(imageBlocks).toHaveLength(0);
+    const textFallback = sanitized.content.find(
+      (b) => b.type === "text" && (b as { text: string }).text.includes("missing data or mimeType"),
+    );
+    expect(textFallback).toBeDefined();
+  });
+
 
   it("drops malformed image base64 payloads", async () => {
     const blocks = [

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -28,12 +28,17 @@ const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
 const log = createSubsystemLogger("agents/tool-images");
 
+function isImageTypeBlock(block: unknown): block is Record<string, unknown> & { type: "image" } {
+  return (
+    Boolean(block) && typeof block === "object" && (block as { type?: unknown }).type === "image"
+  );
+}
+
 function isImageBlock(block: unknown): block is ImageContentBlock {
-  if (!block || typeof block !== "object") {
+  if (!isImageTypeBlock(block)) {
     return false;
   }
-  const rec = block as Record<string, unknown>;
-  return rec.type === "image" && typeof rec.data === "string" && typeof rec.mimeType === "string";
+  return typeof block.data === "string" && typeof block.mimeType === "string";
 }
 
 function isTextBlock(block: unknown): block is TextContentBlock {
@@ -285,6 +290,13 @@ export async function sanitizeContentBlocksImages(
     }
 
     if (!isImageBlock(block)) {
+      if (isImageTypeBlock(block)) {
+        out.push({
+          type: "text",
+          text: `[${label}] omitted image payload: missing data or mimeType`,
+        } satisfies TextContentBlock);
+        continue;
+      }
       out.push(block);
       continue;
     }
@@ -353,7 +365,7 @@ export async function sanitizeToolResultImages(
   opts: ImageSanitizationLimits = {},
 ): Promise<AgentToolResult<unknown>> {
   const content = Array.isArray(result.content) ? result.content : [];
-  if (!content.some((b) => isImageBlock(b) || isTextBlock(b))) {
+  if (!content.some((block) => isImageTypeBlock(block) || isTextBlock(block))) {
     return result;
   }
 

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -1,3 +1,5 @@
+// web_fetch SSRF tests cover URL, DNS, redirect, and proxy policy enforcement
+// before network requests reach fetch or provider fallbacks.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
 import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
@@ -34,9 +36,21 @@ function setMockFetch(
   return fetchSpy;
 }
 
+function expectRawFetchSuccessDetails(details: unknown) {
+  const typedDetails = details as { status?: number; extractor?: string };
+  expect(typedDetails.status).toBe(200);
+  expect(typedDetails.extractor).toBe("raw");
+}
+
+function firstFetchUrl(fetchSpy: ReturnType<typeof setMockFetch>): string {
+  const input = fetchSpy.mock.calls[0]?.[0];
+  return input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+}
+
 function createWebFetchToolForTest(params?: {
   firecrawlApiKey?: string;
-  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean };
+  useTrustedEnvProxy?: boolean;
+  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
   cacheTtlMinutes?: number;
 }) {
   return createWebFetchTool({
@@ -58,6 +72,7 @@ function createWebFetchToolForTest(params?: {
         web: {
           fetch: {
             cacheTtlMinutes: params?.cacheTtlMinutes ?? 0,
+            useTrustedEnvProxy: params?.useTrustedEnvProxy,
             ssrfPolicy: params?.ssrfPolicy,
             ...(params?.firecrawlApiKey ? { provider: "firecrawl" } : {}),
           },
@@ -89,6 +104,7 @@ describe("web_fetch SSRF protection", () => {
     global.fetch = priorFetch;
     lookupMock.mockClear();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("blocks localhost hostnames before fetch/firecrawl", async () => {
@@ -130,6 +146,8 @@ describe("web_fetch SSRF protection", () => {
   });
 
   it("blocks redirects to private hosts", async () => {
+    // Redirect targets are new network destinations and must be re-checked
+    // against the same SSRF policy as the original URL.
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 
     const fetchSpy = setMockFetch().mockResolvedValueOnce(
@@ -150,13 +168,42 @@ describe("web_fetch SSRF protection", () => {
     const tool = createWebFetchToolForTest();
 
     const result = await tool?.execute?.("call", { url: "https://example.com" });
-    expect(result?.details).toMatchObject({
-      status: 200,
-      extractor: "raw",
-    });
+    expectRawFetchSuccessDetails(result?.details);
+  });
+
+  it("preserves trailing Unicode URL text through tool argument parsing", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ok"));
+    const tool = createWebFetchToolForTest();
+
+    await tool?.execute?.("call", { url: "https://example.com/a\u00a0" });
+
+    expect(firstFetchUrl(fetchSpy)).toBe("https://example.com/a%C2%A0");
+  });
+
+  it("trims leading Unicode whitespace through tool argument parsing", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ok"));
+    const tool = createWebFetchToolForTest();
+
+    await tool?.execute?.("call", { url: "\u00a0\ufeffhttps://example.com" });
+
+    expect(firstFetchUrl(fetchSpy)).toBe("https://example.com/");
+  });
+
+  it("trims trailing Unicode whitespace after a bare authority", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ok"));
+    const tool = createWebFetchToolForTest();
+
+    await tool?.execute?.("call", { url: "https://example.com\u2003" });
+
+    expect(firstFetchUrl(fetchSpy)).toBe("https://example.com/");
   });
 
   it("allows RFC2544 benchmark-range URLs only when web_fetch ssrfPolicy opts in", async () => {
+    // Benchmark ranges are fake-IP infrastructure in some deployments, but
+    // remain denied unless the web_fetch config opts in.
     const url = "http://198.18.0.153/file";
     lookupMock.mockResolvedValue([{ address: "198.18.0.153", family: 4 }]);
 
@@ -170,12 +217,44 @@ describe("web_fetch SSRF protection", () => {
     });
 
     const allowed = await allowedTool?.execute?.("call", { url });
-    expect(allowed?.details).toMatchObject({
-      status: 200,
-      extractor: "raw",
-    });
+    expectRawFetchSuccessDetails(allowed?.details);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const stricterTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
     await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
+  });
+
+  it("allows IPv6 unique-local DNS answers only when web_fetch ssrfPolicy opts in", async () => {
+    const url = "https://fake-ip.test/file";
+    lookupMock.mockResolvedValue([{ address: "fc00::153", family: 6 }]);
+
+    const deniedTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
+    await expectBlockedUrl(deniedTool, url, /private|internal|blocked/i);
+
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ipv6 ula ok"));
+    const allowedTool = createWebFetchToolForTest({
+      ssrfPolicy: { allowIpv6UniqueLocalRange: true },
+      cacheTtlMinutes: 1,
+    });
+
+    const allowed = await allowedTool?.execute?.("call", { url });
+    expectRawFetchSuccessDetails(allowed?.details);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const stricterTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
+    await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
+  });
+
+  it("still blocks dangerous hostnames when trusted env proxy is explicitly enabled", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    vi.stubEnv("http_proxy", "http://127.0.0.1:7890");
+    const fetchSpy = setMockFetch();
+    const tool = createWebFetchToolForTest({
+      useTrustedEnvProxy: true,
+      cacheTtlMinutes: 1,
+    });
+
+    await expectBlockedUrl(tool, "http://localhost/test", /Blocked hostname/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(lookupMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -49,8 +49,7 @@ function firstFetchUrl(fetchSpy: ReturnType<typeof setMockFetch>): string {
 
 function createWebFetchToolForTest(params?: {
   firecrawlApiKey?: string;
-  useTrustedEnvProxy?: boolean;
-  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
+  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean };
   cacheTtlMinutes?: number;
 }) {
   return createWebFetchTool({
@@ -72,7 +71,6 @@ function createWebFetchToolForTest(params?: {
         web: {
           fetch: {
             cacheTtlMinutes: params?.cacheTtlMinutes ?? 0,
-            useTrustedEnvProxy: params?.useTrustedEnvProxy,
             ssrfPolicy: params?.ssrfPolicy,
             ...(params?.firecrawlApiKey ? { provider: "firecrawl" } : {}),
           },
@@ -223,33 +221,11 @@ describe("web_fetch SSRF protection", () => {
     await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
   });
 
-  it("allows IPv6 unique-local DNS answers only when web_fetch ssrfPolicy opts in", async () => {
-    const url = "https://fake-ip.test/file";
-    lookupMock.mockResolvedValue([{ address: "fc00::153", family: 6 }]);
-
-    const deniedTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
-    await expectBlockedUrl(deniedTool, url, /private|internal|blocked/i);
-
-    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ipv6 ula ok"));
-    const allowedTool = createWebFetchToolForTest({
-      ssrfPolicy: { allowIpv6UniqueLocalRange: true },
-      cacheTtlMinutes: 1,
-    });
-
-    const allowed = await allowedTool?.execute?.("call", { url });
-    expectRawFetchSuccessDetails(allowed?.details);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-
-    const stricterTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
-    await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
-  });
-
-  it("still blocks dangerous hostnames when trusted env proxy is explicitly enabled", async () => {
+  it("still blocks dangerous hostnames even when an HTTP(S) proxy env var is set", async () => {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
     vi.stubEnv("http_proxy", "http://127.0.0.1:7890");
     const fetchSpy = setMockFetch();
     const tool = createWebFetchToolForTest({
-      useTrustedEnvProxy: true,
       cacheTtlMinutes: 1,
     });
 

--- a/src/agents/tools/web-fetch.test.ts
+++ b/src/agents/tools/web-fetch.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeWebFetchUrl } from "./web-fetch.js";
+
+describe("sanitizeWebFetchUrl", () => {
+  it("removes whitespace between scheme and authority (reported bug)", () => {
+    expect(sanitizeWebFetchUrl("https:// docs.openclaw.ai")).toBe("https://docs.openclaw.ai");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(sanitizeWebFetchUrl("  https://example.com  ")).toBe("https://example.com");
+  });
+
+  it("trims leading Unicode whitespace", () => {
+    expect(sanitizeWebFetchUrl("\u00a0\ufeffhttps://example.com")).toBe("https://example.com");
+  });
+
+  it("trims trailing newlines", () => {
+    expect(sanitizeWebFetchUrl("https://example.com\n")).toBe("https://example.com");
+  });
+
+  it("preserves trailing Unicode whitespace in paths", () => {
+    expect(sanitizeWebFetchUrl("https://example.com/a\u00a0")).toBe("https://example.com/a\u00a0");
+  });
+
+  it("trims trailing Unicode whitespace after a bare authority", () => {
+    expect(sanitizeWebFetchUrl("https://example.com\u00a0")).toBe("https://example.com");
+  });
+
+  it("preserves spaces in the path component", () => {
+    // WHATWG URL parser percent-encodes path spaces — they must not be stripped
+    const result = sanitizeWebFetchUrl("https://example.com/a b");
+    expect(result).toBe("https://example.com/a b");
+  });
+
+  it("preserves spaces in the query component", () => {
+    const result = sanitizeWebFetchUrl("https://example.com?q=a b");
+    expect(result).toBe("https://example.com?q=a b");
+  });
+
+  it("preserves scheme-like text in the path component", () => {
+    const result = sanitizeWebFetchUrl("https://example.com/a:// b");
+    expect(result).toBe("https://example.com/a:// b");
+  });
+
+  it("preserves scheme-like text in the query component", () => {
+    const result = sanitizeWebFetchUrl("https://example.com?q=x:// y");
+    expect(result).toBe("https://example.com?q=x:// y");
+  });
+
+  it("preserves percent-encoded characters in path", () => {
+    const result = sanitizeWebFetchUrl("https://example.com/a%20b");
+    expect(result).toBe("https://example.com/a%20b");
+  });
+
+  it("does not modify already-valid URLs", () => {
+    expect(sanitizeWebFetchUrl("https://docs.openclaw.ai")).toBe("https://docs.openclaw.ai");
+  });
+
+  it("handles https:// with tab after scheme", () => {
+    expect(sanitizeWebFetchUrl("https://\texample.com")).toBe("https://example.com");
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -300,15 +300,6 @@ function normalizeProviderFinalUrl(value: unknown): string | undefined {
   }
 }
 
-function throwIfFetchAborted(signal: AbortSignal | undefined): void {
-  if (!signal?.aborted) {
-    return;
-  }
-  // readResponseText may finish after an abort races with body reading. Recheck
-  // before wrapping, caching, or returning content from a canceled tool call.
-  throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
-}
-
 /**
  * Sanitize a web_fetch URL parameter that may contain LLM-injected whitespace.
  *
@@ -326,7 +317,6 @@ export function sanitizeWebFetchUrl(raw: string): string {
   const repaired = trimmed.replace(/^(https?:\/\/)\s+/i, "$1");
   return repaired.replace(/^(https?:\/\/[^/?#\s]+)\s+$/i, "$1");
 }
-
 
 function normalizeProviderWebFetchPayload(params: {
   providerId: string;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -300,6 +300,34 @@ function normalizeProviderFinalUrl(value: unknown): string | undefined {
   }
 }
 
+function throwIfFetchAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  // readResponseText may finish after an abort races with body reading. Recheck
+  // before wrapping, caching, or returning content from a canceled tool call.
+  throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
+}
+
+/**
+ * Sanitize a web_fetch URL parameter that may contain LLM-injected whitespace.
+ *
+ * Fixes the reported case where a model emits a space between the scheme and
+ * authority (e.g. `https:// docs.openclaw.ai`), which causes `new URL()` to
+ * throw. Path and query whitespace is intentionally preserved — the WHATWG URL
+ * parser percent-encodes those characters correctly per RFC 3986.
+ */
+export function sanitizeWebFetchUrl(raw: string): string {
+  let end = raw.length;
+  while (end > 0 && raw.charCodeAt(end - 1) <= 0x20) {
+    end -= 1;
+  }
+  const trimmed = raw.slice(0, end).replace(/^\s+/, "");
+  const repaired = trimmed.replace(/^(https?:\/\/)\s+/i, "$1");
+  return repaired.replace(/^(https?:\/\/[^/?#\s]+)\s+$/i, "$1");
+}
+
+
 function normalizeProviderWebFetchPayload(params: {
   providerId: string;
   payload: unknown;
@@ -630,7 +658,9 @@ export function createWebFetchTool(options?: {
     parameters: WebFetchSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const url = readStringParam(params, "url", { required: true });
+      const url = sanitizeWebFetchUrl(
+        readStringParam(params, "url", { required: true, trim: false }),
+      );
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(params, "maxChars", { integer: true });
       const maxCharsCap = resolveFetchMaxCharsCap(fetch);


### PR DESCRIPTION
## Summary

Batch 2 of the curated OpenClaw → Gemmaclaw upstream sync. Ports 6 high-value upstream fixes while preserving all Gemmaclaw-specific product behavior, branding, and the `.gemmaclaw` home-dir seam.

### Commits ported

| SHA (upstream) | Fix | Files changed |
|---|---|---|
| 5967ae61 | fix(security): audit oauth lock hash | `src/agents/auth-profiles/path-resolve.ts` |
| 314de694 | fix(mcp): harden stdio env filtering | `src/agents/mcp-config-shared.ts` |
| 6451550c | fix(heartbeat): refresh stale current time | `src/agents/current-time.ts` |
| 4001be54 | fix(agents): catch malformed image blocks | `src/agents/tool-images.ts` |
| 46a34422 | fix(web_fetch): sanitize URL whitespace | `src/agents/tools/web-fetch.ts` |
| aa8070a7 | fix(llm): defer Anthropic stream start event | `src/agents/anthropic-transport-stream.ts` |

Plus 1 adaptation commit (`bccd97003f`) removing upstream test scaffolding for features not present in Gemmaclaw (`useTrustedEnvProxy` per-tool flag, `allowIpv6UniqueLocalRange` ssrfPolicy seam) and adding a missing `createRawSseResponse` test helper.

### Gemmaclaw compatibility

- Branding intact (gemmaclaw CLI surface, `.gemmaclaw` home handling)
- No setup wizard / sandbox backend / provider defaults / baseUrl / backup-restore layout changes → Jake reinstall config unaffected
- Docker live-smoke not triggered: all ported code is runtime agent/auth/llm/tool code, no setup/config-schema/bootstrap seams

### Deferred to batch 3

- `allowIpv6UniqueLocalRange` ssrfPolicy seam — upstream has this, gemmaclaw does not; needs a proper seam introduction rather than a patch

### Gate results

- `pnpm build` exit 0 (2502 files, version 2026.7.0)
- `pnpm check:changed` GREEN: typecheck core+tests, lint 0/0, import-cycles 0, auth/webhook guards, unit-fast 26/26, agents 393 files / 4211 passed / 5 skipped / 0 failed
- CLI help checks OK (gemmaclaw, setup, backup, backup restore — Gemmaclaw branding intact)