### PR TITLE
maintenance: upstream openclaw batch 8 selective sync (2026-06-23)

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -2,7 +2,10 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryLightDreamingConfig,
+  resolveMemoryRemDreamingConfig,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
@@ -214,12 +217,23 @@ async function listWorkspaceDailyFiles(workspaceDir: string, limit: number): Pro
 
 function formatDreamingSummary(cfg: OpenClawConfig): string {
   const pluginConfig = resolveMemoryPluginConfig(cfg);
-  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
-  if (!dreaming.enabled) {
-    return "off";
-  }
-  const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
-  return `${dreaming.cron}${timezone} · limit=${dreaming.limit} · minScore=${dreaming.minScore} · minRecallCount=${dreaming.minRecallCount} · minUniqueQueries=${dreaming.minUniqueQueries} · recencyHalfLifeDays=${dreaming.recencyHalfLifeDays} · maxAgeDays=${dreaming.maxAgeDays ?? "none"}`;
+  const light = resolveMemoryLightDreamingConfig({ pluginConfig, cfg });
+  const deep = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
+  const rem = resolveMemoryRemDreamingConfig({ pluginConfig, cfg });
+  const timezone = deep.timezone ?? light.timezone ?? rem.timezone;
+  const formatCron = (cron: string) => (timezone ? `${cron} (${timezone})` : cron);
+  const lightSummary = light.enabled
+    ? `light=${formatCron(light.cron)} · limit=${light.limit} · lookbackDays=${light.lookbackDays}`
+    : null;
+  const remSummary = rem.enabled
+    ? `rem=${formatCron(rem.cron)} · limit=${rem.limit} · lookbackDays=${rem.lookbackDays} · minPatternStrength=${rem.minPatternStrength}`
+    : null;
+  const hasLighterPhase = light.enabled || rem.enabled;
+  const deepLabel = hasLighterPhase ? "deep=" : "";
+  const deepDetails = `${formatCron(deep.cron)} · limit=${deep.limit} · minScore=${deep.minScore} · minRecallCount=${deep.minRecallCount} · minUniqueQueries=${deep.minUniqueQueries} · recencyHalfLifeDays=${deep.recencyHalfLifeDays} · maxAgeDays=${deep.maxAgeDays ?? "none"}`;
+  const deepSummary = deep.enabled ? `${deepLabel}${deepDetails}` : null;
+  const phases = [lightSummary, remSummary, deepSummary].filter(Boolean);
+  return phases.length > 0 ? phases.join(" · ") : "off";
 }
 
 function formatAuditCounts(audit: ShortTermAuditSummary): string {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -384,6 +384,74 @@ describe("memory cli", () => {
     });
   });
 
