### PR TITLE
fix(extensions): rename stale openclaw workspace dep to gemmaclaw

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -5,13 +5,13 @@
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -15,13 +15,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -10,13 +10,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -11,13 +11,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -9,13 +9,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -15,13 +15,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -8,13 +8,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -10,13 +10,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -10,13 +10,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -15,13 +15,13 @@
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
     "@types/jsonwebtoken": "^9.0.10",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -8,13 +8,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -9,13 +9,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -9,13 +9,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -13,13 +13,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/qa-matrix/package.json
+++ b/extensions/qa-matrix/package.json
@@ -10,13 +10,13 @@
   "devDependencies": {
     "@openclaw/matrix": "workspace:*",
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -14,13 +14,13 @@
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
     "@types/ws": "^8.18.1",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -11,13 +11,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -10,13 +10,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -12,13 +12,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -8,13 +8,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -9,13 +9,13 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "workspace:*"
+    "gemmaclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.20"
+    "gemmaclaw": ">=2026.4.20"
   },
   "peerDependenciesMeta": {
-    "openclaw": {
+    "gemmaclaw": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,7 +317,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -510,7 +510,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -557,7 +557,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -622,7 +622,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -681,7 +681,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -753,7 +753,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -766,7 +766,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -788,7 +788,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -820,7 +820,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -892,7 +892,7 @@ importers:
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -905,7 +905,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -921,7 +921,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1006,7 +1006,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1031,7 +1031,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1047,7 +1047,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1081,7 +1081,7 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1228,7 +1228,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1303,7 +1303,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1356,7 +1356,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1397,7 +1397,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 
@@ -1413,7 +1413,7 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      openclaw:
+      gemmaclaw:
         specifier: workspace:*
         version: link:../..
 

--- a/scripts/sync-plugin-versions.ts
+++ b/scripts/sync-plugin-versions.ts
@@ -21,20 +21,31 @@ type PackageJson = {
 
 const OPENCLAW_VERSION_RANGE_RE = /^>=\d{4}\.\d{1,2}\.\d{1,2}(?:[-.][^"\s]+)?$/u;
 
+// Bundled extensions declare their host package as "gemmaclaw"; "openclaw"
+// remains recognized for plugins ported from upstream.
+const HOST_PACKAGE_DEPENDENCY_KEYS = ["gemmaclaw", "openclaw"] as const;
+
 function syncOpenClawDependencyRange(
   deps: Record<string, string> | undefined,
   targetVersion: string,
 ): boolean {
-  const current = deps?.openclaw;
-  if (!current || current === "workspace:*" || !OPENCLAW_VERSION_RANGE_RE.test(current)) {
+  if (!deps) {
     return false;
   }
-  const next = `>=${targetVersion}`;
-  if (current === next) {
-    return false;
+  let changed = false;
+  for (const key of HOST_PACKAGE_DEPENDENCY_KEYS) {
+    const current = deps[key];
+    if (!current || current === "workspace:*" || !OPENCLAW_VERSION_RANGE_RE.test(current)) {
+      continue;
+    }
+    const next = `>=${targetVersion}`;
+    if (current === next) {
+      continue;
+    }
+    deps[key] = next;
+    changed = true;
   }
-  deps.openclaw = next;
-  return true;
+  return changed;
 }
 
 function syncPluginApiVersion(pkg: PackageJson, targetVersion: string): boolean {

--- a/src/scripts/sync-plugin-versions.test.ts
+++ b/src/scripts/sync-plugin-versions.test.ts
@@ -73,4 +73,37 @@ describe("syncPluginVersions", () => {
     expect(updatedPackage.openclaw?.compat?.pluginApi).toBe(">=2026.4.1");
     expect(updatedPackage.openclaw?.build?.openclawVersion).toBe("2026.4.1");
   });
+
+  it("syncs gemmaclaw peer ranges and preserves workspace gemmaclaw devDependencies", () => {
+    const rootDir = makeTempDir(tempDirs, "gemmaclaw-sync-plugin-versions-");
+
+    writeJson(path.join(rootDir, "package.json"), {
+      name: "gemmaclaw",
+      version: "2026.4.1",
+    });
+    writeJson(path.join(rootDir, "extensions/bluebubbles/package.json"), {
+      name: "@openclaw/bluebubbles",
+      version: "2026.3.30",
+      devDependencies: {
+        gemmaclaw: "workspace:*",
+      },
+      peerDependencies: {
+        gemmaclaw: ">=2026.3.30",
+      },
+    });
+
+    const summary = syncPluginVersions(rootDir);
+    const updatedPackage = JSON.parse(
+      fs.readFileSync(path.join(rootDir, "extensions/bluebubbles/package.json"), "utf8"),
+    ) as {
+      version?: string;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+
+    expect(summary.updated).toContain("@openclaw/bluebubbles");
+    expect(updatedPackage.version).toBe("2026.4.1");
+    expect(updatedPackage.devDependencies?.gemmaclaw).toBe("workspace:*");
+    expect(updatedPackage.peerDependencies?.gemmaclaw).toBe(">=2026.4.1");
+  });
 });


### PR DESCRIPTION
## Summary

- `pnpm install` fails immediately on a fresh clone with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` because 20 bundled extensions still depend on a workspace package named `openclaw`, which no longer exists since the root package was renamed to `gemmaclaw`.
- Renamed the `"openclaw": "workspace:*"` dependency plus the matching `peerDependencies`/`peerDependenciesMeta` entries to `gemmaclaw` in each affected extension (`bluebubbles`, `discord`, `feishu`, `googlechat`, `line`, `matrix`, `mattermost`, `memory-core`, `memory-wiki`, `msteams`, `nextcloud-talk`, `nostr`, `qa-channel`, `qa-lab`, `qa-matrix`, `qqbot`, `tlon`, `voice-call`, `whatsapp`, `zalo`, `zalouser`). These 21 are the complete set of extensions carrying host-package dependency entries.
- Left each extension's own `"openclaw": { ... }` plugin-manifest metadata block untouched — that's an unrelated schema key, not a package reference (confirmed by comparing against `telegram`, which isn't affected and uses the same manifest key).
- Also fixing the peer dependency entries (not just the workspace dependency) matters: without it, `autoInstallPeers` resolves the real upstream `openclaw` npm package as an actual dependency for all 20 extensions, bloating the lockfile with an unrelated package. With both fixed, `pnpm-lock.yaml` only changes the 21 renamed `workspace:*` links.
- Follow-up commit: `scripts/sync-plugin-versions.ts` (the `pnpm plugins:sync` release-alignment lane) looked up host dependency ranges by the `openclaw` key only, so after the rename it would silently stop bumping these extensions' peer ranges. It now recognizes both `gemmaclaw` and `openclaw` keys, with test coverage for the renamed shape.

## Why CI never caught this

`main`'s `pnpm-lock.yaml` still contains the stale `openclaw: { specifier: workspace:*, version: link:../.. }` importer entries from before the root package rename. Frozen-lockfile installs (the CI default) consume those `link:../..` targets verbatim without re-resolving the workspace name, so CI installs succeed — only fresh/non-frozen resolves (i.e., new contributors following the README, or anyone touching dependencies) hit the failure.

## Test plan

- [x] `pnpm install` completes successfully from a clean clone (previously failed instantly)
- [x] `pnpm check:changed` passes
- [x] `pnpm build` passes
- [x] `pnpm test src/scripts/sync-plugin-versions.test.ts` passes (covers both the upstream-ported and renamed dependency shapes)
- [x] Verified the lockfile diff is minimal (21 renamed entries, no incidental dependency additions)