### PR TITLE
chore: upstream sync openclaw -> gemmaclaw 2026-06-18 (batch 3)

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
+import {
+  markdownToTelegramChunks,
+  markdownToTelegramHtml,
+  splitTelegramHtmlChunks,
+} from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -134,4 +138,47 @@ describe("markdownToTelegramHtml", () => {
   it("fails loudly when tag overhead leaves no room for text", () => {
     expect(() => splitTelegramHtmlChunks("<b><i><u>x</u></i></b>", 10)).toThrow(/tag overhead/i);
   });
+
+  it("does not split an astral char across the chunk boundary", () => {
+    // Emoji surrogate pair straddles index 10 (limit): high at 9, low at 10.
+    const input = `${"A".repeat(9)}😀${"B".repeat(20)}`;
+    const chunks = splitTelegramHtmlChunks(input, 10);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(input);
+    for (const chunk of chunks) {
+      expect(containsLoneSurrogate(chunk)).toBe(false);
+    }
+  });
+
+  it("keeps an astral char whole when a positive limit starts on its pair", () => {
+    expect(splitTelegramHtmlChunks("A😀B", 1)).toEqual(["A", "😀", "B"]);
+  });
+
+  it("keeps astral chars whole in rendered Markdown chunks", () => {
+    const chunks = markdownToTelegramChunks("A😀B", 1);
+
+    expect(chunks.map((chunk) => chunk.text)).toEqual(["A", "😀", "B"]);
+    for (const chunk of chunks) {
+      expect(containsLoneSurrogate(chunk.html)).toBe(false);
+      expect(containsLoneSurrogate(chunk.text)).toBe(false);
+    }
+  });
 });
