### PR TITLE
chore: upstream sync openclaw -> gemmaclaw 2026-06-19 (batch 4)

### DIFF
--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,0 +1,31 @@
+// Slack tests cover auth.test token handling during provider boot.
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getSlackClient,
+  resetSlackTestState,
+  startSlackMonitor,
+  stopSlackMonitor,
+} from "../monitor.test-helpers.js";
+
+const { monitorSlackProvider } = await import("./provider.js");
+
+beforeEach(() => {
+  resetSlackTestState();
+});
+
+describe("auth.test boot call", () => {
+  it("does not pass the bot token in the call arguments", async () => {
+    const monitor = startSlackMonitor(monitorSlackProvider);
+    await stopSlackMonitor(monitor);
+
+    const client = getSlackClient();
+    expect(client.auth.test).toHaveBeenCalledTimes(1);
+    // The SDK serializes every property from the call argument into the POST
+    // body.  Passing { token } would leak the bot token into the request
+    // payload alongside the Authorization header.
+    const firstArg = client.auth.test.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    if (firstArg != null) {
+      expect(firstArg).not.toHaveProperty("token");
+    }
+  });
+});

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -456,7 +456,11 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let apiAppId = "";
   const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
   try {
-    const auth = await app.client.auth.test({ token: botToken });
+    // The Bolt App client is already constructed with the bot token, so it
+    // sends it in the Authorization header. Passing { token } here would also
+    // serialize the bot token into the request body, leaking it. Call with no
+    // arguments so the token only travels in the Authorization header.
+    const auth = await app.client.auth.test();
     botUserId = auth.user_id ?? "";
     botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";


### PR DESCRIPTION
## Curated upstream OpenClaw -> Gemmaclaw sync (Batch 4, 2026-06-19)

Continues the daily curated selective-sync from Batch 3 (origin/main `554d26b7ba`). The raw "behind upstream" count is fork divergence, not real outstanding work — this batch ports only the high-value curated fixes that map to a gemmaclaw code path.

### Ported

**SECURITY — fix(slack): stop leaking bot token into auth.test request body** (upstream `fbc12e0879`, #94574)

`monitorSlackProvider` called `app.client.auth.test({ token: botToken })`. The Bolt `App` client is already constructed with the bot token (so it sends it in the `Authorization` header); passing `{ token }` into the call also serializes the bot token into the POST request body, leaking it alongside the header. Fixed to call `auth.test()` with no arguments.

- `extensions/slack/src/monitor/provider.ts` — drop the `{ token: botToken }` argument.
- `extensions/slack/src/monitor/provider.auth-test-token.test.ts` — new regression test asserting the bot token never appears in the `auth.test` call arguments. Verified it **fails** on the vulnerable code (`expected { token: 'bot-token' } to not have property "token"`) and **passes** on the fix.

### Triaged & skipped (no gemmaclaw code path / out of curated scope)

| Upstream | Reason |
|---|---|
| `95c87e31e2` preserve pending subagent completion announces | gemmaclaw reimplements the direct-announce delivery seam with await-final + retry (`runAnnounceDeliveryWithRetry` / `callGateway` `expectFinal:true`); the `completion_handoff_pending` pending early-return does not exist, so not affected. |
| `ea76a45917` Codex thread rotation next-step context | `extensions/codex/src/app-server/context-engine-projection.ts` absent in gemmaclaw codex; `run-attempt.ts` has no rotation/projection path. |
| `9928516a78` deliver native subagent idle results | `extensions/codex/src/app-server/native-subagent-monitor.ts` absent; feature not present in gemmaclaw codex. |
| `49e6f5a524` auto-reply lifecycle storage seams | Pure refactor introducing an absent `src/config/sessions/session-accessor.ts` seam + boundary script; no behavioral fix. |
| ~30 `fix(e2e)` / `fix(live)` test-limit commits | Touch upstream-only e2e harness files (`scripts/lib/docker-e2e-*.sh`, `test/scripts/docker-build-helper.test.ts`, `scripts/e2e/*.sh`) absent in gemmaclaw, which uses the Gemma benchmark harness + docker setup live smoke instead. |
| `e9e44bf83c` auth-monitor template mutation | Operator-only Anthropic-auth-monitor setup script, not test-harness/product surface; deferred out of this security-focused batch. |

### Local verification (Node 22)

- `pnpm install` + `pnpm build` — pass.
- `pnpm check:changed` — typecheck OK, lint 0 warnings / 0 errors (4424 files), 0 import cycles, slack suite 337 tests pass (incl. new regression test).
- CLI: `setup` / `backup` / `backup restore` `--help` all render Gemmaclaw branding + flags intact.
- Live setup smoke not triggered: change is a Slack channel extension only (not setup/sandbox/runtime/backup/config).

Scope: additive curated porting only. No benchmark/site/published-result changes.