+  it("reports all active dreaming phases (light + rem + deep) during status", async () => {
+    // Before the fix the status summary only described the deep
+    // (short-term-promotion) phase, so an operator running light or rem
+    // dreaming saw nothing about them. The fix reports every enabled phase.
+    loadConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                timezone: "UTC",
+                cron: "0 3 * * *",
+                limit: 7,
+                minScore: 0.72,
+                minRecallCount: 4,
+                minUniqueQueries: 2,
+                recencyHalfLifeDays: 5,
+                maxAgeDays: 30,
+                light: {
+                  enabled: true,
+                  cron: "5 * * * *",
+                  limit: 4,
+                  lookbackDays: 2,
+                },
+                rem: {
+                  enabled: true,
+                  cron: "0 6 * * 0",
+                  limit: 3,
+                  lookbackDays: 9,
+                  minPatternStrength: 0.81,
+                },
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main", default: true }],
+      },
+    });
+
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus({ workspaceDir: "/tmp/openclaw" }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status", "--agent", "main"]);
+
+    // The fix labels each enabled phase; pre-fix the summary only described the
+    // deep phase with no "light="/"rem="/"deep=" markers.
+    const dreamingLine = log.mock.calls
+      .map((call) => String(call[0]))
+      .find((line) => line.includes("Dreaming:"));
+    expect(dreamingLine).toBeDefined();
+    expect(dreamingLine).toContain("light=");
+    expect(dreamingLine).toContain("lookbackDays=2");
+    expect(dreamingLine).toContain("rem=");
+    expect(dreamingLine).toContain("minPatternStrength=");
+    expect(dreamingLine).toContain("deep=");
+    expect(dreamingLine).toContain("minScore=");
+    expect(close).toHaveBeenCalled();
+  });
+
   it("reports dreaming blocked when another explicit heartbeat agent excludes main", async () => {
     loadConfig.mockReturnValue({
       plugins: {

--- a/src/agents/pi-embedded-helpers/failover-matches.test.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.test.ts
@@ -3,6 +3,7 @@ import {
   isAuthErrorMessage,
   isBillingErrorMessage,
   isRateLimitErrorMessage,
+  isTimeoutErrorMessage,
 } from "./failover-matches.js";
 
 describe("Z.ai vendor error codes (#48988)", () => {
@@ -75,5 +76,37 @@ describe("Z.ai vendor error codes (#48988)", () => {
     it("auth still classified correctly", () => {
       expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
     });
+  });
+});
+
+describe("generic assistant error text classification (#93931)", () => {
+  it("classifies the bare 'LLM request failed.' as a timeout (transient)", () => {
+    // The generic error text wraps local-provider availability failures (model
+    // not loaded, endpoint unreachable) that should engage retry/fallback. The
+    // fork produces this exact text from assistant-failover.ts and the
+    // lifecycle handlers.
+    expect(isTimeoutErrorMessage("LLM request failed.")).toBe(true);
+  });
+
+  it("classifies lowercase 'llm request failed.' as a timeout (case-insensitive)", () => {
+    expect(isTimeoutErrorMessage("llm request failed.")).toBe(true);
+  });
+
+  it("does NOT match the schema-rejection variant via the exact-match pattern", () => {
+    // A format/schema error is not transient; it must fall through to its own
+    // classification, not the generic LLM-request-failed match.
+    expect(
+      isTimeoutErrorMessage(
+        "LLM request failed: provider rejected the request schema or tool payload.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match the connection-refused variant via the exact-match pattern", () => {
+    // The colon-suffixed sanitized variant must not be caught by the strict
+    // /^llm request failed\.$/i regex.
+    expect(
+      isTimeoutErrorMessage("LLM request failed: connection refused by the provider endpoint."),
+    ).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -126,6 +126,17 @@ const ERROR_PATTERNS = {
     // falls through to reason=unknown (#58315).
     /\boperation was aborted\b/i,
     /\bstream (?:was )?(?:closed|aborted)\b/i,
+    // The generic assistant error text "LLM request failed." is produced when
+    // the underlying provider error cannot be formatted into a specific
+    // category. For local providers (LM Studio, Ollama, llama.cpp) this wraps
+    // connection/availability failures when the model is not loaded or the
+    // endpoint is unreachable. Without this match, cron retry and
+    // payload.fallbacks never engage because the error is not classified as any
+    // transient type (#93931). Use a strict exact-match regex so variants like
+    // "LLM request failed: provider rejected the request schema or tool payload."
+    // (a format/schema error, not transient) are NOT caught here — they fall
+    // through to their own pattern classifications.
+    /^llm request failed\.$/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -6,9 +6,17 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isInternalNonDeliveryChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
+
+function isSystemEventProvider(provider?: string): boolean {
+  return provider === "heartbeat" || provider === "cron-event" || provider === "exec-event";
+}
 
 const mergeOrigin = (
   existing: SessionOrigin | undefined,
@@ -22,9 +30,21 @@ const mergeOrigin = (
   // moving Slack -> Telegram, or between Slack accounts). Channel-keyed fields belong to the prior
   // channel; drop them so an inbound that omits them does not keep reactions, native threading, and
   // status reads pointed at the previous channel.
+  // Only a real, deliverable channel switch should reset the bound identity. A
+  // non-delivery turn (gateway webchat send, heartbeat/cron/webhook tick,
+  // voice, internal sessions_send, or a system-event provider) derives its
+  // origin provider as an internal channel and must not wipe the session's live
+  // native channel/thread identity even though the session never left it.
+  const nextProvider = next?.provider;
+  const nextIsDeliverableChannel =
+    nextProvider != null &&
+    nextProvider !== INTERNAL_MESSAGE_CHANNEL &&
+    !isInternalNonDeliveryChannel(nextProvider) &&
+    !isSystemEventProvider(nextProvider);
   const channelChanged =
     existing != null &&
-    ((existing.provider != null && next?.provider != null && next.provider !== existing.provider) ||
+    nextIsDeliverableChannel &&
+    ((existing.provider != null && nextProvider !== existing.provider) ||
       (existing.surface != null && next?.surface != null && next.surface !== existing.surface) ||
       (existing.accountId != null &&
         next?.accountId != null &&
@@ -72,9 +92,7 @@ export function deriveSessionOrigin(
   ctx: MsgContext,
   opts?: { skipSystemEventOrigin?: boolean },
 ): SessionOrigin | undefined {
-  const isSystemEventProvider =
-    ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event";
-  if (opts?.skipSystemEventOrigin && isSystemEventProvider) {
+  if (opts?.skipSystemEventOrigin && isSystemEventProvider(ctx.Provider)) {
     return undefined;
   }
   const label = normalizeOptionalString(resolveConversationLabel(ctx));

--- a/src/config/sessions/origin-channel-switch.test.ts
+++ b/src/config/sessions/origin-channel-switch.test.ts
@@ -157,3 +157,73 @@ describe("session origin across a channel switch", () => {
     expect(afterFollowUp.origin?.threadId).toBe("1700000000.000100");
   });
 });
+
+describe("session origin across a non-delivery turn", () => {
+  const webchatTurn = {
+    Provider: "webchat",
+    Surface: "webchat",
+    OriginatingChannel: "webchat",
+    ChatType: "direct",
+  } satisfies Partial<MsgContext>;
+
+  it("keeps the bound Slack channel identity across a non-deliver gateway webchat turn", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterWebchat = applyOrigin(afterSlack, webchatTurn);
+
+    expect(afterWebchat.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterWebchat.origin?.nativeDirectUserId).toBe("U0001");
+    expect(afterWebchat.origin?.accountId).toBe("slack-team-1");
+    expect(afterWebchat.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("keeps the bound channel identity across a heartbeat tick", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterHeartbeat = applyOrigin(afterSlack, {
+      Provider: "heartbeat",
+      Surface: "heartbeat",
+      OriginatingChannel: "heartbeat",
+      ChatType: "direct",
+    } satisfies Partial<MsgContext>);
+
+    expect(afterHeartbeat.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterHeartbeat.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("keeps the bound channel identity across a cron-event turn that omits the channel", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterCron = applyOrigin(afterSlack, {
+      Provider: "cron-event",
+      ChatType: "direct",
+      From: "cron:job_REDACTED",
+      To: "cron:job_REDACTED",
+    } satisfies Partial<MsgContext>);
+
+    expect(afterCron.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterCron.origin?.nativeDirectUserId).toBe("U0001");
+    expect(afterCron.origin?.accountId).toBe("slack-team-1");
+    expect(afterCron.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("keeps the bound channel identity across an exec-event turn that omits the channel", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterExec = applyOrigin(afterSlack, {
+      Provider: "exec-event",
+      ChatType: "direct",
+      From: "exec:run_REDACTED",
+      To: "exec:run_REDACTED",
+    } satisfies Partial<MsgContext>);
+
+    expect(afterExec.origin?.nativeChannelId).toBe("D111SLACK");
+    expect(afterExec.origin?.threadId).toBe("1700000000.000100");
+  });
+
+  it("still adopts a real channel after an intervening non-delivery turn", () => {
+    const afterSlack = applyOrigin(undefined, slackTurn);
+    const afterWebchat = applyOrigin(afterSlack, webchatTurn);
+    const afterTelegram = applyOrigin(afterWebchat, telegramTurn);
+
+    expect(afterTelegram.origin?.provider).toBe("telegram");
+    expect(afterTelegram.origin?.nativeChannelId).toBeUndefined();
+    expect(afterTelegram.origin?.threadId).toBeUndefined();
+  });
+});

--- a/src/cron/service.add-recompute-drops-due-every.test.ts
+++ b/src/cron/service.add-recompute-drops-due-every.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createFinishedBarrier,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+describe("add() must not drop a due every-job's pending run", () => {
+  it("preserves a due every-job nextRunAtMs when an unrelated job is added", async () => {
+    const store = await makeStorePath();
+    const base = Date.parse("2025-12-13T00:00:00.000Z");
+
+    const finished = createFinishedBarrier();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      onEvent: finished.onEvent,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "every 10s",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 10_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "tick" },
+    });
+    const jobId = job.id;
+    expect(job.state.nextRunAtMs).toBe(base + 10_000);
+
+    vi.setSystemTime(new Date(base + 10_000 + 5));
+    const firstRun = finished.waitForOk(jobId);
+    await vi.runOnlyPendingTimersAsync();
+    await firstRun;
+
+    let current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    const lastRunAtMs = current.state.lastRunAtMs!;
+    const dueSlot = current.state.nextRunAtMs!;
+    expect(dueSlot).toBe(lastRunAtMs + 10_000);
+
+    vi.setSystemTime(new Date(dueSlot + 50));
+    const nowDue = dueSlot + 50;
+
+    await cron.add({
+      name: "unrelated daily",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "daily" },
+    });
+
+    current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    expect(current.state.lastRunAtMs).toBe(lastRunAtMs);
+    expect(current.state.nextRunAtMs).toBeLessThanOrEqual(nowDue);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service.remove-recompute-drops-due-every.test.ts
+++ b/src/cron/service.remove-recompute-drops-due-every.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+  writeCronStoreSnapshot,
+} from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+const base = Date.parse("2025-12-13T00:00:00.000Z");
+
+// A recurring every-job whose slot at base - 5_000 is due (now === base) but
+// has not yet fired (lastRunAtMs precedes it). The explicit anchor makes the
+// fork's next-run computation deterministic.
+function dueEveryJob(): CronJob {
+  return {
+    id: "due-every",
+    name: "due every 10s",
+    enabled: true,
+    createdAtMs: base - 3_600_000,
+    updatedAtMs: base - 10_000,
+    schedule: { kind: "every", everyMs: 10_000, anchorMs: base - 5_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "tick" },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: base - 5_000, lastRunAtMs: base - 15_000 },
+  } as unknown as CronJob;
+}
+
+function jobToRemove(): CronJob {
+  return {
+    id: "to-remove",
+    name: "obsolete job",
+    enabled: true,
+    createdAtMs: base - 3_600_000,
+    updatedAtMs: base - 10_000,
+    schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "noop" },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: base + 3_600_000 },
+  } as unknown as CronJob;
+}
+
+// Companion to the add() regression: remove() must load with skipRecompute and
+// use the maintenance recompute (which never advances a present past-due slot)
+// rather than letting the cold-store load run the full recomputeNextRuns. The
+// pre-fix remove() ran ensureLoaded() without skipRecompute, so the post-load
+// recomputeNextRuns advanced the due slot a full interval and silently dropped
+// the pending run (#94323). remove() must be the first op so it triggers the
+// cold load itself (a prior read would warm the store and mask the bug).
+describe("remove() must not drop a due every-job's pending run", () => {
+  it("preserves a due sibling's pending slot on cold-store remove", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [dueEveryJob(), jobToRemove()],
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    const result = await cron.remove("to-remove");
+    expect(result).toEqual({ ok: true, removed: true });
+
+    // Pre-fix the cold load advanced this to base + 5_000 (the next aligned
+    // slot), dropping the due-but-unfired occurrence. The fix preserves it.
+    const dueEvery = cron.getJob("due-every");
+    expect(dueEvery?.state.nextRunAtMs).toBe(base - 5_000);
+    expect(dueEvery?.state.lastRunAtMs).toBe(base - 15_000);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -249,12 +249,16 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
 export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
-    await ensureLoaded(state);
+    await ensureLoaded(state, { skipRecompute: true });
     const job = createJob(state, input);
     state.store?.jobs.push(job);
 
-    // Defensive: recompute all next-run times to ensure consistency
-    recomputeNextRuns(state);
+    // Maintenance recompute backfills missing next-run times but never advances
+    // a present past-due slot, so an unrelated add no longer silently discards a
+    // due-but-unfired recurring occurrence on a sibling job (#94323). The full
+    // recomputeNextRuns advanced nextRunAtMs whenever now >= nextRun, dropping
+    // the run with no error and no log. Matches every other ops.ts caller.
+    recomputeNextRunsForMaintenance(state);
 
     await persist(state);
     armTimer(state);
@@ -332,13 +336,18 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
 export async function remove(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     warnIfDisabled(state, "remove");
-    await ensureLoaded(state);
+    await ensureLoaded(state, { skipRecompute: true });
     const before = state.store?.jobs.length ?? 0;
     if (!state.store) {
       return { ok: false, removed: false } as const;
     }
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
     const removed = (state.store.jobs.length ?? 0) !== before;
+
+    // Use maintenance recompute (never advances a present past-due slot) so a
+    // remove cannot silently drop a due-but-unfired run on a sibling job (#94323).
+    recomputeNextRunsForMaintenance(state);
+
     await persist(state);
     armTimer(state);
     if (removed) {

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -113,17 +113,23 @@ export function mergeDeliveryContext(
     normalizedPrimary?.channel &&
     normalizedFallback?.channel &&
     normalizedPrimary.channel !== normalizedFallback.channel;
+  const accountsConflict =
+    normalizedPrimary?.accountId &&
+    normalizedFallback?.accountId &&
+    normalizedPrimary.accountId !== normalizedFallback.accountId;
+  const routesConflict = channelsConflict || accountsConflict;
   return normalizeDeliveryContext({
     channel: normalizedPrimary?.channel ?? normalizedFallback?.channel,
-    // Keep route fields paired to their channel; avoid crossing fields between
-    // unrelated channels during session context merges.
-    to: channelsConflict
+    // Keep route fields paired to their channel and account; avoid crossing
+    // fields between unrelated channels or accounts during session context
+    // merges (a fallback route on a different bot account must not be inherited).
+    to: routesConflict
       ? normalizedPrimary?.to
       : (normalizedPrimary?.to ?? normalizedFallback?.to),
-    accountId: channelsConflict
+    accountId: routesConflict
       ? normalizedPrimary?.accountId
       : (normalizedPrimary?.accountId ?? normalizedFallback?.accountId),
-    threadId: channelsConflict
+    threadId: routesConflict
       ? normalizedPrimary?.threadId
       : (normalizedPrimary?.threadId ?? normalizedFallback?.threadId),
   });

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -98,6 +98,20 @@ describe("delivery context helpers", () => {
     expect(merged?.threadId).toBeUndefined();
   });
 
+  it("does not inherit route fields from a different account on the same channel", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram", accountId: "bot-a" },
+      { channel: "telegram", to: "123", accountId: "bot-b", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: undefined,
+      accountId: "bot-a",
+    });
+    expect(merged?.threadId).toBeUndefined();
+  });
+
   it("inherits missing route fields when channels match", () => {
     const merged = mergeDeliveryContext(
       { channel: "demo-channel" },

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -1,2 +1,20 @@
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
 export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
+
+// Internal pseudo-channels that never correspond to a real deliverable surface.
+// Turns whose provider is one of these (heartbeat/cron ticks, webhook fires,
+// voice, internal sessions_send) must not be treated as a cross-channel switch
+// that resets a session's bound native channel identity.
+const INTERNAL_NON_DELIVERY_CHANNELS = [
+  "heartbeat",
+  "cron",
+  "webhook",
+  "voice",
+  "sessions_send",
+] as const;
+
+export function isInternalNonDeliveryChannel(
+  value: string,
+): value is (typeof INTERNAL_NON_DELIVERY_CHANNELS)[number] {
+  return (INTERNAL_NON_DELIVERY_CHANNELS as readonly string[]).includes(value);
+}

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -24,6 +24,7 @@ export {
 } from "./message-channel-normalize.js";
 export {
   INTERNAL_MESSAGE_CHANNEL,
+  isInternalNonDeliveryChannel,
   type InternalMessageChannel,
 } from "./message-channel-constants.js";
 import {


### PR DESCRIPTION
## upstream-sync Batch 8 (openclaw -> gemmaclaw, 2026-06-23)

Curated selective-sync continuing Batch 7 (PR #309). Surveyed the upstream range `4113982fa8..c51661f1bf` (427 non-merge commits) via a 24-agent parallel triage, one agent per high-value candidate plus a broad survey. Of the 18 curated candidates + 5 Batch-7-deferred + survey findings, **5 commits** had a genuinely clean fork seam with a real product impact and were ported, each as its own commit with a fork-native regression test (verified failing pre-fix / passing post-fix).

### Ported (5)

| commit | upstream | file(s) | disposition |
|---|---|---|---|
| `9a9cf1cf4a` | `8fdb1b61db` (#94062) | `src/agents/pi-embedded-helpers/failover-matches.ts` (+test) | classify the bare `LLM request failed.` text as a transient timeout so cron retry / payload.fallbacks engage for local-provider (Gemma/Ollama/LM Studio/llama.cpp) availability failures. Strict exact-match regex; colon-suffixed variants fall through. Fork path `pi-embedded-helpers/` (upstream `embedded-agent-helpers/`). |
| `7680a2e2fc` | `1ed8592467` | `src/utils/delivery-context.shared.ts` (+test) | `mergeDeliveryContext` now treats a differing `accountId` (same channel, e.g. a second bot account) as a route conflict, so route fields are not inherited across accounts. Applied clean. |
| `b2e582836e` | `c854e4e93f` (#94323) | `src/cron/service/ops.ts` (+2 tests) | **cron data-loss fix.** `add()`/`remove()` used the full `recomputeNextRuns` (and a non-`skipRecompute` cold load), advancing a sibling recurring job's due-but-unfired slot a full interval and silently dropping the run. Switched both to `ensureLoaded(..., { skipRecompute: true })` + `recomputeNextRunsForMaintenance`, matching every other ops.ts caller. Cold-store remove regression test asserts via the in-memory `getJob()` (the fork persists runtime state to a split `<store>-state.json`). |
| `9865376f81` | `fc15c58715` (#93113) | `extensions/memory-core/src/cli.runtime.ts` (+test) | `memory status` now reports every enabled dreaming phase (light/rem/deep) instead of only the deep phase. Dropped the upstream `maxPromotedSnippetTokens` field (fork deep config does not carry it). |
| `f5e8fa9b50` | `f257c0609d` (#95467) | `src/config/sessions/metadata.ts`, `src/utils/message-channel-constants.ts`, `src/utils/message-channel.ts` (+test) | keep the bound native channel identity across non-delivery turns (gateway webchat send, heartbeat/cron/webhook/voice tick, system-event providers). `mergeOrigin` now gates the channel-switch reset on the next turn being a real deliverable channel. Added `isInternalNonDeliveryChannel` to the fork's constants. |

### Deferred to Batch 9
- `b8434386b8` acp resume-required recovery — the fork's acpx adapter delegates `runTurn` and surfaces no structured `detailCode`; the "could not be resumed" message originates from the acpx library. Porting the detailCode-keyed recovery would be dead plumbing unless the acpx adapter is also wired to emit `SESSION_RESUME_REQUIRED` (deep-seam design), and gemmaclaw's ACP backend (Claude Code) is already covered by the existing reason-text regex; the Kiro gap that motivated the fix is not a gemmaclaw backend.
- `5e915e1f89` cron cloud idle watchdog (signature + callsite change; gemmaclaw is local-first so limited benefit), `ef62076789` webchat session status (needs `runSessionKey` infra), `a0ed4273ee` bound route agent (fallbackAgentId across 5 files + ingress), `2dc2d73b07` webchat reconnect (8 files incl UI), `e90fb67641` message-tool mirror replay (session-file-repair stub), `3675c01410` /status verbose (provenance infra), `1662b07810` cron CLI fallbacks (12-file schema divergence), `7c8ca26364` setup health hints (setup seam — kept this batch smoke-free), `b335381247` Windows QMD (Windows-only value for a Linux fork), `c2ee9b0be8`/`5d1e649aea`/`84cf64770f` (Batch-7-deferred, still deep), `90fb2ee4e1` TLS empty-cert (reorganized tls file, narrow config edge).

### Skipped (no fork seam / already implemented / irrelevant)
`50e7a546a1` + `965d1fff3f` already implemented; `f87f30d429` + `037ee6de0a` no fork seam; `af3e509ab8` Termux/Android private auth-monitor (irrelevant to gemmaclaw).

### Local gate (Node 22)
- `pnpm build` exit 0
- `pnpm check:changed` exit 0 — typecheck core/core-tests/extensions/extension-tests clean, lint 0/0, 13 test targets pass
- CLI `setup` / `backup` / `backup restore` `--help` all succeed with Gemmaclaw branding
- Docker setup-live-smoke **not required**: no setup/sandbox/backup/local-model/shared-folder/generated-config seam touched (same disposition as Batch 7)

> Note: `gemmaclaw.mjs --version` prints an `OpenClaw` banner — this is pre-existing fork drift (this PR touches zero version/branding files) and is owned by a separate version-branding task.
