### PR TITLE
fix(gateway): normalize secret fallback values (re-land Batch 6 f8675b3b70)

### DIFF
--- a/src/gateway/resolve-configured-secret-input-string.test.ts
+++ b/src/gateway/resolve-configured-secret-input-string.test.ts
@@ -53,6 +53,36 @@ describe("resolveConfiguredSecretInputWithFallback", () => {
     });
   });
 
+  it("ignores blank fallback values when no SecretRef is configured", async () => {
+    const resolved = await resolveConfiguredSecretInputWithFallback({
+      config: createConfig(""),
+      env: {} as NodeJS.ProcessEnv,
+      value: "",
+      path: "gateway.auth.token",
+      readFallback: () => "   ",
+    });
+
+    expect(resolved).toEqual({
+      secretRefConfigured: false,
+    });
+  });
+
+  it("normalizes fallback values when no SecretRef is configured", async () => {
+    const resolved = await resolveConfiguredSecretInputWithFallback({
+      config: createConfig(""),
+      env: {} as NodeJS.ProcessEnv,
+      value: "",
+      path: "gateway.auth.token",
+      readFallback: () => "  env-token  ",
+    });
+
+    expect(resolved).toEqual({
+      value: "env-token",
+      source: "fallback",
+      secretRefConfigured: false,
+    });
+  });
+
   it("returns resolved SecretRef value", async () => {
     const resolved = await resolveConfiguredSecretInputWithFallback({
       config: createConfig("${CUSTOM_GATEWAY_TOKEN}"),
@@ -83,6 +113,21 @@ describe("resolveConfiguredSecretInputWithFallback", () => {
       source: "fallback",
       secretRefConfigured: true,
     });
+  });
+
+  it("ignores blank fallback values when SecretRef cannot be resolved", async () => {
+    const resolved = await resolveConfiguredSecretInputWithFallback({
+      config: createConfig("${MISSING_GATEWAY_TOKEN}"),
+      env: {} as NodeJS.ProcessEnv,
+      value: "${MISSING_GATEWAY_TOKEN}",
+      path: "gateway.auth.token",
+      readFallback: () => "   ",
+    });
+
+    expect(resolved.value).toBeUndefined();
+    expect(resolved.source).toBeUndefined();
+    expect(resolved.secretRefConfigured).toBe(true);
+    expect(resolved.unresolvedRefReason).toContain("gateway.auth.token SecretRef is unresolved");
   });
 
   it("returns unresolved reason when SecretRef cannot be resolved and no fallback exists", async () => {

--- a/src/gateway/resolve-configured-secret-input-string.ts
+++ b/src/gateway/resolve-configured-secret-input-string.ts
@@ -102,6 +102,7 @@ export async function resolveConfiguredSecretInputWithFallback(params: {
     value: params.value,
     defaults: params.config.secrets?.defaults,
   });
+  const readNormalizedFallback = () => normalizeOptionalString(params.readFallback?.());
   const configValue = !ref ? normalizeOptionalString(params.value) : undefined;
   if (configValue) {
     return {
@@ -111,7 +112,7 @@ export async function resolveConfiguredSecretInputWithFallback(params: {
     };
   }
   if (!ref) {
-    const fallback = params.readFallback?.();
+    const fallback = readNormalizedFallback();
     if (fallback) {
       return {
         value: fallback,
@@ -137,7 +138,7 @@ export async function resolveConfiguredSecretInputWithFallback(params: {
     };
   }
 
-  const fallback = params.readFallback?.();
+  const fallback = readNormalizedFallback();
   if (fallback) {
     return {
       value: fallback,


### PR DESCRIPTION
## Summary

Re-lands the upstream secret-fallback normalization fix `f8675b3b70` that was nominally part of Batch 6 (PR #303) but never actually applied: the Batch 6 commit `64f9d5fd12` claiming this port was an **empty commit**, so on `main` the two `params.readFallback?.()` call sites in `resolveConfiguredSecretInputWithFallback` were still un-normalized.

## Change

- Add a `readNormalizedFallback` helper that wraps `params.readFallback?.()` in `normalizeOptionalString`, so whitespace-only fallback values are treated as absent (consistent with how direct config values are already normalized).
- Replace both raw `readFallback` call sites in `resolveConfiguredSecretInputWithFallback`.
- Adapted to the fork's `resolveSecretInputRef`-based code path (`ref` vs upstream's `resolved.refConfigured`); semantics identical to upstream.

## Tests

Adds 3 matching tests:
- ignores blank fallback values when no SecretRef is configured
- normalizes whitespace-padded fallback values when no SecretRef is configured
- ignores blank fallback values when SecretRef cannot be resolved

Local gate (Node 22): targeted gateway project 11/11 pass; pre-commit `check:changed` 2652/2652 tests pass across 232 files.