### PR TITLE
maintenance: upstream openclaw batch 6 selective sync (2026-06-21)

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -181,71 +181,79 @@ async function withTimeout<T>(
 }
 
 async function fetchOpenRouterModels(fetchImpl: typeof fetch): Promise<OpenRouterModelMeta[]> {
-  const res = await fetchImpl(OPENROUTER_MODELS_URL, {
-    headers: { Accept: "application/json" },
-  });
-  if (!res.ok) {
-    throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
-  }
-  const payload = (await res.json()) as { data?: unknown };
-  const entries = Array.isArray(payload.data) ? payload.data : [];
+  let res: Response | undefined;
+  try {
+    res = await fetchImpl(OPENROUTER_MODELS_URL, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      throw new Error(`OpenRouter /models failed: HTTP ${res.status}`);
+    }
+    const payload = (await res.json()) as { data?: unknown };
+    const entries = Array.isArray(payload.data) ? payload.data : [];
 
-  return entries
-    .map((entry) => {
-      if (!entry || typeof entry !== "object") {
-        return null;
-      }
-      const obj = entry as Record<string, unknown>;
-      const id = normalizeOptionalString(obj.id) ?? "";
-      if (!id) {
-        return null;
-      }
-      const name = typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : id;
+    return entries
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+        const obj = entry as Record<string, unknown>;
+        const id = normalizeOptionalString(obj.id) ?? "";
+        if (!id) {
+          return null;
+        }
+        const name = typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : id;
 
-      const contextLength =
-        typeof obj.context_length === "number" && Number.isFinite(obj.context_length)
-          ? obj.context_length
-          : null;
-
-      const maxCompletionTokens =
-        typeof obj.max_completion_tokens === "number" && Number.isFinite(obj.max_completion_tokens)
-          ? obj.max_completion_tokens
-          : typeof obj.max_output_tokens === "number" && Number.isFinite(obj.max_output_tokens)
-            ? obj.max_output_tokens
+        const contextLength =
+          typeof obj.context_length === "number" && Number.isFinite(obj.context_length)
+            ? obj.context_length
             : null;
 
-      const supportedParameters = Array.isArray(obj.supported_parameters)
-        ? obj.supported_parameters
-            .filter((value): value is string => typeof value === "string")
-            .map((value) => value.trim())
-            .filter(Boolean)
-        : [];
+        const maxCompletionTokens =
+          typeof obj.max_completion_tokens === "number" &&
+          Number.isFinite(obj.max_completion_tokens)
+            ? obj.max_completion_tokens
+            : typeof obj.max_output_tokens === "number" && Number.isFinite(obj.max_output_tokens)
+              ? obj.max_output_tokens
+              : null;
 
-      const supportedParametersCount = supportedParameters.length;
-      const supportsToolsMeta = supportedParameters.includes("tools");
+        const supportedParameters = Array.isArray(obj.supported_parameters)
+          ? obj.supported_parameters
+              .filter((value): value is string => typeof value === "string")
+              .map((value) => value.trim())
+              .filter(Boolean)
+          : [];
 
-      const modality =
-        typeof obj.modality === "string" && obj.modality.trim() ? obj.modality.trim() : null;
+        const supportedParametersCount = supportedParameters.length;
+        const supportsToolsMeta = supportedParameters.includes("tools");
 
-      const inferredParamB = inferParamBFromIdOrName(`${id} ${name}`);
-      const createdAtMs = normalizeCreatedAtMs(obj.created_at);
-      const pricing = parseOpenRouterPricing(obj.pricing);
+        const modality =
+          typeof obj.modality === "string" && obj.modality.trim() ? obj.modality.trim() : null;
 
-      return {
-        id,
-        name,
-        contextLength,
-        maxCompletionTokens,
-        supportedParameters,
-        supportedParametersCount,
-        supportsToolsMeta,
-        modality,
-        inferredParamB,
-        createdAtMs,
-        pricing,
-      } satisfies OpenRouterModelMeta;
-    })
-    .filter((entry): entry is OpenRouterModelMeta => Boolean(entry));
+        const inferredParamB = inferParamBFromIdOrName(`${id} ${name}`);
+        const createdAtMs = normalizeCreatedAtMs(obj.created_at);
+        const pricing = parseOpenRouterPricing(obj.pricing);
+
+        return {
+          id,
+          name,
+          contextLength,
+          maxCompletionTokens,
+          supportedParameters,
+          supportedParametersCount,
+          supportsToolsMeta,
+          modality,
+          inferredParamB,
+          createdAtMs,
+          pricing,
+        } satisfies OpenRouterModelMeta;
+      })
+      .filter((entry): entry is OpenRouterModelMeta => Boolean(entry));
+  } finally {
+    if (res && !res.bodyUsed) {
+      await res.body?.cancel().catch(() => undefined);
+    }
+  }
 }
 
 async function probeTool(

--- a/src/agents/pi-embedded-runner/google-prompt-cache.ts
+++ b/src/agents/pi-embedded-runner/google-prompt-cache.ts
@@ -188,6 +188,12 @@ function buildManagedContextWithoutSystemPrompt(context: Parameters<StreamFn>[1]
   };
 }
 
