### PR TITLE
maintenance: upstream openclaw batch 7 selective sync (2026-06-22)

### DIFF
--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -104,6 +104,55 @@ describe("createWhatsAppOutboundBase", () => {
     );
   });
 
+  it("uses the native send (not a dep override) when a quote reply resolves", async () => {
+    cacheInboundMessageMeta("work", "15551234567@s.whatsapp.net", "reply-native", {
+      participant: "111@s.whatsapp.net",
+      body: "quoted body",
+    });
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "native-1",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const overrideSend = vi.fn(async () => ({
+      messageId: "override-1",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    const result = await outbound.sendText!({
+      cfg: {
+        channels: {
+          whatsapp: {
+            defaultAccount: "work",
+            accounts: { work: {} },
+          },
+        },
+      } as never,
+      to: "whatsapp:+15551234567",
+      text: "reply",
+      deps: { sendWhatsApp: overrideSend },
+      replyToId: "reply-native",
+    });
+
+    // A dep-injected send override would drop the native quotedMessageKey; the
+    // quote-reply path must bypass it and call sendMessageWhatsApp directly.
+    expect(overrideSend).not.toHaveBeenCalled();
+    expect(sendMessageWhatsApp).toHaveBeenCalledWith(
+      "whatsapp:+15551234567",
+      "reply",
+      expect.objectContaining({
+        quotedMessageKey: expect.objectContaining({ id: "reply-native" }),
+      }),
+    );
+    expect(result.messageId).toBe("native-1");
+  });
+
   it("normalizes mixed-case defaultAccount before quote metadata lookup", async () => {
     cacheInboundMessageMeta("work", "15551234567@s.whatsapp.net", "reply-case", {
       participant: "333@s.whatsapp.net",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -131,16 +131,17 @@ export function createWhatsAppOutboundBase({
         if (skipEmptyText && !normalizedText) {
           return { messageId: "" };
         }
-        const send =
-          resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-            legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-          }) ?? sendMessageWhatsApp;
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
         const quotedMessageKey = resolveQuotedMessageKey({
           accountId: lookupAccountId,
           to,
           replyToId,
         });
+        const send = quotedMessageKey
+          ? sendMessageWhatsApp
+          : (resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
+              legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
+            }) ?? sendMessageWhatsApp);
         return await send(to, normalizedText, {
           verbose: false,
           cfg,
@@ -162,16 +163,17 @@ export function createWhatsAppOutboundBase({
         gifPlayback,
         replyToId,
       }) => {
-        const send =
-          resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-            legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-          }) ?? sendMessageWhatsApp;
         const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
         const quotedMessageKey = resolveQuotedMessageKey({
           accountId: lookupAccountId,
           to,
           replyToId,
         });
+        const send = quotedMessageKey
+          ? sendMessageWhatsApp
+          : (resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
+              legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
+            }) ?? sendMessageWhatsApp);
         return await send(to, normalizeText(text), {
           verbose: false,
           cfg,

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -149,6 +149,142 @@ describe("channelsCapabilitiesCommand", () => {
     expect(output).toContain("users:read");
   });
 
+  it("caps oversized timeouts before invoking capability probes", async () => {
+    const probeAccount = vi.fn(async () => ({ ok: true }));
+    const buildCapabilitiesDiagnostics = vi.fn(async () => ({
+      lines: [{ text: "Diagnostics: ok" }],
+    }));
+    const plugin = buildPlugin({
+      id: "slack",
+      account: {
+        accountId: "default",
+        botToken: "xoxb-bot",
+      },
+    });
+    plugin.status = { probeAccount, buildCapabilitiesDiagnostics };
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: {} },
+      channelId: "slack",
+      plugin,
+      configChanged: false,
+    });
+
+    await channelsCapabilitiesCommand({ channel: "slack", timeout: "999999" }, runtime);
+
+    expect(probeAccount).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 30_000 }));
+    expect(buildCapabilitiesDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+  });
+
+  it("serializes a failed probe when a capability probe exceeds its timeout", async () => {
+    const probeAccount = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Intentionally never settles; command timeout should win.
+        }),
+    );
+    const plugin = buildPlugin({
+      id: "slack",
+      account: {
+        accountId: "default",
+        botToken: "xoxb-bot",
+      },
+    });
+    plugin.status = { probeAccount };
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: {} },
+      channelId: "slack",
+      plugin,
+      configChanged: false,
+    });
+
+    await channelsCapabilitiesCommand({ channel: "slack", json: true, timeout: "1" }, runtime);
+
+    const payload = JSON.parse(logs[0] ?? "{}") as {
+      channels?: Array<{ probe?: unknown }>;
+    };
+    expect(payload.channels?.[0]?.probe).toStrictEqual({
+      ok: false,
+      timedOut: true,
+      error: "probe timed out after 1ms",
+    });
+  });
+
+  it("prints timed-out probes when a channel formatter has no custom output", async () => {
+    const probeAccount = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Intentionally never settles; command timeout should win.
+        }),
+    );
+    const plugin = buildPlugin({
+      id: "telegram",
+      account: {
+        accountId: "default",
+        botToken: "bot-token",
+      },
+    });
+    plugin.status = { probeAccount, formatCapabilitiesProbe: () => [] };
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: {} },
+      channelId: "telegram",
+      plugin,
+      configChanged: false,
+    });
+
+    await channelsCapabilitiesCommand({ channel: "telegram", timeout: "1" }, runtime);
+
+    expect(logs[0]?.split("\n")).toContain("Probe: failed (probe timed out after 1ms)");
+  });
+
+  it("serializes diagnostics when capability diagnostics exceed their timeout", async () => {
+    const buildCapabilitiesDiagnostics = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Intentionally never settles; command timeout should win.
+        }),
+    );
+    const plugin = buildPlugin({
+      id: "slack",
+      account: {
+        accountId: "default",
+        botToken: "xoxb-bot",
+      },
+      probe: { ok: true },
+    });
+    plugin.status = { ...plugin.status, buildCapabilitiesDiagnostics };
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: {} },
+      channelId: "slack",
+      plugin,
+      configChanged: false,
+    });
+
+    await channelsCapabilitiesCommand({ channel: "slack", json: true, timeout: "1" }, runtime);
+
+    const payload = JSON.parse(logs[0] ?? "{}") as {
+      channels?: Array<{ diagnostics?: unknown }>;
+    };
+    expect(payload.channels?.[0]?.diagnostics).toStrictEqual({
+      lines: [
+        {
+          text: "Diagnostics: timed out after 1ms",
+          tone: "error",
+        },
+      ],
+      details: { timedOut: true },
+    });
+  });
+
   it("prints Teams Graph permission hints when present", async () => {
     const plugin = buildPlugin({
       id: "msteams",

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -56,6 +56,93 @@ function normalizeTimeout(raw: unknown, fallback = 10_000) {
   return value;
 }
 
+const CHANNEL_CAPABILITIES_TIMEOUT_MAX_MS = 30_000;
+
+type ChannelCapabilitiesStepResult<T> =
+  | { kind: "value"; value: T }
+  | { kind: "error"; error: unknown }
+  | { kind: "timeout" };
+
+function resolveChannelCapabilitiesTimeoutMs(timeoutMs: number) {
+  return Math.min(timeoutMs, CHANNEL_CAPABILITIES_TIMEOUT_MAX_MS);
+}
+
+async function raceChannelCapabilitiesStep<T>(params: {
+  timeoutMs: number;
+  run: () => Promise<T> | T;
+}): Promise<ChannelCapabilitiesStepResult<T>> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<ChannelCapabilitiesStepResult<T>>((resolve) => {
+    timeout = setTimeout(() => resolve({ kind: "timeout" }), params.timeoutMs);
+    timeout.unref?.();
+  });
+  const resultPromise: Promise<ChannelCapabilitiesStepResult<T>> = Promise.resolve()
+    .then(params.run)
+    .then(
+      (value): ChannelCapabilitiesStepResult<T> => ({ kind: "value", value }),
+      (error: unknown): ChannelCapabilitiesStepResult<T> => ({ kind: "error", error }),
+    );
+  const result = await Promise.race([resultPromise, timeoutPromise]);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  return result;
+}
+
+async function runChannelCapabilitiesProbe(params: {
+  timeoutMs: number;
+  run: () => unknown;
+}): Promise<unknown> {
+  const result = await raceChannelCapabilitiesStep(params);
+  switch (result.kind) {
+    case "value":
+      return result.value;
+    case "timeout":
+      return {
+        ok: false,
+        timedOut: true,
+        error: `probe timed out after ${params.timeoutMs}ms`,
+      };
+    case "error":
+      return { ok: false, error: formatErrorMessage(result.error) };
+  }
+  return undefined;
+}
+
+async function runChannelCapabilitiesDiagnostics(params: {
+  timeoutMs: number;
+  run: () =>
+    | Promise<ChannelCapabilitiesDiagnostics | undefined>
+    | ChannelCapabilitiesDiagnostics
+    | undefined;
+}): Promise<ChannelCapabilitiesDiagnostics | undefined> {
+  const result = await raceChannelCapabilitiesStep(params);
+  switch (result.kind) {
+    case "value":
+      return result.value;
+    case "timeout":
+      return {
+        lines: [
+          {
+            text: `Diagnostics: timed out after ${params.timeoutMs}ms`,
+            tone: "error",
+          },
+        ],
+        details: { timedOut: true },
+      };
+    case "error":
+      return {
+        lines: [
+          {
+            text: `Diagnostics: failed (${formatErrorMessage(result.error)})`,
+            tone: "error",
+          },
+        ],
+      };
+  }
+  return undefined;
+}
+
 function formatSupport(capabilities?: ChannelCapabilities) {
   if (!capabilities) {
     return "unknown";
@@ -160,25 +247,29 @@ async function resolveChannelReports(params: {
       : (resolvedAccount as { enabled?: boolean }).enabled !== false;
     let probe: unknown;
     if (configured && enabled && plugin.status?.probeAccount) {
-      try {
-        probe = await plugin.status.probeAccount({
-          account: resolvedAccount,
-          timeoutMs,
-          cfg,
-        });
-      } catch (err) {
-        probe = { ok: false, error: formatErrorMessage(err) };
-      }
-    }
-
-    const diagnostics =
-      configured && enabled
-        ? await plugin.status?.buildCapabilitiesDiagnostics?.({
+      probe = await runChannelCapabilitiesProbe({
+        timeoutMs,
+        run: () =>
+          plugin.status?.probeAccount?.({
             account: resolvedAccount,
             timeoutMs,
             cfg,
-            probe,
-            target: params.target,
+          }),
+      });
+    }
+
+    const diagnostics =
+      configured && enabled && plugin.status?.buildCapabilitiesDiagnostics
+        ? await runChannelCapabilitiesDiagnostics({
+            timeoutMs,
+            run: () =>
+              plugin.status?.buildCapabilitiesDiagnostics?.({
+                account: resolvedAccount,
+                timeoutMs,
+                cfg,
+                probe,
+                target: params.target,
+              }),
           })
         : undefined;
     const discoveredActions = resolveMessageActionDiscoveryForPlugin({
@@ -223,7 +314,7 @@ export async function channelsCapabilitiesCommand(
     return;
   }
   let cfg = loadedCfg;
-  const timeoutMs = normalizeTimeout(opts.timeout, 10_000);
+  const timeoutMs = resolveChannelCapabilitiesTimeoutMs(normalizeTimeout(opts.timeout, 10_000));
   const rawChannel = normalizeLowercaseStringOrEmpty(opts.channel);
   const rawTarget = normalizeOptionalString(opts.target) ?? "";
 
@@ -315,10 +406,12 @@ export async function channelsCapabilitiesCommand(
       const enabledLabel = report.enabled === false ? "disabled" : "enabled";
       lines.push(`Status: ${configuredLabel}, ${enabledLabel}`);
     }
-    const probeLines =
-      report.plugin.status?.formatCapabilitiesProbe?.({
-        probe: report.probe,
-      }) ?? formatGenericProbeLines(report.probe);
+    const formattedProbeLines = report.plugin.status?.formatCapabilitiesProbe?.({
+      probe: report.probe,
+    });
+    const probeLines = formattedProbeLines?.length
+      ? formattedProbeLines
+      : formatGenericProbeLines(report.probe);
     if (probeLines.length > 0) {
       lines.push(...probeLines.map(renderDisplayLine));
     } else if (report.configured && report.enabled) {

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -148,6 +148,66 @@ describe("normalizeCompatibilityConfigValues", () => {
       "Moved channels.whatsapp single-account top-level values into channels.whatsapp.accounts.default.",
     );
   });
+  it("preserves inherited WhatsApp access policy on named accounts when seeding accounts.default", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+          groupPolicy: "open",
+          groupAllowFrom: [],
+          accounts: {
+            work: {
+              enabled: true,
+              authDir: "/tmp/wa-work",
+            },
+          },
+        },
+      },
+    });
+
+    // The named account must inherit the channel-level access policy that was
+    // moved into accounts.default, otherwise the migration would silently drop
+    // the policy for the named account.
+    expect(res.config.channels?.whatsapp?.accounts?.work).toEqual({
+      enabled: true,
+      authDir: "/tmp/wa-work",
+      dmPolicy: "allowlist",
+      allowFrom: ["+15550001111"],
+      groupPolicy: "open",
+      groupAllowFrom: [],
+    });
+  });
+  it("keeps named-account access policy overrides when seeding accounts.default", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        discord: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          allowFrom: ["top-dm"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["top-group"],
+          accounts: {
+            work: {
+              enabled: true,
+              allowFrom: ["work-dm"],
+              groupPolicy: "disabled",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    // Existing per-account values win; only missing policy keys are inherited.
+    expect(res.config.channels?.discord?.accounts?.work).toEqual({
+      enabled: true,
+      dmPolicy: "allowlist",
+      allowFrom: ["work-dm"],
+      groupPolicy: "disabled",
+      groupAllowFrom: ["top-group"],
+    });
+  });
   it("migrates browser ssrfPolicy allowPrivateNetwork to dangerouslyAllowPrivateNetwork", () => {
     const res = normalizeCompatibilityConfigValues({
       browser: {

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -12,6 +12,8 @@ import { sanitizeForLog } from "../../../terminal/ansi.js";
 import { hasOwnKey, isRecord } from "./legacy-config-record-shared.js";
 export { normalizeLegacyTalkConfig } from "./legacy-talk-config-normalizer.js";
 
+const INHERITED_ACCOUNT_POLICY_KEYS = ["dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"];
+
 export function normalizeLegacyBrowserConfig(
   cfg: OpenClawConfig,
   changes: string[],
@@ -145,10 +147,34 @@ export function seedMissingDefaultAccountsFromSingleAccountBase(
     for (const key of keysToMove) {
       delete nextChannel[key];
     }
-    nextChannel.accounts = {
+    const inheritedPolicyKeys = INHERITED_ACCOUNT_POLICY_KEYS.filter((key) =>
+      keysToMove.includes(key),
+    );
+    const nextAccounts: Record<string, unknown> = {
       ...rawAccounts,
       [DEFAULT_ACCOUNT_ID]: defaultAccount,
     };
+    if (inheritedPolicyKeys.length > 0) {
+      for (const [accountId, rawAccount] of Object.entries(rawAccounts)) {
+        if (!isRecord(rawAccount)) {
+          continue;
+        }
+        const nextAccount = { ...rawAccount };
+        let accountChanged = false;
+        for (const key of inheritedPolicyKeys) {
+          if (hasOwnKey(nextAccount, key)) {
+            continue;
+          }
+          const value = rawChannel[key];
+          nextAccount[key] = value && typeof value === "object" ? structuredClone(value) : value;
+          accountChanged = true;
+        }
+        if (accountChanged) {
+          nextAccounts[accountId] = nextAccount;
+        }
+      }
+    }
+    nextChannel.accounts = nextAccounts;
 
     nextChannels[channelId] = nextChannel;
     channelsChanged = true;

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -18,6 +18,23 @@ const mergeOrigin = (
     return undefined;
   }
   const merged: SessionOrigin = existing ? { ...existing } : {};
+  // A provider/surface/account change is a fresh channel identity (e.g. a dmScope:"main" session
+  // moving Slack -> Telegram, or between Slack accounts). Channel-keyed fields belong to the prior
+  // channel; drop them so an inbound that omits them does not keep reactions, native threading, and
+  // status reads pointed at the previous channel.
+  const channelChanged =
+    existing != null &&
+    ((existing.provider != null && next?.provider != null && next.provider !== existing.provider) ||
+      (existing.surface != null && next?.surface != null && next.surface !== existing.surface) ||
+      (existing.accountId != null &&
+        next?.accountId != null &&
+        next.accountId !== existing.accountId));
+  if (channelChanged) {
+    delete merged.nativeChannelId;
+    delete merged.nativeDirectUserId;
+    delete merged.accountId;
+    delete merged.threadId;
+  }
   if (next?.label) {
     merged.label = next.label;
   }

--- a/src/config/sessions/origin-channel-switch.test.ts
+++ b/src/config/sessions/origin-channel-switch.test.ts
@@ -1,0 +1,159 @@
+// Session origin must drop the prior channel's identity when a dmScope:"main" session moves
+// across providers, so channel-keyed fields do not reference a now-inactive channel.
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { deriveSessionMetaPatch } from "./metadata.js";
+import type { SessionEntry } from "./types.js";
+
+const sessionKey = "agent:user";
+
+function applyOrigin(existing: SessionEntry | undefined, ctx: Partial<MsgContext>): SessionEntry {
+  const patch = deriveSessionMetaPatch({
+    ctx: ctx as MsgContext,
+    sessionKey,
+    existing,
+  });
+  return { ...existing, ...patch } as SessionEntry;
+}
+
+const slackTurn = {
+  Provider: "slack",
+  Surface: "slack",
+  ChatType: "direct",
+  From: "slack:U0001",
+  To: "slack:D111SLACK",
+  NativeChannelId: "D111SLACK",
+  NativeDirectUserId: "U0001",
+  AccountId: "slack-team-1",
+  MessageThreadId: "1700000000.000100",
+} satisfies Partial<MsgContext>;
+
+const telegramTurn = {
+  Provider: "telegram",
+  Surface: "telegram",
+  ChatType: "direct",
+  From: "telegram:42",
+  To: "telegram:42",
+  AccountId: "telegram-bot-1",
+} satisfies Partial<MsgContext>;
+
+describe("session origin across a channel switch", () => {
+  it("clears stale channel-keyed fields when provider changes and the new turn omits them", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    expect(afterSlack.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterSlack.origin?.threadId).toBe("1700000000.000100");
+
+    const afterTelegram = applyOrigin(afterSlack, telegramTurn);
+
+    // Provider/surface flip to Telegram, and the Slack-only identity must not survive.
+    expect(afterTelegram.origin?.provider).toBe("telegram");
+    expect(afterTelegram.origin?.surface).toBe("telegram");
+    expect(afterTelegram.origin?.accountId).toBe("telegram-bot-1");
+    expect(afterTelegram.origin?.nativeChannelId).toBeUndefined();
+    expect(afterTelegram.origin?.nativeDirectUserId).toBeUndefined();
+    expect(afterTelegram.origin?.threadId).toBeUndefined();
+  });
+
+  it("does not re-stamp the prior channel id on subsequent same-channel turns", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterTelegram = applyOrigin(afterSlack, telegramTurn);
+    const afterTelegramAgain = applyOrigin(afterTelegram, telegramTurn);
+
+    expect(afterTelegramAgain.origin?.provider).toBe("telegram");
+    expect(afterTelegramAgain.origin?.nativeChannelId).toBeUndefined();
+    expect(afterTelegramAgain.origin?.threadId).toBeUndefined();
+  });
+
+  it("clears stale account id when provider changes and the new turn omits it", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const telegramWithoutAccount = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      From: "telegram:42",
+      To: "telegram:42",
+    } satisfies Partial<MsgContext>;
+
+    const afterTelegram = applyOrigin(afterSlack, telegramWithoutAccount);
+
+    expect(afterTelegram.origin?.provider).toBe("telegram");
+    expect(afterTelegram.origin?.accountId).toBeUndefined();
+  });
+
+  it("adopts the new channel's identity when the new turn supplies it", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const telegramWithChannel = {
+      ...telegramTurn,
+      NativeChannelId: "C222TG",
+      MessageThreadId: 555,
+    } satisfies Partial<MsgContext>;
+
+    const afterTelegram = applyOrigin(afterSlack, telegramWithChannel);
+    expect(afterTelegram.origin?.nativeChannelId).toBe("C222TG");
+    expect(afterTelegram.origin?.threadId).toBe(555);
+  });
+
+  it("preserves sparse channel metadata across turns on the same provider", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const slackFollowUp = {
+      Provider: "slack",
+      Surface: "slack",
+      ChatType: "direct",
+      From: "slack:U0001",
+      To: "slack:D111SLACK",
+      AccountId: "slack-team-1",
+    } satisfies Partial<MsgContext>;
+
+    const afterFollowUp = applyOrigin(afterSlack, slackFollowUp);
+    // Same provider: the established channel id and thread are retained when omitted.
+    expect(afterFollowUp.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterFollowUp.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("clears stale channel-keyed fields when the account changes and the new turn omits them", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const slackOtherAccount = {
+      Provider: "slack",
+      Surface: "slack",
+      ChatType: "direct",
+      From: "slack:U0002",
+      To: "slack:D222SLACK",
+      AccountId: "slack-team-2",
+    } satisfies Partial<MsgContext>;
+
+    const afterAccountSwitch = applyOrigin(afterSlack, slackOtherAccount);
+
+    expect(afterAccountSwitch.origin?.provider).toBe("slack");
+    expect(afterAccountSwitch.origin?.accountId).toBe("slack-team-2");
+    expect(afterAccountSwitch.origin?.nativeChannelId).toBeUndefined();
+    expect(afterAccountSwitch.origin?.nativeDirectUserId).toBeUndefined();
+    expect(afterAccountSwitch.origin?.threadId).toBeUndefined();
+  });
+
+  it("preserves sparse existing channel metadata when optional identity fields are first populated", () => {
+    const existing = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      origin: {
+        provider: "slack",
+        nativeChannelId: "D111SLACK",
+        threadId: "1700000000.000100",
+      },
+    } satisfies SessionEntry;
+    const slackFollowUp = {
+      Provider: "slack",
+      Surface: "slack",
+      ChatType: "direct",
+      From: "slack:U0001",
+      To: "slack:D111SLACK",
+      AccountId: "slack-team-1",
+    } satisfies Partial<MsgContext>;
+
+    const afterFollowUp = applyOrigin(existing, slackFollowUp);
+
+    expect(afterFollowUp.origin?.surface).toBe("slack");
+    expect(afterFollowUp.origin?.accountId).toBe("slack-team-1");
+    expect(afterFollowUp.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterFollowUp.origin?.threadId).toBe("1700000000.000100");
+  });
+});

--- a/src/gateway/node-pending-work.test.ts
+++ b/src/gateway/node-pending-work.test.ts
@@ -73,6 +73,31 @@ describe("node pending work", () => {
     expect(getNodePendingWorkStateCountForTests()).toBe(0);
   });
 
+  it("assigns default expiry to queued work without explicit ttl", () => {
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const expiresAtMs = (() => {
+      try {
+        const { item } = enqueueNodePendingWork({
+          nodeId: "node-default-expiry",
+          type: "location.request",
+        });
+        const queuedExpiresAtMs = item.expiresAtMs;
+        expect(queuedExpiresAtMs).toBe(1_000 + 24 * 60 * 60_000);
+        if (typeof queuedExpiresAtMs !== "number") {
+          throw new Error("expected queued work expiry");
+        }
+        return queuedExpiresAtMs;
+      } finally {
+        dateNow.mockRestore();
+      }
+    })();
+
+    const drained = drainNodePendingWork("node-default-expiry", { nowMs: expiresAtMs });
+
+    expect(drained.items.map((item) => item.id)).toEqual(["baseline-status"]);
+    expect(getNodePendingWorkStateCountForTests()).toBe(0);
+  });
+
   it("prunes the state entry when all items expire naturally via drain", () => {
     enqueueNodePendingWork({ nodeId: "node-6", type: "location.request", expiresInMs: 5_000 });
     expect(getNodePendingWorkStateCountForTests()).toBe(1);

--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -41,6 +41,7 @@ type DrainResult = {
 const DEFAULT_STATUS_ITEM_ID = "baseline-status";
 const DEFAULT_STATUS_PRIORITY: NodePendingWorkPriority = "default";
 const DEFAULT_PRIORITY: NodePendingWorkPriority = "normal";
+const DEFAULT_PENDING_WORK_TTL_MS = 24 * 60 * 60_000;
 const DEFAULT_MAX_ITEMS = 4;
 const MAX_ITEMS = 10;
 const PRIORITY_RANK: Record<NodePendingWorkPriority, number> = {
@@ -113,11 +114,12 @@ function makeBaselineStatusItem(nowMs: number): NodePendingWorkItem {
   };
 }
 
-function resolvePendingWorkExpiresAtMs(expiresInMs: unknown, nowMs: number): number | null {
-  if (typeof expiresInMs !== "number" || !Number.isFinite(expiresInMs)) {
-    return null;
-  }
-  return resolveExpiresAtMsFromDurationMs(Math.max(1_000, Math.trunc(expiresInMs)), { nowMs }) ?? 0;
+function resolvePendingWorkExpiresAtMs(expiresInMs: unknown, nowMs: number): number {
+  const ttlMs =
+    typeof expiresInMs === "number" && Number.isFinite(expiresInMs)
+      ? Math.max(1_000, Math.trunc(expiresInMs))
+      : DEFAULT_PENDING_WORK_TTL_MS;
+  return resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs }) ?? 0;
 }
 
 export function enqueueNodePendingWork(params: {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -773,6 +773,27 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientScopes()).not.toContain("operator.admin");
   });
 
+  test("caps plugin session message reads at the max limit", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("synthetic-session-read-cap"));
+
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      expect(opts.req.method).toBe("sessions.get");
+      expect(opts.req.params).toEqual({ key: "s-limited", limit: 1_000 });
+      opts.respond(true, { messages: [{ id: "m-cap" }] });
+    });
+
+    await expect(
+      runtime.getSessionMessages({
+        sessionKey: "s-limited",
+        limit: 9e15,
+      }),
+    ).resolves.toEqual({
+      messages: [{ id: "m-cap" }],
+    });
+  });
+
   test("rejects fallback session deletion without minting admin scope", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -297,11 +297,20 @@ async function dispatchGatewayMethod<T>(
   return result.payload as T;
 }
 
+const PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT = 1_000;
+
 export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
   const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
+    const limit =
+      params.limit == null || !Number.isFinite(params.limit)
+        ? undefined
+        : Math.min(
+            PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT,
+            Math.max(1, Math.floor(params.limit)),
+          );
     const payload = await dispatchGatewayMethod<{ messages?: unknown[] }>("sessions.get", {
       key: params.sessionKey,
-      ...(params.limit != null && { limit: params.limit }),
+      ...(limit != null && { limit }),
     });
     return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
   };

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -40,7 +40,19 @@ type ServerNotification = {
 
 const CLAUDE_PERMISSION_REPLY_RE = /^(yes|no)\s+([a-km-z]{5})$/i;
 const QUEUE_LIMIT = 1_000;
+const CONVERSATIONS_LIST_LIMIT = 500;
+const MESSAGES_READ_LIMIT = 200;
+const EVENTS_POLL_LIMIT = 200;
+const EVENTS_WAIT_TIMEOUT_LIMIT_MS = 300_000;
 
+function clampPositiveInteger(value: number | undefined, fallback: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(1, Math.floor(value)));
+}
+
+/** Connects the MCP server surface to a Gateway client and queues channel events for polling. */
 export class OpenClawChannelBridge {
   private gateway: GatewayClient | null = null;
   private readonly verbose: boolean;
@@ -159,8 +171,9 @@ export class OpenClawChannelBridge {
     includeLastMessage?: boolean;
   }): Promise<ConversationDescriptor[]> {
     await this.waitUntilReady();
+    const limit = clampPositiveInteger(params?.limit, 50, CONVERSATIONS_LIST_LIMIT);
     const response: SessionListResult = await this.requestGateway("sessions.list", {
-      limit: params?.limit ?? 50,
+      limit,
       search: params?.search,
       includeDerivedTitles: params?.includeDerivedTitles ?? true,
       includeLastMessage: params?.includeLastMessage ?? true,
@@ -192,9 +205,10 @@ export class OpenClawChannelBridge {
     limit = 20,
   ): Promise<NonNullable<ChatHistoryResult["messages"]>> {
     await this.waitUntilReady();
+    const requestLimit = clampPositiveInteger(limit, 20, MESSAGES_READ_LIMIT);
     const response: ChatHistoryResult = await this.requestGateway("chat.history", {
       sessionKey,
-      limit,
+      limit: requestLimit,
     });
     return response.messages ?? [];
   }
@@ -242,7 +256,10 @@ export class OpenClawChannelBridge {
   }
 
   pollEvents(filter: WaitFilter, limit = 20): { events: QueueEvent[]; nextCursor: number } {
-    const events = this.queue.filter((event) => matchEventFilter(event, filter)).slice(0, limit);
+    const eventLimit = clampPositiveInteger(limit, 20, EVENTS_POLL_LIMIT);
+    const events = this.queue
+      .filter((event) => matchEventFilter(event, filter))
+      .slice(0, eventLimit);
     const nextCursor = events.at(-1)?.cursor ?? filter.afterCursor;
     return { events, nextCursor };
   }
@@ -252,6 +269,7 @@ export class OpenClawChannelBridge {
     if (existing) {
       return existing;
     }
+    const waitTimeoutMs = clampPositiveInteger(timeoutMs, 30_000, EVENTS_WAIT_TIMEOUT_LIMIT_MS);
     return await new Promise<QueueEvent | null>((resolve) => {
       const waiter: PendingWaiter = {
         filter,
@@ -261,11 +279,9 @@ export class OpenClawChannelBridge {
         },
         timeout: null,
       };
-      if (timeoutMs > 0) {
-        waiter.timeout = setTimeout(() => {
-          waiter.resolve(null);
-        }, timeoutMs);
-      }
+      waiter.timeout = setTimeout(() => {
+        waiter.resolve(null);
+      }, waitTimeoutMs);
       this.pendingWaiters.add(waiter);
     });
   }

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -159,6 +159,39 @@ describe("openclaw channel mcp server", () => {
         );
       });
 
+      test("clamps direct bridge session limits to the public MCP windows", async () => {
+        const sessionKey = "agent:main:main";
+        const gatewayRequest = vi.fn(async (method: string) => {
+          if (method === "sessions.list") {
+            return { sessions: [] };
+          }
+          if (method === "chat.history") {
+            return { messages: [] };
+          }
+          throw new Error(`unexpected gateway method ${method}`);
+        });
+        const bridge = new OpenClawChannelBridge({} as never, {
+          claudeChannelMode: "off",
+          verbose: false,
+        });
+        attachReadyGateway(bridge, gatewayRequest);
+
+        await bridge.listConversations({ limit: 10_000 });
+        await bridge.readMessages(sessionKey, 10_000);
+
+        expect(gatewayRequest).toHaveBeenNthCalledWith(
+          1,
+          "sessions.list",
+          expect.objectContaining({ limit: 500 }),
+        );
+        // Fork seam: readMessages dispatches chat.history { sessionKey, limit }
+        // (not upstream's sessions.get { key, limit }).
+        expect(gatewayRequest).toHaveBeenNthCalledWith(2, "chat.history", {
+          sessionKey,
+          limit: 200,
+        });
+      });
+
       test("emits Claude channel and permission notifications", async () => {
         const sessionKey = "agent:main:main";
         let mcp: Awaited<ReturnType<typeof connectMcpWithoutGateway>> | null = null;

--- a/src/plugin-sdk/secret-input-schema.ts
+++ b/src/plugin-sdk/secret-input-schema.ts
@@ -25,31 +25,37 @@ const secretInputSchema = z
   .union([
     z.string(),
     z.discriminatedUnion("source", [
-      z.object({
-        source: z.literal("env"),
-        provider: providerSchema,
-        id: z
-          .string()
-          .regex(
-            ENV_SECRET_REF_ID_RE,
-            'Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
-          ),
-      }),
-      z.object({
-        source: z.literal("file"),
-        provider: providerSchema,
-        id: z
-          .string()
-          .refine(
-            isValidFileSecretRefId,
-            'File secret reference id must be an absolute JSON pointer (example: "/providers/openai/apiKey"), or "value" for singleValue mode.',
-          ),
-      }),
-      z.object({
-        source: z.literal("exec"),
-        provider: providerSchema,
-        id: z.string().refine(isValidExecSecretRefId, formatExecSecretRefIdValidationMessage()),
-      }),
+      z
+        .object({
+          source: z.literal("env"),
+          provider: providerSchema,
+          id: z
+            .string()
+            .regex(
+              ENV_SECRET_REF_ID_RE,
+              'Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ (example: "OPENAI_API_KEY").',
+            ),
+        })
+        .strict(),
+      z
+        .object({
+          source: z.literal("file"),
+          provider: providerSchema,
+          id: z
+            .string()
+            .refine(
+              isValidFileSecretRefId,
+              'File secret reference id must be an absolute JSON pointer (example: "/providers/openai/apiKey"), or "value" for singleValue mode.',
+            ),
+        })
+        .strict(),
+      z
+        .object({
+          source: z.literal("exec"),
+          provider: providerSchema,
+          id: z.string().refine(isValidExecSecretRefId, formatExecSecretRefIdValidationMessage()),
+        })
+        .strict(),
     ]),
   ])
   .register(sensitive);

--- a/src/plugins/provider-auth-env-trust.test.ts
+++ b/src/plugins/provider-auth-env-trust.test.ts
@@ -39,6 +39,34 @@ describe("provider auth env trust", () => {
     });
   });
 
+  it("buildApiKeyCredential rejects malformed object SecretRefs", async () => {
+    const { buildApiKeyCredential } = await import("./provider-auth-helpers.js");
+    const malformedRefs = [
+      { source: "env", provider: "default", id: "OPENAI_API_KEY", extra: "x" },
+      { source: "env", provider: "Default", id: "OPENAI_API_KEY" },
+      { source: "env", provider: "default", id: "openai_api_key" },
+      { source: "file", provider: "default", id: "providers/openai/apiKey" },
+      { source: "exec", provider: "vault", id: "vault/../api-key" },
+    ];
+
+    for (const ref of malformedRefs) {
+      expect(() => buildApiKeyCredential("openai", ref as never)).toThrow(
+        "API key SecretRef is invalid.",
+      );
+    }
+  });
+
+  it("buildApiKeyCredential keeps invalid env-template strings as plaintext", async () => {
+    const { buildApiKeyCredential } = await import("./provider-auth-helpers.js");
+    const overlongEnvRef = `\${A${"B".repeat(128)}}`;
+
+    expect(buildApiKeyCredential("openai", overlongEnvRef)).toEqual({
+      type: "api_key",
+      provider: "openai",
+      key: overlongEnvRef,
+    });
+  });
+
   it("resolveRefFallbackInput excludes untrusted workspace plugin env vars", async () => {
     const { resolveRefFallbackInput } = await import("./provider-auth-ref.js");
     const config = { plugins: {} };

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -10,14 +10,14 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   coerceSecretRef,
   DEFAULT_SECRET_PROVIDER_ALIAS,
+  parseEnvTemplateSecretRef,
   type SecretInput,
   type SecretRef,
 } from "../config/types.secrets.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
+import { isValidSecretRef } from "../secrets/ref-contract.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import type { SecretInputMode } from "./provider-auth-types.js";
-
-const ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
 
 const resolveAuthAgentDir = (agentDir?: string) => agentDir ?? resolveOpenClawAgentDir();
 
@@ -34,14 +34,6 @@ export type WriteOAuthCredentialsOptions = {
 
 function buildEnvSecretRef(id: string): SecretRef {
   return { source: "env", provider: DEFAULT_SECRET_PROVIDER_ALIAS, id };
-}
-
-function parseEnvSecretRef(value: string): SecretRef | null {
-  const match = ENV_REF_PATTERN.exec(value);
-  if (!match) {
-    return null;
-  }
-  return buildEnvSecretRef(match[1]);
 }
 
 function resolveProviderDefaultEnvSecretRef(provider: string, config?: OpenClawConfig): SecretRef {
@@ -63,15 +55,25 @@ function resolveApiKeySecretInput(
   input: SecretInput,
   options?: ApiKeyStorageOptions,
 ): SecretInput {
+  if (input !== null && typeof input === "object") {
+    const coercedRef = coerceSecretRef(input);
+    if (!coercedRef || !isValidSecretRef(coercedRef)) {
+      throw new Error("API key SecretRef is invalid.");
+    }
+    return coercedRef;
+  }
   if (options?.secretInputMode === "plaintext") {
     return normalizeSecretInput(input);
   }
   const coercedRef = coerceSecretRef(input);
   if (coercedRef) {
+    if (!isValidSecretRef(coercedRef)) {
+      throw new Error("API key SecretRef is invalid.");
+    }
     return coercedRef;
   }
   const normalized = normalizeSecretInput(input);
-  const inlineEnvRef = parseEnvSecretRef(normalized);
+  const inlineEnvRef = parseEnvTemplateSecretRef(normalized, DEFAULT_SECRET_PROVIDER_ALIAS);
   if (inlineEnvRef) {
     return inlineEnvRef;
   }

--- a/src/secrets/exec-secret-ref-id-parity.test.ts
+++ b/src/secrets/exec-secret-ref-id-parity.test.ts
@@ -57,6 +57,21 @@ describe("exec SecretRef id parity", () => {
     });
   }
 
+  function configAcceptsRef(ref: unknown): boolean {
+    const result = validateConfigObjectRaw({
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: ref,
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    return result.ok;
+  }
+
   for (const id of [...VALID_EXEC_SECRET_REF_IDS, ...INVALID_EXEC_SECRET_REF_IDS]) {
     it(`keeps config/plan/gateway/plugin parity for exec id "${id}"`, () => {
       const expected = isValidExecSecretRefId(id);
@@ -66,6 +81,23 @@ describe("exec SecretRef id parity", () => {
       expect(
         pluginSdkSecretInput.safeParse({ source: "exec", provider: "vault", id }).success,
       ).toBe(expected);
+    });
+  }
+
+  for (const ref of [
+    { source: "env", provider: "default", id: "OPENAI_API_KEY", extra: "x" },
+    { source: "file", provider: "default", id: "value", extra: "x" },
+    { source: "exec", provider: "vault", id: "vault/openai/api-key", extra: "x" },
+  ]) {
+    it(`rejects non-canonical ${ref.source} refs with extra properties across config/gateway/plugin`, () => {
+      expect(configAcceptsRef(ref)).toBe(false);
+      // Fork seam: gateway schema is compiled with ajv, so call the validator
+      // directly (upstream uses TypeBox .Check()).
+      expect(validateGatewaySecretRef(ref)).toBe(false);
+      expect(pluginSdkSecretInput.safeParse(ref).success).toBe(false);
+      // Note: the fork's isSecretsApplyPlan ref check does not reject extra
+      // properties (a separate seam this commit does not modify), so plan-level
+      // parity for extra-property refs is intentionally not asserted here.
     });
   }
 

--- a/src/secrets/ref-contract.test.ts
+++ b/src/secrets/ref-contract.test.ts
@@ -3,7 +3,11 @@ import {
   INVALID_EXEC_SECRET_REF_IDS,
   VALID_EXEC_SECRET_REF_IDS,
 } from "../test-utils/secret-ref-test-vectors.js";
-import { isValidExecSecretRefId, validateExecSecretRefId } from "./ref-contract.js";
+import {
+  isValidExecSecretRefId,
+  isValidSecretRef,
+  validateExecSecretRefId,
+} from "./ref-contract.js";
 
 describe("exec secret ref id validation", () => {
   it("accepts valid exec secret ref ids", () => {
@@ -29,5 +33,21 @@ describe("exec secret ref id validation", () => {
       ok: false,
       reason: "traversal-segment",
     });
+  });
+});
+
+describe("secret ref validation", () => {
+  it("rejects non-canonical refs with extra properties", () => {
+    expect(isValidSecretRef({ source: "env", provider: "default", id: "OPENAI_API_KEY" })).toBe(
+      true,
+    );
+    expect(
+      isValidSecretRef({
+        source: "env",
+        provider: "default",
+        id: "OPENAI_API_KEY",
+        extra: "x",
+      } as never),
+    ).toBe(false);
   });
 });

--- a/src/secrets/ref-contract.ts
+++ b/src/secrets/ref-contract.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_SECRET_PROVIDER_ALIAS,
+  isSecretRef,
+  isValidEnvSecretRefId,
   type SecretRef,
   type SecretRefSource,
 } from "../config/types.secrets.js";
@@ -105,4 +107,21 @@ export function formatExecSecretRefIdValidationMessage(): string {
     'and must not include "." or ".." path segments',
     '(example: "vault/openai/api-key").',
   ].join(" ");
+}
+
+/** Validates a complete SecretRef against the shared provider/source/id grammar. */
+export function isValidSecretRef(ref: SecretRef): boolean {
+  if (!isSecretRef(ref)) {
+    return false;
+  }
+  if (!isValidSecretProviderAlias(ref.provider)) {
+    return false;
+  }
+  if (ref.source === "env") {
+    return isValidEnvSecretRefId(ref.id);
+  }
+  if (ref.source === "file") {
+    return isValidFileSecretRefId(ref.id);
+  }
+  return isValidExecSecretRefId(ref.id);
 }


### PR DESCRIPTION
## Batch 7 selective upstream sync (openclaw → gemmaclaw, 2026-06-22)

Selective Phase-0 follow-up. Base `origin/main` `d6f686b58c` (PR #308). Upstream range surveyed: `6c2c43d63f..4113982fa8` (353 commits / 232 `fix(`). A parallel triage examined the 23 genuinely high-value behavioral candidates against the fork seam; the remaining ~209 commits are Windows `taskkill`/timer-clamp/flag-rejection/QA-lab/deadcode-sqlite/CI infra with no gemmaclaw runtime seam.

Every commit has a focused, fork-native or ported test. Each landed through the per-commit `check:changed` gate (typecheck + lint + the relevant vitest lane).

### Applied (8)

| upstream SHA | title | disposition |
|---|---|---|
| `5be9c929fd` ← `f6d432e545` | fix(gateway): expire default node pending work | applied clean (runtime + test) |
| `038e82acee` ← `b66b4504f8` | fix(gateway): cap plugin session message reads | applied clean (fork-native clamp test) |
| `8063e39f3c` ← `73c988a9c8` | fix(sessions): reset stale per-channel origin fields on channel switch | runtime clean; ported the `deriveSessionMetaPatch` test block (dropped the upstream inbound-event-context block — no fork seam) |
| `6e9207af1a` ← `b50a5aebba` | fix(whatsapp): preserve native quote replies | applied clean; added fork-native test that the native send bypasses a dep override when a quote resolves |
| `41c26108d3` ← `7b46167607` | fix(channels): preserve migrated account policies | adapted (hand-applied runtime + 2 fork-native inheritance/override tests) |
| `b8597f2d6c` ← `8ecdb97b63` | fix(channels): bound capabilities probes | adapted to the fork's local `normalizeTimeout` (wrapped by `resolveChannelCapabilitiesTimeoutMs`); test ported |
| `53692f7374` ← `a39e548ede` | fix(mcp): cap channel bridge request limits | adapted: `readMessages` clamp wired to the fork's `chat.history { sessionKey, limit }` seam (upstream uses `sessions.get { key, limit }`); dropped 3 upstream-only `PENDING_*` context consts; fork-native clamp test |
| `58e899de9b` ← `6bfe7a2b06` | fix(secrets): enforce canonical secret refs | **deferred from Batch 6**, now adapted: reconstructed `isValidSecretRef` (absent in fork) from fork-local `isSecretRef`+`isValidEnvSecretRefId`; `.strict()` on env/file/exec schemas; `provider-auth-helpers` validates coerced refs + swaps local `ENV_REF_PATTERN`/`parseEnvSecretRef` for canonical `parseEnvTemplateSecretRef`. Tests adapted to fork ajv gateway validator; extra-property parity omits plan-level assertion (fork `isSecretsApplyPlan` does not reject extra props — separate seam) |

### Skipped / deferred (15)

- **`f87f30d429`** fix(harness): preserve prompt input range — **DEFER again** (`prompt-compaction-hook-helpers.ts` deeply diverged at the touched lines).
- **`c2ee9b0be8`** preserve owner MCP tools for agent RPC — DEFER (deep MCP-capture seam divergence in `cli-runner`).
- **`5d1e649aea`** route mobile exec approvals to reviewer device — DEFER (gateway approval-runtime layer substantially diverged).
- **`84cf64770f`** whatsapp Baileys retry/cache hooks — DEFER (files present, fix absent, but `readWhatsAppBaileysCacheEntry` seam needs deeper design).
- **`a60947fb3e`**, **`2f33999898`** (agents cache-stable / preflight history) — SKIP, already implemented in fork.
- **`12c34fc3a9`**, **`c037a34ba7`**, **`108d6d7eca`**, **`4cb94cc2cf`**, **`3e1d3c5feb`**, **`4b881509eb`**, **`2cafbd0774`**, **`2bdcc8314d`** — SKIP, no fork seam (files absent or test-only refactors).
- **`af3e509ab8`** remove private auth monitor defaults — DEFER (split commit; shell/service edits apply, but two config edits need review).

### Verification

- Node 22. Per-commit `check:changed` green for all 8 (typecheck + lint + relevant vitest lane).
- Targeted secrets re-run: `src/secrets/ref-contract.test.ts` + `exec-secret-ref-id-parity.test.ts` (41) + `provider-auth-env-trust.test.ts` (6) — all pass.
- Full `pnpm build` + `pnpm check:changed` + CLI help checks (`--version`, `setup --help`, `backup --help`, `backup restore --help`) — see comments.

No setup/sandbox/runtime-provider/backup/restore/local-model/shared-folder/generated-config behavior changed, so the Docker setup-live-smoke is not required for this batch.

**Batch 8 resume point:** upstream/main HEAD at this batch start was `4113982fa8`; resume curated survey from there. First re-check the deferred `f87f30d429`, `c2ee9b0be8`, `5d1e649aea`, `84cf64770f`, `af3e509ab8`.
