### PR TITLE
Fix mobile overflow on generated community pages

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -4514,7 +4514,7 @@ CSS = """
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -4522,6 +4522,7 @@ CSS = """
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -5706,12 +5707,58 @@ CSS = """
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -5788,7 +5835,8 @@ CSS = """
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -5811,7 +5859,8 @@ CSS = """
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/functiongemma-270m-high.html
+++ b/site/benchmark-results/functiongemma-270m-high.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma3-1b__ollama__2026-05-30T05-04-50.html
+++ b/site/benchmark-results/gemma3-1b__ollama__2026-05-30T05-04-50.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma4-12b-q4-high-antirep.html
+++ b/site/benchmark-results/gemma4-12b-q4-high-antirep.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma4-12b-q4-high.html
+++ b/site/benchmark-results/gemma4-12b-q4-high.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma4-12b-q4-nothink.html
+++ b/site/benchmark-results/gemma4-12b-q4-nothink.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma4-26b-q4-high.html
+++ b/site/benchmark-results/gemma4-26b-q4-high.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma4-31b-q4-high.html
+++ b/site/benchmark-results/gemma4-31b-q4-high.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmark-results/gemma4-e4b-q4-high.html
+++ b/site/benchmark-results/gemma4-e4b-q4-high.html
@@ -28,7 +28,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -36,6 +36,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1220,12 +1221,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1302,7 +1349,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1325,7 +1373,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/benchmarking.html
+++ b/site/benchmarking.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/community.html
+++ b/site/community.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/compare.html
+++ b/site/compare.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/enhancements.html
+++ b/site/enhancements.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/goals.html
+++ b/site/goals.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/index.html
+++ b/site/index.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/self-hosting.html
+++ b/site/self-hosting.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;

--- a/site/setup.html
+++ b/site/setup.html
@@ -37,7 +37,7 @@
       --bad: #cf222e;
     }
     * { margin: 0; padding: 0; box-sizing: border-box; min-width: 0; }
-    html { scroll-behavior: smooth; overflow-x: hidden; }
+    html { scroll-behavior: smooth; overflow-x: hidden; width: 100%; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
@@ -45,6 +45,7 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
       overflow-x: hidden;
+      width: 100%;
     }
 
     /* Nav */
@@ -1229,12 +1230,58 @@
 
     /* Responsive */
     @media (max-width: 640px) {
-      h1 { font-size: 2rem; }
+      html,
+      body {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      h1 { font-size: 1.7rem; line-height: 1.25; overflow-wrap: break-word; }
+      h2 { font-size: 1.35rem; line-height: 1.3; overflow-wrap: break-word; }
+      h3 { overflow-wrap: break-word; }
       .tagline { font-size: 1rem; }
-      .nav-inner { padding: 0.5rem 1rem; }
-      .nav-links { gap: 0.75rem; }
-      .nav-links a { font-size: 0.84rem; padding: 0.35rem 0; }
-      .wrap { padding: 1.5rem 1rem 3rem; }
+      .topnav,
+      footer {
+        width: 100vw;
+        max-width: 100vw;
+        overflow-x: hidden;
+      }
+      .nav-inner {
+        width: 100%;
+        max-width: 100vw;
+        padding: 0.5rem 1rem;
+        overflow: hidden;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+      }
+      .nav-links {
+        flex: 1 1 auto;
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        overflow: visible;
+        gap: 0.35rem 0.75rem;
+      }
+      .nav-links a { font-size: 0.82rem; padding: 0.2rem 0; white-space: normal; }
+      .wrap { width: 100%; max-width: 100vw; padding: 1.5rem 1rem 3rem; overflow-x: hidden; }
+      .wrap > * {
+        max-width: calc(100vw - 2rem);
+      }
+      .wrap p,
+      .wrap li,
+      .field-notes p,
+      .cr-summary,
+      .cr-comment-text {
+        overflow-wrap: break-word;
+        word-break: normal;
+      }
+      .field-notes,
+      .cr-card,
+      .page-toc {
+        width: 100%;
+        max-width: 100%;
+      }
       .page-cards { grid-template-columns: 1fr; }
       .hw-specs { flex-direction: column; gap: 0.25rem; }
       .hw-model { display: grid; grid-template-columns: 1fr 1fr; gap: 0.45rem; align-items: stretch; }
@@ -1311,7 +1358,8 @@
       .benchmark-card-head { align-items: flex-start; }
       .benchmark-score { font-size: 1.35rem; }
       .page-toc {
-        top: 54px;
+        position: static;
+        top: auto;
         grid-template-columns: 1fr;
         gap: 0.45rem;
         padding: 0.55rem;
@@ -1334,7 +1382,8 @@
         word-break: break-word;
       }
       .benchmark-jump-nav {
-        top: 54px;
+        position: static;
+        top: auto;
         gap: 0.35rem;
         padding: 0.45rem;
         border-radius: 10px;


### PR DESCRIPTION
## Summary
- clamp generated site wrappers to the mobile viewport
- let the mobile nav wrap instead of clipping labels
- disable sticky TOC/jump nav on mobile so headings are not covered
- regenerate static site output

## Verification
- pnpm check:changed
- pnpm test:changed
- Playwright 390x844 mobile screenshot: no horizontal overflow, heading visible below TOC
- Playwright 1280x800 desktop screenshot: desktop layout unchanged