### PR TITLE
fix: gemmaclaw --version prints Gemmaclaw not OpenClaw

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -459,7 +459,11 @@ function tryOutputLauncherVersion(argv) {
     }
     const version = resolveLauncherVersion();
     const commit = resolveLauncherCommit();
-    process.stdout.write(commit ? `OpenClaw ${version} (${commit})\n` : `OpenClaw ${version}\n`);
+    // Keep this branded product name in sync with the --help banner
+    // (src/cli/banner.ts "💎 Gemmaclaw") and the dist version paths
+    // (src/entry.version-fast-path.ts, src/cli/program/help.ts). This launcher
+    // fast-path runs before dist loads and is what `gemmaclaw --version` hits.
+    process.stdout.write(commit ? `Gemmaclaw ${version} (${commit})\n` : `Gemmaclaw ${version}\n`);
     return true;
   } catch {
     return false;

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -132,13 +132,35 @@ describe("configureProgramHelp", () => {
   });
 
   it("prints version and exits immediately when version flags are present", () => {
+    // argv[1] is "openclaw" (the gemmaclaw bin re-execs openclaw.mjs, so
+    // CLI_NAME resolves to "openclaw" at runtime). The version line must still
+    // be branded "Gemmaclaw", matching the --help banner and launcher.
     process.argv = ["node", "openclaw", "--version"];
-    expectVersionExit({ expectedVersion: "OpenClaw 9.9.9-test (abc1234)" });
+    expectVersionExit({ expectedVersion: "Gemmaclaw 9.9.9-test (abc1234)" });
   });
 
   it("prints version and exits immediately without commit metadata", () => {
     process.argv = ["node", "openclaw", "--version"];
     resolveCommitHashMock.mockReturnValue(null);
-    expectVersionExit({ expectedVersion: "OpenClaw 9.9.9-test" });
+    expectVersionExit({ expectedVersion: "Gemmaclaw 9.9.9-test" });
+  });
+
+  it("brands the version line Gemmaclaw and never OpenClaw", () => {
+    process.argv = ["node", "openclaw", "--version"];
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? ""}`);
+    }) as typeof process.exit);
+
+    try {
+      const program = makeProgramWithCommands();
+      expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
+      const printed = logSpy.mock.calls.at(0)?.[0] as string;
+      expect(printed.startsWith("Gemmaclaw ")).toBe(true);
+      expect(printed).not.toContain("OpenClaw");
+    } finally {
+      logSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -114,7 +114,12 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasFlag(process.argv, "--version") ||
     hasRootVersionAlias(process.argv)
   ) {
-    const brandName = CLI_NAME === "openclaw" ? "OpenClaw" : "Gemmaclaw";
+    // Always brand the version line "Gemmaclaw", matching the --help banner
+    // (src/cli/banner.ts "💎 Gemmaclaw") and the launcher fast-path
+    // (openclaw.mjs). The gemmaclaw bin re-execs openclaw.mjs, so CLI_NAME
+    // resolves to "openclaw" at runtime; a CLI_NAME ternary would always pick
+    // the upstream "OpenClaw" string and drift from the rest of the branding.
+    const brandName = "Gemmaclaw";
     const commit = resolveCommitHash({ moduleUrl: import.meta.url });
     console.log(
       commit

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -259,7 +259,10 @@ describe("openclaw launcher", () => {
     );
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe("OpenClaw 1.2.3-test (abcdef0)\n");
+    // Launcher fast-path must brand the version line "Gemmaclaw" (matching the
+    // --help banner and dist version paths), never the upstream "OpenClaw".
+    expect(result.stdout).toBe("Gemmaclaw 1.2.3-test (abcdef0)\n");
+    expect(result.stdout).not.toContain("OpenClaw");
     expect(result.stderr).toBe("");
   });
 


### PR DESCRIPTION
## Problem

The published npm package `gemmaclaw@latest` prints the wrong product name on its `--version` code path:

```
$ gemmaclaw --version
OpenClaw 2026.8.2 (30fd4bb)   # ❌ should read "Gemmaclaw"
```

The `--help` banner is correctly branded (`💎 Gemmaclaw …`), so this was an isolated discrepancy on the version-string path that ships on the **default install path** (`npm install gemmaclaw` → `gemmaclaw --version`).

## Root cause

`gemmaclaw` is the bin, but `gemmaclaw.mjs` re-execs `node openclaw.mjs …` as a child process. In that child, `process.argv[1]` basename is `openclaw`, so `resolveCliName()` returns `"openclaw"`. Two `--version` code paths keyed off that name and therefore always picked the upstream "OpenClaw" string:

1. **`openclaw.mjs` launcher fast-path** (`tryOutputLauncherVersion`) — runs before `dist/` loads and hard-coded `OpenClaw ${version}`. This is what the simple `gemmaclaw --version` invocation actually hits.
2. **`src/cli/program/help.ts`** — the Commander fallback used `CLI_NAME === "openclaw" ? "OpenClaw" : "Gemmaclaw"`, which can never resolve to "Gemmaclaw" in the gemmaclaw product.

The `--help` banner (`src/cli/banner.ts`) and the dist version fast-path (`src/entry.version-fast-path.ts`) already hard-code "Gemmaclaw", which is why only `--version` drifted.

## Fix

Brand both `--version` paths "Gemmaclaw", consistent with the `--help` banner and dist fast-path:

- `openclaw.mjs` — launcher version line → `Gemmaclaw ${version} (${commit})`
- `src/cli/program/help.ts` — `const brandName = "Gemmaclaw"`

Both sites carry a sync comment pointing at the other branded version sources so a future upstream sync re-applies the override instead of reverting it.

## Tests

- `src/cli/program/help.test.ts` — updated the two version assertions `OpenClaw → Gemmaclaw` and added a regression test asserting the version line starts with `Gemmaclaw` and never contains `OpenClaw` (runs with `argv[1] = "openclaw"`, the exact published-binary condition).
- `test/openclaw-launcher.e2e.test.ts` — updated the launcher version assertion `OpenClaw → Gemmaclaw` and added `not.toContain("OpenClaw")`.
- `src/entry.version-fast-path.test.ts` already asserts `Gemmaclaw` (unchanged).

## Verification (local, Node 22, this branch)

```
$ node gemmaclaw.mjs --version
Gemmaclaw 2026.8.2 (918fcf0)      # ✅
$ node gemmaclaw.mjs -V
Gemmaclaw 2026.8.2 (918fcf0)      # ✅
$ node gemmaclaw.mjs --help | head -1
💎 Gemmaclaw 2026.8.2 (918fcf0) — …   # ✅ banner intact, no regression
```

`pnpm check:changed`: conflict-markers / typecheck-all / lint / runtime-import-cycles all green. The only test failures in the full local suite are pre-existing, network/timeout-bound extension tests (browser CDP + venice/ollama `EAI_AGAIN`, telegram media-group 120s timeouts) unrelated to this change.

## Notes

- Scope is intentionally limited to the `--version` output and its tests. The same `cliName === "openclaw"` pattern in `src/cli/program/register.backup.ts` (the `gemmaclaw backup` display name) and the internal `OpenClaw Gateway` service descriptions are left untouched.
- The corrected branding will appear on the **next published version** after this merges.