+async function cancelUnreadResponseBody(response: Response | undefined): Promise<void> {
+  if (response && !response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
 async function updateGooglePromptCacheTtl(params: {
   apiKey: string;
   baseUrl: string;
@@ -197,22 +203,24 @@ async function updateGooglePromptCacheTtl(params: {
   headers?: Record<string, string>;
   signal?: AbortSignal;
 }): Promise<{ expireTime?: string } | null> {
-  const response = await params.fetchImpl(
-    `${params.baseUrl}/${params.cachedContent}?updateMask=ttl`,
-    {
+  let response: Response | undefined;
+  try {
+    response = await params.fetchImpl(`${params.baseUrl}/${params.cachedContent}?updateMask=ttl`, {
       method: "PATCH",
       headers: mergeTransportHeaders(parseGeminiAuth(params.apiKey).headers, params.headers),
       body: JSON.stringify({
         ttl: resolveGooglePromptCacheTtl(params.cacheRetention),
       }),
       signal: params.signal,
-    },
-  );
-  if (!response.ok) {
-    return null;
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const json = (await response.json()) as { expireTime?: string };
+    return json;
+  } finally {
+    await cancelUnreadResponseBody(response);
   }
-  const json = (await response.json()) as { expireTime?: string };
-  return json;
 }
 
 async function createGooglePromptCache(params: {
@@ -225,24 +233,29 @@ async function createGooglePromptCache(params: {
   signal?: AbortSignal;
   systemPrompt: string;
 }): Promise<{ cachedContent: string; expireTime?: string } | null> {
-  const response = await params.fetchImpl(`${params.baseUrl}/cachedContents`, {
-    method: "POST",
-    headers: mergeTransportHeaders(parseGeminiAuth(params.apiKey).headers, params.headers),
-    body: JSON.stringify({
-      model: params.modelId.startsWith("models/") ? params.modelId : `models/${params.modelId}`,
-      ttl: resolveGooglePromptCacheTtl(params.cacheRetention),
-      systemInstruction: {
-        parts: [{ text: params.systemPrompt }],
-      },
-    }),
-    signal: params.signal,
-  });
-  if (!response.ok) {
-    return null;
+  let response: Response | undefined;
+  try {
+    response = await params.fetchImpl(`${params.baseUrl}/cachedContents`, {
+      method: "POST",
+      headers: mergeTransportHeaders(parseGeminiAuth(params.apiKey).headers, params.headers),
+      body: JSON.stringify({
+        model: params.modelId.startsWith("models/") ? params.modelId : `models/${params.modelId}`,
+        ttl: resolveGooglePromptCacheTtl(params.cacheRetention),
+        systemInstruction: {
+          parts: [{ text: params.systemPrompt }],
+        },
+      }),
+      signal: params.signal,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const json = (await response.json()) as { name?: string; expireTime?: string };
+    const cachedContent = normalizeOptionalString(json.name) ?? "";
+    return cachedContent ? { cachedContent, expireTime: json.expireTime } : null;
+  } finally {
+    await cancelUnreadResponseBody(response);
   }
-  const json = (await response.json()) as { name?: string; expireTime?: string };
-  const cachedContent = normalizeOptionalString(json.name) ?? "";
-  return cachedContent ? { cachedContent, expireTime: json.expireTime } : null;
 }
 
 async function ensureGooglePromptCache(

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -39,6 +39,7 @@ export { resolveUserPath } from "../utils.js";
 export { callGatewayTool } from "../agents/tools/gateway.js";
 export { isMessagingTool, isMessagingToolSendAction } from "../agents/pi-embedded-messaging.js";
 export {
+  extractToolErrorMessage,
   extractToolResultMediaArtifact,
   filterToolResultMediaUrls,
 } from "../agents/pi-embedded-subscribe.tools.js";


### PR DESCRIPTION
## Upstream Selective Sync — Batch 6

Curated cherry-picks from upstream openclaw (`b6d754e3cb..6c2c43d63f`) following the Batch 1–5 pattern (PRs #292, #294, #296, #298, #299).

**Theme:** Error-response-body hardening (continued from Batch 5) + plugin-sdk API surface addition. Each commit was manually adapted to the fork's layout (path rename `embedded-agent-runner` → `pi-embedded-runner`, absence of `normalizeStringEntries`, different `resolveConfiguredSecretInputWithFallback` internals).

| Upstream SHA | Fix | Fork file | Adaptation |
|---|---|---|---|
| `e6743eb7` | cancel prompt cache error bodies | `src/agents/pi-embedded-runner/google-prompt-cache.ts` | manual port (path renamed in fork) |
| `8ff1d3e67b` | surface returned tool errors (plugin-sdk) | `src/plugin-sdk/agent-harness-runtime.ts` | 1-line addition |
| `f8675b3b70` | normalize secret fallback values | `src/gateway/resolve-configured-secret-input-string.ts` | adapted to fork's `resolveSecretInputRef` code path |
| `dbd5689e` | cancel model scan error bodies | `src/agents/model-scan.ts` | adapted (no `withTimeout`, inline filter instead of `normalizeStringEntries`) |

**Deferred (no seam or complex conflict):** `6bfe7a2b06` (enforce canonical secret refs — 5-file conflict), `f87f30d429` (preserve prompt input range — prompt-compaction-hook-helpers diverged), `15f2a56590`, `6084442ab6` (empty prompt range family — depends on deferred `promptInputRange` type).

**Regression gate:**
- `pnpm build` ✅ exit 0 (Node 22.22.2 / pnpm 10.33.0)
- `pnpm check:changed` (typecheck, lint, import cycles, webhook/pairing guards, tests changed) ✅ all green
- `tests extensions` 1 failure (`msteams/sdk.test.ts` + `googlechat` — passes in isolation; pre-existing parallel-run flakiness, same class as prior batches)
- CLI `--version` → `Gemmaclaw 2026.8.0 (9908877)` ✅

**Pre-existing CI failure set (same as #297/#299 baseline):** `security-dependency-audit`, `security-fast`, `checks-node-core`, `checks-node-core-runtime-infra`, `checks-node-core-support-boundary`, `checks-node-extensions`, `checks-node-extensions-shard-4`, `CI` summary.