+
+function containsLoneSurrogate(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    const isHigh = code >= 0xd800 && code <= 0xdbff;
+    const isLow = code >= 0xdc00 && code <= 0xdfff;
+    if (isHigh) {
+      const next = text.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+    } else if (isLow) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -291,11 +291,30 @@ function findTelegramHtmlEntityEnd(text: string, start: number): number {
   return text[index] === ";" ? index : -1;
 }
 
+// Never return a split index that lands between a UTF-16 surrogate pair, or
+// both chunks would carry a lone surrogate that re-encodes to U+FFFD. If the
+// pair starts the segment, keep it whole so chunking still advances.
+function clampToSurrogateBoundary(text: string, index: number): number {
+  const high = text.charCodeAt(index - 1);
+  const low = text.charCodeAt(index);
+  const splitsPair =
+    index > 0 && high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+  if (!splitsPair) {
+    return index;
+  }
+  return index > 1 ? index - 1 : index + 1;
+}
+
 function findTelegramHtmlSafeSplitIndex(text: string, maxLength: number): number {
   if (text.length <= maxLength) {
     return text.length;
   }
   const normalizedMaxLength = Math.max(1, Math.floor(maxLength));
+  const splitIndex = findTelegramHtmlEntitySafeSplitIndex(text, normalizedMaxLength);
+  return clampToSurrogateBoundary(text, splitIndex);
+}
+
+function findTelegramHtmlEntitySafeSplitIndex(text: string, normalizedMaxLength: number): number {
   const lastAmpersand = text.lastIndexOf("&", normalizedMaxLength - 1);
   if (lastAmpersand === -1) {
     return normalizedMaxLength;

--- a/extensions/telegram/src/send.chunks.test.ts
+++ b/extensions/telegram/src/send.chunks.test.ts
@@ -1,0 +1,57 @@
+// Telegram tests cover plain-text chunk-splitting behavior.
+import { describe, expect, it } from "vitest";
+import { splitTelegramPlainTextChunksForTests } from "./send.js";
+
+function containsLoneSurrogate(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    const isHigh = code >= 0xd800 && code <= 0xdbff;
+    const isLow = code >= 0xdc00 && code <= 0xdfff;
+    if (isHigh) {
+      const next = text.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+    } else if (isLow) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("splitTelegramPlainTextChunks", () => {
+  it("does not split an astral char across the chunk boundary", () => {
+    // Emoji surrogate pair straddles index 10 (limit): high at 9, low at 10.
+    const input = `${"A".repeat(9)}😀${"B".repeat(20)}`;
+    const chunks = splitTelegramPlainTextChunksForTests(input, 10);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(input);
+    for (const chunk of chunks) {
+      expect(containsLoneSurrogate(chunk)).toBe(false);
+    }
+  });
+
+  it("does not hang when limit=1 and text starts with an astral char", () => {
+    // Regression: with limit=1 the clamp would return start (no advance),
+    // causing the while-loop to spin forever. The surrogate pair must be
+    // emitted as a unit (2 code units) so the loop always advances.
+    const input = "😀X";
+    const chunks = splitTelegramPlainTextChunksForTests(input, 1);
+    expect(chunks.join("")).toBe(input);
+    for (const chunk of chunks) {
+      expect(containsLoneSurrogate(chunk)).toBe(false);
+    }
+  });
+
+  it("does not hang when limit=1 and an astral char appears mid-string at a chunk boundary", () => {
+    // 'A' + emoji: with limit=1, second iteration starts at index 1 (high
+    // surrogate) — same stall condition as above, now mid-string.
+    const input = "A😀B";
+    const chunks = splitTelegramPlainTextChunksForTests(input, 1);
+    expect(chunks.join("")).toBe(input);
+    for (const chunk of chunks) {
+      expect(containsLoneSurrogate(chunk)).toBe(false);
+    }
+  });
+});

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -143,14 +143,40 @@ function resolveTelegramMessageIdOrThrow(
   throw new Error(`Telegram ${context} returned no message_id`);
 }
 
+// Pull a chunk end back off a UTF-16 surrogate pair so neither chunk carries a
+// lone surrogate that re-encodes to U+FFFD. Mirrors the guard in
+// bot/native-quote.ts `truncateUtf16Safe`; shared by both plain-text splitters.
+//
+// `start` is the beginning of the current chunk — the return value is
+// guaranteed to be > start, so callers that loop on `start = end` always
+// advance. When clamping would land on `start` (i.e. the surrogate pair begins
+// exactly at `start`), we emit both surrogates together (end = start + 2)
+// rather than emitting a lone surrogate or stalling.
+function surrogateSafeChunkEnd(text: string, end: number, start: number): number {
+  const high = text.charCodeAt(end - 1);
+  const low = text.charCodeAt(end);
+  const splitsPair = end > 0 && high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+  if (!splitsPair) {
+    return end;
+  }
+  const clamped = end - 1;
+  // Guard: never return an index that would stall the loop. If clamped equals
+  // start the surrogate pair's high unit is the very first char of this chunk;
+  // emit both surrogates together instead of splitting or stalling.
+  return clamped > start ? clamped : start + 2;
+}
+
 function splitTelegramPlainTextChunks(text: string, limit: number): string[] {
   if (!text) {
     return [];
   }
   const normalizedLimit = Math.max(1, Math.floor(limit));
   const chunks: string[] = [];
-  for (let start = 0; start < text.length; start += normalizedLimit) {
-    chunks.push(text.slice(start, start + normalizedLimit));
+  let start = 0;
+  while (start < text.length) {
+    const end = surrogateSafeChunkEnd(text, start + normalizedLimit, start);
+    chunks.push(text.slice(start, end));
+    start = end;
   }
   return chunks;
 }
@@ -173,10 +199,17 @@ function splitTelegramPlainTextFallback(text: string, chunkCount: number, limit:
       remainingChunks === 1
         ? remainingChars
         : Math.min(normalizedLimit, Math.ceil(remainingChars / remainingChunks));
-    chunks.push(text.slice(offset, offset + nextChunkLength));
-    offset += nextChunkLength;
+    const end = surrogateSafeChunkEnd(text, offset + nextChunkLength, offset);
+    chunks.push(text.slice(offset, end));
+    offset = end;
   }
   return chunks;
+}
+
+// Test-only handle: the plain-text splitter is internal, but its surrogate-safe
+// chunk boundary needs direct behavior coverage.
+export function splitTelegramPlainTextChunksForTests(text: string, limit: number): string[] {
+  return splitTelegramPlainTextChunks(text, limit);
 }
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;

--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -6,6 +6,7 @@ import { resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
 import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/testing";
 import { afterAll, afterEach, beforeAll, beforeEach, vi, type Mock } from "vitest";
+import type { WebChannelStatus } from "./auto-reply/types.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./inbound.js";
 import {
   resetBaileysMocks as _resetBaileysMocks,
@@ -277,6 +278,7 @@ export function startWebAutoReplyMonitor(params: {
   messageTimeoutMs?: number;
   watchdogCheckMs?: number;
   reconnect?: { initialMs: number; maxMs: number; maxAttempts: number; factor: number };
+  statusSink?: (status: WebChannelStatus) => void;
 }): WebAutoReplyMonitorHarness {
   const runtime = createWebAutoReplyRuntime();
   const controller = new AbortController();
@@ -293,6 +295,7 @@ export function startWebAutoReplyMonitor(params: {
       watchdogCheckMs: params.watchdogCheckMs,
       reconnect: params.reconnect ?? { initialMs: 10, maxMs: 10, maxAttempts: 3, factor: 1.1 },
       sleep: params.sleep,
+      statusSink: params.statusSink,
     },
   );
 

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -77,6 +77,26 @@ describe("web auto-reply connection", () => {
     expect(() => formatEnvelopeTimestamp(d, " America/Los_Angeles ")).not.toThrow();
   });
 
+  it("does not publish running status when config loading fails", async () => {
+    setLoadConfigMock(() => {
+      throw new Error("config snapshot failed");
+    });
+
+    const statuses: Array<{ running?: boolean }> = [];
+    const listenerFactory = vi.fn(async () => createMockWebListener());
+    const { run } = startWebAutoReplyMonitor({
+      monitorWebChannelFn: monitorWebChannel as never,
+      listenerFactory,
+      sleep: vi.fn(async () => {}),
+      statusSink: (next) => statuses.push({ ...next }),
+    });
+
+    await expect(run).rejects.toThrow("config snapshot failed");
+
+    expect(listenerFactory).not.toHaveBeenCalled();
+    expect(statuses.some((status) => status.running === true)).toBe(false);
+  });
+
   it("handles reconnect progress and max-attempt stop behavior", async () => {
     for (const scenario of [
       {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -113,9 +113,6 @@ export async function monitorWebChannel(
   const replyLogger = getChildLogger({ module: "web-auto-reply", runId });
   const heartbeatLogger = getChildLogger({ module: "web-heartbeat", runId });
   const reconnectLogger = getChildLogger({ module: "web-reconnect", runId });
-  const statusController = createWebChannelStatusController(tuning.statusSink);
-  statusController.emit();
-
   const baseCfg = loadConfig();
   const sourceCfg = getRuntimeConfigSourceSnapshot();
   const account = resolveWhatsAppAccount({
@@ -197,6 +194,8 @@ export async function monitorWebChannel(
     sleep,
     isNonRetryableStatus: isNonRetryableWebCloseStatus,
   });
+  const statusController = createWebChannelStatusController(tuning.statusSink);
+  statusController.emit();
 
   try {
     while (true) {

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -49,7 +49,7 @@ function firstFetchUrl(fetchSpy: ReturnType<typeof setMockFetch>): string {
 
 function createWebFetchToolForTest(params?: {
   firecrawlApiKey?: string;
-  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean };
+  ssrfPolicy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
   cacheTtlMinutes?: number;
 }) {
   return createWebFetchTool({
@@ -211,6 +211,29 @@ describe("web_fetch SSRF protection", () => {
     const fetchSpy = setMockFetch().mockResolvedValue(textResponse("benchmark ok"));
     const allowedTool = createWebFetchToolForTest({
       ssrfPolicy: { allowRfc2544BenchmarkRange: true },
+      cacheTtlMinutes: 1,
+    });
+
+    const allowed = await allowedTool?.execute?.("call", { url });
+    expectRawFetchSuccessDetails(allowed?.details);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const stricterTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
+    await expectBlockedUrl(stricterTool, url, /private|internal|blocked/i);
+  });
+
+  it("allows IPv6 ULA addresses only when web_fetch ssrfPolicy opts in", async () => {
+    // fc00::/7 (Unique Local Addresses) are blocked by default but can be
+    // exempted for fake-IP proxy stacks (sing-box, Clash, Surge) that resolve
+    // foreign domains to ULA addresses.
+    const url = "http://[fd12:3456:789a::1]/file";
+    lookupMock.mockResolvedValue([{ address: "fd12:3456:789a::1", family: 6 }]);
+
+    const deniedTool = createWebFetchToolForTest({ cacheTtlMinutes: 1 });
+    await expectBlockedUrl(deniedTool, url, /private|internal|blocked/i);
+
+    const fetchSpy = setMockFetch().mockResolvedValue(textResponse("ula ok"));
+    const allowedTool = createWebFetchToolForTest({
+      ssrfPolicy: { allowIpv6UniqueLocalRange: true },
       cacheTtlMinutes: 1,
     });
 

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -273,6 +273,7 @@ type WebFetchRuntimeParams = {
   readabilityEnabled: boolean;
   ssrfPolicy?: {
     allowRfc2544BenchmarkRange?: boolean;
+    allowIpv6UniqueLocalRange?: boolean;
   };
   lookupFn?: LookupFn;
   resolveProviderFallback: () => Promise<WebFetchProviderFallback>;
@@ -406,8 +407,9 @@ async function maybeFetchProviderWebFetchPayload(
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
   const allowRfc2544BenchmarkRange = params.ssrfPolicy?.allowRfc2544BenchmarkRange === true;
+  const allowIpv6UniqueLocalRange = params.ssrfPolicy?.allowIpv6UniqueLocalRange === true;
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${allowRfc2544BenchmarkRange ? ":allow-rfc2544" : ""}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${allowRfc2544BenchmarkRange ? ":allow-rfc2544" : ""}${allowIpv6UniqueLocalRange ? ":allow-ipv6-ula" : ""}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {
@@ -435,7 +437,13 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
       lookupFn: params.lookupFn,
-      policy: allowRfc2544BenchmarkRange ? { allowRfc2544BenchmarkRange } : undefined,
+      policy:
+        allowRfc2544BenchmarkRange || allowIpv6UniqueLocalRange
+          ? {
+              ...(allowRfc2544BenchmarkRange ? { allowRfc2544BenchmarkRange } : {}),
+              ...(allowIpv6UniqueLocalRange ? { allowIpv6UniqueLocalRange } : {}),
+            }
+          : undefined,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -551,6 +551,10 @@ describe("chunkMarkdownTextWithMode", () => {
       expect(chunkMarkdownTextWithMode(text, limit, "newline"), name).toEqual(expected);
     },
   );
+
+  it("keeps an astral character whole when a positive hard limit starts on its pair", () => {
+    expect(chunkMarkdownTextWithMode("A😀B", 1, "length")).toEqual(["A", "😀", "B"]);
+  });
 });
 
 describe("resolveChunkMode", () => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -8,7 +8,10 @@ import { findFenceSpanAt, isSafeFenceBreak, parseFenceSpans } from "../markdown/
 import { resolveChannelStreamingChunkMode } from "../plugin-sdk/channel-streaming.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
-import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
+import {
+  avoidTrailingHighSurrogateBreak,
+  chunkTextByBreakResolver,
+} from "../shared/text-chunking.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 
 export type TextChunkProvider = ChannelId;
@@ -392,6 +395,16 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
       const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
       fenceToSplit =
         fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
+    }
+
+    const safeBreakIdx = avoidTrailingHighSurrogateBreak(text, start, breakIdx);
+    if (safeBreakIdx !== breakIdx) {
+      breakIdx = safeBreakIdx;
+      if (fenceToSplit) {
+        const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
+        fenceToSplit =
+          fenceAtBreak && fenceAtBreak.start === fenceToSplit.start ? fenceAtBreak : undefined;
+      }
     }
 
     const rawContent = text.slice(start, breakIdx);

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -7,6 +7,7 @@ import {
   isBlockedSpecialUseIpv6Address,
   isCanonicalDottedDecimalIPv4,
   type Ipv4SpecialUseBlockOptions,
+  type Ipv6SpecialUseBlockOptions,
   isIpv4Address,
   isLegacyIpv4Literal,
   parseCanonicalIpAddress,
@@ -40,6 +41,14 @@ export type SsrFPolicy = {
   allowPrivateNetwork?: boolean;
   dangerouslyAllowPrivateNetwork?: boolean;
   allowRfc2544BenchmarkRange?: boolean;
+  /**
+   * Exempt addresses in `fc00::/7` (IPv6 Unique Local Address block, RFC 4193)
+   * from the SSRF private-IP block. Companion to
+   * `allowRfc2544BenchmarkRange` for fake-ip proxy stacks (sing-box, Clash,
+   * Surge) that resolve foreign domains to ULA addresses alongside the IPv4
+   * 198.18.0.0/15 range. See #74351.
+   */
+  allowIpv6UniqueLocalRange?: boolean;
   allowedHostnames?: string[];
   hostnameAllowlist?: string[];
 };
@@ -103,6 +112,12 @@ function resolveIpv4SpecialUseBlockOptions(policy?: SsrFPolicy): Ipv4SpecialUseB
   };
 }
 
+function resolveIpv6SpecialUseBlockOptions(policy?: SsrFPolicy): Ipv6SpecialUseBlockOptions {
+  return {
+    allowUniqueLocalRange: policy?.allowIpv6UniqueLocalRange === true,
+  };
+}
+
 export function isHostnameAllowedByPattern(hostname: string, pattern: string): boolean {
   if (pattern.startsWith("*.")) {
     const suffix = pattern.slice(2);
@@ -141,13 +156,14 @@ export function isPrivateIpAddress(address: string, policy?: SsrFPolicy): boolea
     return false;
   }
   const blockOptions = resolveIpv4SpecialUseBlockOptions(policy);
+  const ipv6BlockOptions = resolveIpv6SpecialUseBlockOptions(policy);
 
   const strictIp = parseCanonicalIpAddress(normalized);
   if (strictIp) {
     if (isIpv4Address(strictIp)) {
       return isBlockedSpecialUseIpv4Address(strictIp, blockOptions);
     }
-    if (isBlockedSpecialUseIpv6Address(strictIp)) {
+    if (isBlockedSpecialUseIpv6Address(strictIp, ipv6BlockOptions)) {
       return true;
     }
     const embeddedIpv4 = extractEmbeddedIpv4FromIpv6(strictIp);

--- a/src/markdown/render-aware-chunking.ts
+++ b/src/markdown/render-aware-chunking.ts
@@ -103,6 +103,13 @@ function findLargestChunkTextLengthWithinRenderedLimit<TRendered>(
   // Rendered length is not guaranteed to be monotonic after escaping/link or
   // file-reference rewriting, so test exact candidates from longest to shortest.
   for (let candidateLength = currentTextLength - 1; candidateLength >= 1; candidateLength -= 1) {
+    // Skip any split index that lands between a UTF-16 surrogate pair to avoid
+    // emitting lone surrogates that re-encode to U+FFFD replacement characters.
+    const prevCode = chunk.text.charCodeAt(candidateLength - 1);
+    const nextCode = chunk.text.charCodeAt(candidateLength);
+    if (prevCode >= 0xd800 && prevCode <= 0xdbff && nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+      continue;
+    }
     const candidate = sliceMarkdownIR(chunk, 0, candidateLength);
     const rendered = options.renderChunk(candidate);
     if (options.measureRendered(rendered) <= renderedLimit) {

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -3,6 +3,15 @@
  *
  * Singleton hook runner that's initialized when plugins are loaded
  * and can be called from anywhere in the codebase.
+ *
+ * The runner is created once and resolves hooks live on every dispatch from a
+ * composed view of the registries that are currently live: the most recently
+ * initialized registry, the active registry, and the pinned channel/http-route
+ * surfaces. Freezing one registry caused scoped mid-run activations (harness
+ * and memory ensures) to rebind the runner to a narrow registry and silently
+ * drop other plugins' tool-call hooks (#91918). Composing live also preserves
+ * the older contract that hooks pushed into a registry after initialization
+ * (e.g. the SDK `addTestHook` helper) dispatch immediately.
  */
 
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -10,6 +19,9 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
 import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./hook-types.js";
 import { createHookRunner, type HookRunner } from "./hooks.js";
+import { isPluginRegistryRetired } from "./registry-lifecycle.js";
+import type { PluginRegistry } from "./registry-types.js";
+import { collectLivePluginRegistries } from "./runtime.js";
 
 type HookRunnerGlobalState = {
   hookRunner: HookRunner | null;
@@ -25,25 +37,152 @@ const getState = () =>
 
 const getLog = () => createSubsystemLogger("plugins");
 
+function collectHookRegistrySources(
+  lastInitialized: GlobalHookRunnerRegistry | null,
+): GlobalHookRunnerRegistry[] {
+  const ordered: GlobalHookRunnerRegistry[] = [];
+  const seen = new Set<GlobalHookRunnerRegistry>();
+  const add = (registry: GlobalHookRunnerRegistry | null) => {
+    if (!registry || seen.has(registry)) {
+      return;
+    }
+    // Retired registries were superseded by a newer activation; dispatching
+    // their hooks would resurrect stale config closures. Only lastInitialized
+    // can be retired here (the live registries below are active/pinned, never
+    // retired); SDK-supplied registries are not PluginRegistry and never match.
+    if (isPluginRegistryRetired(registry as PluginRegistry)) {
+      return;
+    }
+    seen.add(registry);
+    ordered.push(registry);
+  };
+  // Precedence: the explicitly initialized registry wins so an SDK caller that
+  // initializes an isolated registry stays authoritative; in the gateway it is
+  // the same object as the active registry, so this just dedupes.
+  add(lastInitialized);
+  for (const registry of collectLivePluginRegistries()) {
+    add(registry);
+  }
+  return ordered;
+}
+
+function composeLiveHookRegistry(
+  lastInitialized: GlobalHookRunnerRegistry | null,
+): GlobalHookRunnerRegistry {
+  const sources = collectHookRegistrySources(lastInitialized);
+  // One source registry owns a plugin's entire contribution (status + hooks),
+  // so handlers never double-fire across registries and a plugin's hooks stay
+  // paired with the status the inbound-claim path reads.
+  const ownerSourceIndexByPluginId = new Map<string, number>();
+  const claimOwner = (pluginId: string, index: number) => {
+    if (!ownerSourceIndexByPluginId.has(pluginId)) {
+      ownerSourceIndexByPluginId.set(pluginId, index);
+    }
+  };
+  // pluginIds each source actually contributes a hook for, so ownership can
+  // prefer a source that carries the plugin's hooks over a same-plugin record
+  // that loaded without any (e.g. a setup-runtime channel load registers the
+  // channel but not the plugin's api.on(...) hooks).
+  const hookPluginIdsBySource = sources.map((registry) => {
+    const ids = new Set<string>();
+    for (const hook of registry.typedHooks) {
+      ids.add(hook.pluginId);
+    }
+    for (const hook of registry.hooks) {
+      ids.add(hook.pluginId);
+    }
+    return ids;
+  });
+  // Prefer the highest-precedence source where the plugin loaded AND actually
+  // contributes a hook, so a loaded-but-hookless record (failed/disabled scoped
+  // reload, or a setup-runtime channel load) cannot shadow a lower-precedence
+  // registration that still carries a fail-closed tool-call gate.
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded" && hookPluginIdsBySource[index].has(plugin.id)) {
+        claimOwner(plugin.id, index);
+      }
+    }
+  });
+  // Then a loaded record owns the plugin's status when no live source
+  // contributes a hook for it, keeping status paired with a single owner.
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      if (plugin.status === "loaded") {
+        claimOwner(plugin.id, index);
+      }
+    }
+  });
+  sources.forEach((registry, index) => {
+    for (const plugin of registry.plugins) {
+      claimOwner(plugin.id, index);
+    }
+  });
+  // Defensive: claim any hook whose plugin record is absent from .plugins so a
+  // malformed registry never silently drops a registered hook.
+  sources.forEach((registry, index) => {
+    for (const hook of registry.typedHooks) {
+      claimOwner(hook.pluginId, index);
+    }
+    for (const hook of registry.hooks) {
+      claimOwner(hook.pluginId, index);
+    }
+  });
+  return {
+    hooks: sources.flatMap((registry, index) =>
+      registry.hooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
+    ),
+    typedHooks: sources.flatMap((registry, index) =>
+      registry.typedHooks.filter((hook) => ownerSourceIndexByPluginId.get(hook.pluginId) === index),
+    ),
+    plugins: sources.flatMap((registry, index) =>
+      registry.plugins.filter((plugin) => ownerSourceIndexByPluginId.get(plugin.id) === index),
+    ),
+  };
+}
+
+function createComposedHookRegistryFacade(state: HookRunnerGlobalState): GlobalHookRunnerRegistry {
+  // Live getters: createHookRunner reads these on every hasHooks/getHooksForName
+  // call, so the runner always dispatches the current live registry set rather
+  // than a snapshot captured at initialization. Composition is bounded by the
+  // small live registry set and runs on hook-paced events, not tight loops.
+  return {
+    get hooks() {
+      return composeLiveHookRegistry(state.registry).hooks;
+    },
+    get typedHooks() {
+      return composeLiveHookRegistry(state.registry).typedHooks;
+    },
+    get plugins() {
+      return composeLiveHookRegistry(state.registry).plugins;
+    },
+  };
+}
+
 /**
  * Initialize the global hook runner with a plugin registry.
- * Called once when plugins are loaded during gateway startup.
+ * Called on every plugin registry activation and by SDK consumers. The runner
+ * instance stays stable so references captured mid-run keep seeing current
+ * hooks; the passed registry becomes the highest-precedence composition source.
  */
 export function initializeGlobalHookRunner(registry: GlobalHookRunnerRegistry): void {
   const state = getState();
   const log = getLog();
   state.registry = registry;
-  state.hookRunner = createHookRunner(registry, {
-    logger: {
-      debug: (msg) => log.debug(msg),
-      warn: (msg) => log.warn(msg),
-      error: (msg) => log.error(msg),
-    },
-    catchErrors: true,
-    failurePolicyByHook: {
-      before_tool_call: "fail-closed",
-    },
-  });
+  if (!state.hookRunner) {
+    state.hookRunner = createHookRunner(createComposedHookRegistryFacade(state), {
+      logger: {
+        debug: (msg) => log.debug(msg),
+        warn: (msg) => log.warn(msg),
+        error: (msg) => log.error(msg),
+      },
+      catchErrors: true,
+      failurePolicyByHook: {
+        before_install: "fail-closed",
+        before_tool_call: "fail-closed",
+      },
+    });
+  }
 
   const hookCount = registry.hooks.length;
   if (hookCount > 0) {
@@ -60,8 +199,9 @@ export function getGlobalHookRunner(): HookRunner | null {
 }
 
 /**
- * Get the global plugin registry.
- * Returns null if plugins haven't been loaded yet.
+ * Get the registry from the most recent activation or explicit initialization.
+ * Returns null if plugins haven't been loaded yet. Hook dispatch does not use
+ * this single registry; the runner resolves hooks from the live composed view.
  */
 export function getGlobalPluginRegistry(): GlobalHookRunnerRegistry | null {
   return getState().registry;

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -1,0 +1,30 @@
+/** Tracks active and retired plugin registries so stale runtime calls can be rejected. */
+import type { PluginRegistry } from "./registry-types.js";
+
+const retiredRegistries = new WeakSet<PluginRegistry>();
+const activatedRegistries = new WeakSet<PluginRegistry>();
+
+/** Marks a registry retired so late runtime calls can reject stale plugin state. */
+export function markPluginRegistryRetired(registry: PluginRegistry | null | undefined): void {
+  if (registry) {
+    retiredRegistries.add(registry);
+  }
+}
+
+/** Marks a registry active and clears any previous retired state. */
+export function markPluginRegistryActive(registry: PluginRegistry | null | undefined): void {
+  if (registry) {
+    activatedRegistries.add(registry);
+    retiredRegistries.delete(registry);
+  }
+}
+
+/** True when a registry has been activated for runtime use. */
+export function isPluginRegistryActivated(registry: PluginRegistry): boolean {
+  return activatedRegistries.has(registry);
+}
+
+/** True when a registry has been retired by a newer active registry. */
+export function isPluginRegistryRetired(registry: PluginRegistry): boolean {
+  return retiredRegistries.has(registry);
+}

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -196,6 +196,30 @@ export function getActivePluginRegistryVersion(): number {
   return state.activeVersion;
 }
 
+/**
+ * Returns the distinct live plugin registries in precedence order: the active
+ * registry first, then the pinned http-route and channel surfaces. Uses the
+ * raw pinned registries (not channel-presentation selection) so a pinned
+ * registry stays visible to runtime dispatch even with zero channels. Shared
+ * by the agent-event bridge and the global hook runner so both dispatch
+ * surfaces agree on what "live" means.
+ */
+export function collectLivePluginRegistries(): PluginRegistry[] {
+  const registries: PluginRegistry[] = [];
+  const seen = new Set<PluginRegistry>();
+  const addRegistry = (registry: PluginRegistry | null) => {
+    if (!registry || seen.has(registry)) {
+      return;
+    }
+    seen.add(registry);
+    registries.push(registry);
+  };
+  addRegistry(asPluginRegistry(state.activeRegistry));
+  addRegistry(asPluginRegistry(state.httpRoute.registry));
+  addRegistry(asPluginRegistry(state.channel.registry));
+  return registries;
+}
+
 function collectLoadedPluginIds(
   registry: PluginRegistry | null | undefined,
   ids: Set<string>,

--- a/src/shared/net/ip.ts
+++ b/src/shared/net/ip.ts
@@ -40,6 +40,22 @@ export type Ipv4SpecialUseBlockOptions = {
   allowRfc2544BenchmarkRange?: boolean;
 };
 
+/**
+ * Per-call exemptions for `isBlockedSpecialUseIpv6Address`. Only
+ * `allowUniqueLocalRange` is exposed (#74351); other reserved IPv6 ranges stay
+ * unconditionally blocked.
+ */
+export type Ipv6SpecialUseBlockOptions = {
+  /**
+   * When true, exempt addresses in `fc00::/7` (the IPv6 Unique Local Address
+   * block, RFC 4193) from the SSRF private-IP block. Sing-box / Clash / Surge
+   * fake-ip implementations resolve foreign domains to ULA addresses
+   * alongside RFC 2544 benchmark IPv4 addresses, and operators using those
+   * proxy stacks need both ranges exempted to keep `web_fetch` working.
+   */
+  allowUniqueLocalRange?: boolean;
+};
+
 const EMBEDDED_IPV4_SENTINEL_RULES: Array<{
   matches: (parts: number[]) => boolean;
   toHextets: (parts: number[]) => [high: number, low: number];
@@ -237,10 +253,19 @@ export function isPrivateOrLoopbackIpAddress(raw: string | undefined): boolean {
   return isBlockedSpecialUseIpv6Address(normalized);
 }
 
-export function isBlockedSpecialUseIpv6Address(address: ipaddr.IPv6): boolean {
+export function isBlockedSpecialUseIpv6Address(
+  address: ipaddr.IPv6,
+  options: Ipv6SpecialUseBlockOptions = {},
+): boolean {
   // ipaddr.js returns "discard" at runtime for 100::/64, but its published
   // TypeScript IPv6Range union omits that literal.
   const range = address.range() as BlockedIpv6Range;
+  if (range === "uniqueLocal" && options.allowUniqueLocalRange === true) {
+    // Operators running fake-ip proxy stacks (sing-box, Clash, Surge) opt in
+    // to fc00::/7 reaching the network — same intent as allowRfc2544BenchmarkRange
+    // for IPv4 fake-ip ranges.
+    return false;
+  }
   if (BLOCKED_IPV6_SPECIAL_USE_RANGES.has(range)) {
     return true;
   }

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -1,3 +1,18 @@
+export function avoidTrailingHighSurrogateBreak(text: string, start: number, end: number): number {
+  if (end <= start || end >= text.length) {
+    return end;
+  }
+  const previous = text.charCodeAt(end - 1);
+  const next = text.charCodeAt(end);
+  const splitsSurrogatePair =
+    previous >= 0xd800 && previous <= 0xdbff && next >= 0xdc00 && next <= 0xdfff;
+  if (!splitsSurrogatePair) {
+    return end;
+  }
+  const adjusted = end - 1;
+  return adjusted > start ? adjusted : end + 1;
+}
+
 export function chunkTextByBreakResolver(
   text: string,
   limit: number,
@@ -14,10 +29,12 @@ export function chunkTextByBreakResolver(
   while (remaining.length > limit) {
     const window = remaining.slice(0, limit);
     const candidateBreak = resolveBreakIndex(window);
-    const breakIdx =
+    const rawBreakIdx =
       Number.isFinite(candidateBreak) && candidateBreak > 0 && candidateBreak <= limit
         ? candidateBreak
         : limit;
+    // Clamp to a surrogate-safe boundary so we never emit a lone surrogate.
+    const breakIdx = avoidTrailingHighSurrogateBreak(remaining, 0, rawBreakIdx);
     const rawChunk = remaining.slice(0, breakIdx);
     const chunk = rawChunk.trimEnd();
     if (chunk.length > 0) {


### PR DESCRIPTION
## Summary

Batch 3 of the June 2026 upstream sync. Ports 5 curated upstream fixes against `origin/main` (post-batch-2 base).

### Changes

| Area | Fix |
|---|---|
| `ssrf` | `allowIpv6UniqueLocalRange` seam wired end-to-end in `web-fetch.ts` — completes deferred Batch 2 seam; IPv6 ULA (fc00::/7) exemptible via plugin config |
| `whatsapp` | `statusController.emit("running")` deferred until after config load — prevents false running status on startup failure |
| `text-chunking` | `chunkTextByBreakResolver` + `findLargestChunkTextLengthWithinRenderedLimit` surrogate guards — prevents lone surrogates in IR chunker path |
| `telegram` | `clampToSurrogateBoundary` + `surrogateSafeChunkEnd` guards in HTML/plain-text splitters |
| `plugins` | Live composed registry view in global hook runner — new `registry-lifecycle.ts`, `collectLivePluginRegistries`, rewritten `hook-runner-global.ts` |

### Gate results

`pnpm check:changed` all lanes green: typecheck (core + extensions), lint (0 errors), import cycles (0), tests (4679 passed across 7 shards).