### PR TITLE
chore: upstream sync openclaw -> gemmaclaw 2026-06-20 (batch 5)

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -10,6 +10,7 @@ import {
   type ThinkingLevel,
 } from "@mariozechner/pi-ai";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { readResponseTextSnippet } from "../media/read-response-with-limit.js";
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -28,6 +29,9 @@ import {
 } from "./transport-stream-shared.js";
 
 const CLAUDE_CODE_VERSION = "2.1.75";
+const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
+const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
+const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
 const CLAUDE_CODE_TOOLS = [
   "Read",
   "Write",
@@ -505,7 +509,7 @@ function createAnthropicMessagesClient(params: {
           signal: options?.signal,
         });
         if (!response.ok) {
-          const detail = await response.text().catch(() => "");
+          const detail = await readAnthropicMessagesErrorBodySnippet(response);
           throw new Error(
             detail || `Anthropic Messages request failed with HTTP ${response.status}`,
           );
@@ -517,6 +521,30 @@ function createAnthropicMessagesClient(params: {
       },
     },
   };
+}
+
+async function readAnthropicMessagesErrorBodySnippet(response: Response): Promise<string> {
+  try {
+    return (
+      (await readResponseTextSnippet(response, {
+        maxBytes: ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES,
+        maxChars: ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS,
+        chunkTimeoutMs: ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS,
+        onIdleTimeout: ({ chunkTimeoutMs }) =>
+          new Error(
+            `Anthropic Messages error response stalled: no data received for ${chunkTimeoutMs}ms`,
+          ),
+      })) ?? ""
+    );
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Anthropic Messages error response stalled:")
+    ) {
+      return error.message;
+    }
+    return "";
+  }
 }
 
 function createAnthropicTransportClient(params: {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -134,6 +134,12 @@ function applyWhamCooldownResult(params: {
   };
 }
 
+async function cancelUnreadResponseBody(response: Response): Promise<void> {
+  if (!response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
 export async function probeWhamForCooldown(
   store: AuthProfileStore,
   profileId: string,
@@ -162,6 +168,7 @@ export async function probeWhamForCooldown(
     });
 
     if (!res.ok) {
+      await cancelUnreadResponseBody(res);
       if (res.status === 401) {
         return { cooldownMs: WHAM_TOKEN_EXPIRED_COOLDOWN_MS, reason: "wham_token_expired" };
       }

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -195,13 +195,20 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
 // API fetch
 // ---------------------------------------------------------------------------
 
+async function cancelUnreadResponseBody(response: Response | undefined): Promise<void> {
+  if (response && !response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
 async function doFetch(): Promise<void> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let response: Response | undefined;
   try {
     const fetchFn = resolveProxyFetchFromEnv() ?? globalThis.fetch;
 
-    const response = await fetchFn(OPENROUTER_MODELS_URL, {
+    response = await fetchFn(OPENROUTER_MODELS_URL, {
       signal: controller.signal,
     });
 
@@ -229,6 +236,7 @@ async function doFetch(): Promise<void> {
     log.warn(`Failed to fetch OpenRouter models: ${message}`);
   } finally {
     clearTimeout(timeout);
+    await cancelUnreadResponseBody(response);
   }
 }
 

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -155,6 +155,9 @@ export async function readResponseText(
         // let cleanup turn a bounded read into a hung fetch.
         void reader.cancel().catch(() => undefined);
       }
+      try {
+        reader.releaseLock();
+      } catch {}
     }
 
     parts.push(decoder.decode());


### PR DESCRIPTION
## Upstream sync openclaw → gemmaclaw 2026-06-20 (Batch 5)

Curated Phase-0 upstream selective-sync. Base: `origin/main` `4fe93df008` (release gemmaclaw 2026.8.0). Upstream HEAD at batch start: `b6d754e3cb`. This batch ports a coherent slice of the 2026-06-19/20 upstream **error-response-body hardening** family — every fix bounds or releases an unread HTTP error/catalog body so a hostile or stalled response cannot exhaust memory or leak/hang a stream reader. Only commits with a real gemmaclaw seam were ported; each was hand-adapted to the fork's file layout.

### Ported commits

| Upstream SHA | Fix | Gemmaclaw file | Adaptation |
|---|---|---|---|
| `d6cefe26f4` (#95108) | bound Anthropic Messages error streams | `src/agents/anthropic-transport-stream.ts` | `readResponseTextSnippet` imported from local `../media/read-response-with-limit.js` (fork has it as a source module, not the upstream `@openclaw/media-core` package); identical helper signature. Bounds non-OK error body to 8KiB / 400 chars with a 10s idle-read timeout. |
| `8aaf937b` | cancel WHAM probe error bodies | `src/agents/auth-profiles/usage.ts` | Same seam; `cancelUnreadResponseBody` helper + call after `!res.ok` in `probeWhamForCooldown`. |
| `0dbac0d5` | release bounded web response readers | `src/agents/tools/web-shared.ts` | Same seam; `reader.releaseLock()` in the `finally` of the bounded `readResponseText` path. |
| `dba291ed` | cancel OpenRouter catalog error bodies | `src/agents/pi-embedded-runner/openrouter-model-capabilities.ts` | Fork path is `pi-embedded-runner/` (upstream `embedded-agent-runner/`); hoisted the fetch `Response` and cancel any unread body in `finally`. |

### Skipped / deferred
- `cd061a4c7b` (preserve delivered message send results) and `1c711048f9` (route plugin approvals through transport channel): **no seam** — gemmaclaw forked before upstream's `pi-tools → agent-tools` rename and has no `tool-result-middleware.ts` / `embedded-agent-message-tool-source-reply.ts`. Not applicable.
- `dbd5689e` (model-scan error bodies, 138-line refactor) and `e6743eb7` (google-prompt-cache, 69 lines): deferred to a future batch to keep this one small and reviewable.

### Verification
- `pnpm build` exit 0 (Node 22.22.2, pnpm 10.33.0); dist head `4fe93df`, banner `OpenClaw / Gemmaclaw 2026.8.0`.
- `pnpm check:changed` exit 0 (`OPENCLAW_VITEST_MAX_WORKERS=2`): typecheck core + tests PASS, lint 0/0 (7005 files), 0 import cycles, webhook/pairing guards PASS, vitest agents shard 393 files / 4212 passed / 5 skipped. Only the agents shard runs because all 4 changed files are under `src/agents/`; whole-tree compile validated by the green build.
- CLI `--version` / `--help` / `setup --help` / `backup --help` / `backup restore --help` all render.
- Bundled discord `openclaw` resolves with `ERR_PACKAGE_PATH_NOT_EXPORTED` (FOUND/SAFE).
- **Docker live smoke NOT required**: all 4 changes are pure runtime agent/auth/tool code — no setup/onboarding, Gemma defaults, provider setup, Docker sandbox, shared-folder, backup/restore, or config-schema changes.

### Jake (Pi) reinstall impact
None — no setup/provider/backup changes. Pi is offline anyway; next post-recovery daily ops run reinstalls to origin/main HEAD (which will include this batch once merged).

### CI
Pre-existing fork-infra/dep-audit failures (security-dependency-audit, security-fast, checks-node-core*, checks-node-extensions*, CI summary) are expected and match the most recent site-only PR (#297). Only NEW failures relative to that baseline are in scope.
