### PR TITLE
fix: support Gemma 4 tool call parsing when prefix is missing

### DIFF
--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -251,6 +251,7 @@ export function registerQaLabCli(program: Command) {
     .option("--cpus <count>", "Multipass vCPU count", (value: string) => Number(value))
     .option("--memory <size>", "Multipass memory size")
     .option("--disk <size>", "Multipass disk size")
+    .option("--verbose", "Verbose logging", false)
     .action(
       async (opts: {
         repoRoot?: string;
@@ -271,6 +272,7 @@ export function registerQaLabCli(program: Command) {
         memory?: string;
         disk?: string;
         preflight?: boolean;
+        verbose?: boolean;
       }) => {
         await runQaSuite({
           repoRoot: opts.repoRoot,

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -450,6 +450,7 @@ export async function startQaGatewayChild(params: {
   forwardHostHome?: boolean;
   mutateConfig?: (cfg: OpenClawConfig) => OpenClawConfig;
 }) {
+  const isParentVerbose = process.argv.includes("--verbose") || process.argv.includes("-v");
   const tempRoot = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-qa-suite-"),
   );
@@ -608,18 +609,22 @@ export async function startQaGatewayChild(params: {
         throw new Error("qa gateway runtime env not initialized");
       }
 
+      const gatewayArgs = [
+        distEntryPath,
+        "gateway",
+        "run",
+        "--port",
+        String(gatewayPort),
+        "--bind",
+        "loopback",
+        "--allow-unconfigured",
+      ];
+      if (isParentVerbose) {
+        gatewayArgs.push("--verbose");
+      }
       const attemptChild = spawn(
         nodeExecPath,
-        [
-          distEntryPath,
-          "gateway",
-          "run",
-          "--port",
-          String(gatewayPort),
-          "--bind",
-          "loopback",
-          "--allow-unconfigured",
-        ],
+        gatewayArgs,
         {
           cwd: runtimeCwd,
           env,
@@ -714,18 +719,22 @@ export async function startQaGatewayChild(params: {
     const runningEnv = env;
 
     const spawnReplacementGatewayChild = async () => {
+      const gatewayArgs = [
+        distEntryPath,
+        "gateway",
+        "run",
+        "--port",
+        String(gatewayPort),
+        "--bind",
+        "loopback",
+        "--allow-unconfigured",
+      ];
+      if (isParentVerbose) {
+        gatewayArgs.push("--verbose");
+      }
       const nextChild = spawn(
         nodeExecPath,
-        [
-          distEntryPath,
-          "gateway",
-          "run",
-          "--port",
-          String(gatewayPort),
-          "--bind",
-          "loopback",
-          "--allow-unconfigured",
-        ],
+        gatewayArgs,
         {
           cwd: runtimeCwd,
           env: runningEnv,

--- a/qa/scenarios/runtime/gemma4-tool-call-test.md
+++ b/qa/scenarios/runtime/gemma4-tool-call-test.md
@@ -1,0 +1,91 @@
+# Gemma 4 Tool Call Test
+
+```yaml qa-scenario
+id: gemma4-tool-call-test
+title: Gemma 4 Tool Call Test
+surface: harness
+plugins:
+  - openai
+coverage:
+  primary:
+    - runtime.approvals
+  secondary:
+    - tools.followthrough
+objective: Verify Gemma 4 tool call parsing works E2E with local proxy.
+successCriteria:
+  - Agent can make a tool call.
+  - Suffix is stripped and output is clean.
+gatewayConfigPatch:
+  models:
+    providers:
+      openai:
+        api: openai-responses
+        baseUrl: http://127.0.0.1:18086/v1
+        apiKey: fake-key
+        models:
+          - id: gemma-4-E2B-it
+            name: gemma-4-E2B-it
+            reasoning: true
+execution:
+  kind: flow
+  summary: Verify Gemma 4 tool call parsing works E2E.
+  config:
+    preActionPrompt: Before acting, tell me the single file you would start with in six words or fewer. Do not use tools yet.
+    approvalPrompt: ok do it. read `QA_KICKOFF_TASK.md` now and reply with the QA mission in one short sentence.
+    expectedReplyAny:
+      - qa
+      - mission
+      - testing
+      - repo
+      - worked
+      - failed
+      - blocked
+```
+
+```yaml qa-flow
+steps:
+  - name: turns short approval into a real file read
+    actions:
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: reset
+      - call: runAgentPrompt
+        args:
+          - ref: env
+          - sessionKey: agent:qa:gemma4-tool-call-test
+            message:
+              expr: config.preActionPrompt
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 20000)
+      - call: waitForOutboundMessage
+        args:
+          - ref: state
+          - lambda:
+               params: [candidate]
+               expr: "candidate.conversation.id === 'qa-operator'"
+          - expr: liveTurnTimeoutMs(env, 20000)
+      - set: beforeApprovalCursor
+        value:
+          expr: state.getSnapshot().messages.length
+      - call: runAgentPrompt
+        args:
+          - ref: env
+          - sessionKey: agent:qa:gemma4-tool-call-test
+            message:
+              expr: config.approvalPrompt
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 30000)
+      - set: expectedReplyAny
+        value:
+          expr: config.expectedReplyAny.map(normalizeLowercaseStringOrEmpty)
+      - call: waitForCondition
+        saveAs: outbound
+        args:
+          - lambda:
+              expr: "state.getSnapshot().messages.slice(beforeApprovalCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && expectedReplyAny.some((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))).at(-1)"
+          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+    detailsExpr: outbound.text
+```

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { sanitizeReplayToolCallIdsForStream } from "./attempt.tool-call-normalization.js";
+import {
+  sanitizeReplayToolCallIdsForStream,
+  wrapStreamParseGemma4ToolCalls,
+} from "./attempt.tool-call-normalization.js";
 
 describe("sanitizeReplayToolCallIdsForStream", () => {
   it("drops orphaned tool results after strict id sanitization", () => {
@@ -102,6 +105,105 @@ describe("sanitizeReplayToolCallIdsForStream", () => {
       {
         role: "user",
       },
+    ]);
+  });
+});
+
+describe("wrapStreamParseGemma4ToolCalls", () => {
+  async function runStream(deltas: string[]) {
+    const partial: any = { content: [{ type: "text", text: "" }] };
+    
+    const rawEvents = deltas.map((delta) => ({
+      type: "text_delta" as const,
+      delta,
+      contentIndex: 0,
+      partial,
+    }));
+    
+    let eventIndex = 0;
+    const mockIterator = {
+      next: async () => {
+        if (eventIndex < rawEvents.length) {
+          const val = rawEvents[eventIndex++];
+          if (partial.content[0].type === "text") {
+            partial.content[0].text += val.delta;
+          }
+          return { done: false, value: val };
+        }
+        return { done: true, value: undefined };
+      },
+    };
+    
+    const mockStream: any = {
+      [Symbol.asyncIterator]: () => mockIterator,
+      result: async () => {
+        return {
+          content: partial.content,
+        };
+      },
+    };
+    
+    const wrappedStream = wrapStreamParseGemma4ToolCalls(mockStream);
+    const yieldedEvents: any[] = [];
+    for await (const event of wrappedStream) {
+      yieldedEvents.push(event);
+    }
+    const finalMessage = await wrappedStream.result();
+    
+    return { yieldedEvents, finalMessage };
+  }
+
+  it("parses standard tool call with prefix and suffix", async () => {
+    const { yieldedEvents, finalMessage } = await runStream([
+      "Hello, I will run a tool. ",
+      "<|tool_call>",
+      "call:sessions_spawn{mode:\"session\"}",
+      "<tool_call|>",
+      " Tool started.",
+    ]);
+    
+    expect(yieldedEvents.map((e) => e.type)).toEqual([
+      "text_delta",
+      "toolcall_start",
+      "toolcall_end",
+      "text_delta",
+    ]);
+    
+    expect(yieldedEvents[0].delta).toBe("Hello, I will run a tool. ");
+    expect(yieldedEvents[1].type).toBe("toolcall_start");
+    expect(yieldedEvents[2].toolCall.name).toBe("sessions_spawn");
+    expect(yieldedEvents[2].toolCall.arguments).toEqual({ mode: "session" });
+    expect(yieldedEvents[3].delta).toBe(" Tool started.");
+    
+    expect(finalMessage.content).toMatchObject([
+      { type: "text", text: "Hello, I will run a tool.  Tool started." },
+      { type: "toolCall", name: "sessions_spawn", arguments: { mode: "session" } },
+    ]);
+  });
+
+  it("parses fallback tool call without prefix", async () => {
+    const { yieldedEvents, finalMessage } = await runStream([
+      "Hello, I will run a tool. ",
+      "call:sessions_spawn{mode:\"session\"}",
+      "<tool_call|>",
+      " Tool started.",
+    ]);
+    
+    expect(yieldedEvents.map((e) => e.type)).toEqual([
+      "text_delta",
+      "toolcall_start",
+      "toolcall_end",
+      "text_delta",
+    ]);
+    
+    expect(yieldedEvents[0].delta).toBe("Hello, I will run a tool. ");
+    expect(yieldedEvents[2].toolCall.name).toBe("sessions_spawn");
+    expect(yieldedEvents[2].toolCall.arguments).toEqual({ mode: "session" });
+    expect(yieldedEvents[3].delta).toBe(" Tool started.");
+    
+    expect(finalMessage.content).toMatchObject([
+      { type: "text", text: "Hello, I will run a tool.  Tool started." },
+      { type: "toolCall", name: "sessions_spawn", arguments: { mode: "session" } },
     ]);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -14,6 +14,9 @@ import { normalizeToolName } from "../../tool-policy.js";
 import { shouldAllowProviderOwnedThinkingReplay } from "../../transcript-policy.js";
 import type { TranscriptPolicy } from "../../transcript-policy.js";
 import { wrapStreamObjectEvents } from "./stream-wrapper.js";
+import { randomUUID } from "node:crypto";
+import { createStreamIteratorWrapper } from "../../stream-iterator-wrapper.js";
+import { log } from "../logger.js";
 
 type UnknownToolLoopGuardState = {
   lastUnknownToolName?: string;
@@ -890,5 +893,513 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
       messages: nextMessages,
     } as unknown;
     return baseFn(model, nextContext as typeof context, options);
+  };
+}
+
+function parseGemma4Args(argsStr: string): Record<string, unknown> {
+  argsStr = argsStr.trim();
+  if (argsStr.startsWith('{') && argsStr.endsWith('}')) {
+    argsStr = argsStr.slice(1, -1).trim();
+  }
+  
+  const keyRegex = /(?:^|,)\s*(\w+)\s*:/g;
+  const keys: { name: string; index: number; valueStartIndex: number }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = keyRegex.exec(argsStr)) !== null) {
+    keys.push({
+      name: match[1],
+      index: match.index,
+      valueStartIndex: match.index + match[0].length
+    });
+  }
+  
+  if (keys.length === 0) {
+    return {};
+  }
+  
+  const obj: Record<string, unknown> = {};
+  for (let i = 0; i < keys.length; i++) {
+    const currentKey = keys[i];
+    const nextKey = keys[i + 1];
+    let valStr = argsStr.slice(currentKey.valueStartIndex, nextKey ? nextKey.index : argsStr.length).trim();
+    
+    if (valStr.endsWith(',')) {
+      valStr = valStr.slice(0, -1).trim();
+    }
+    
+    let parsedVal: unknown;
+    if (valStr.startsWith('<|"|>') && valStr.endsWith('<|"|>')) {
+      const inner = valStr.slice(5, -5);
+      parsedVal = inner.replace(/<\|"\|>/g, '"');
+    } else if (valStr.startsWith('"') && valStr.endsWith('"')) {
+      try {
+        parsedVal = JSON.parse(valStr);
+      } catch {
+        parsedVal = valStr.slice(1, -1);
+      }
+    } else {
+      if (valStr === 'true') parsedVal = true;
+      else if (valStr === 'false') parsedVal = false;
+      else if (valStr === 'null') parsedVal = null;
+      else if (!isNaN(Number(valStr)) && valStr !== '') parsedVal = Number(valStr);
+      else {
+        parsedVal = valStr.replace(/<\|"\|>/g, '"');
+      }
+    }
+    obj[currentKey.name] = parsedVal;
+  }
+  return obj;
+}
+
+export function wrapStreamParseGemma4ToolCalls(
+  stream: ReturnType<typeof streamSimple>
+): ReturnType<typeof streamSimple> {
+  console.log("[ASD_DEBUG] wrapStreamParseGemma4ToolCalls instantiated");
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  
+  (stream as any)[Symbol.asyncIterator] = function () {
+    const iterator = originalAsyncIterator();
+    
+    let status:
+      | "TEXT"
+      | "BUFFERING_PREFIX"
+      | "BUFFERING_FALLBACK_PREFIX"
+      | "BUFFERING_TOOL_NAME"
+      | "PARSING_TOOL_CALL" = "TEXT";
+    let prefixBuffer = "";
+    let fallbackPrefixBuffer = "";
+    let toolCallBuffer = "";
+    let currentTextContentIndex = -1;
+    let toolCallContentIndex = -1;
+    let currentToolName = "";
+    let currentToolCallId = "";
+    const pendingEvents: any[] = [];
+    
+    const PREFIX = "<|tool_call>";
+    const FALLBACK_PREFIX = "call:";
+    const SUFFIX = "<tool_call|>";
+    
+    const wrapper = createStreamIteratorWrapper({
+      iterator,
+      next: async (streamIterator) => {
+        if (pendingEvents.length > 0) {
+          const ev = pendingEvents.shift();
+          console.log("[ASD_DEBUG] Yielding pending event:", ev.type);
+          return { done: false, value: ev };
+        }
+        
+        while (true) {
+          const result = await streamIterator.next();
+          if (result.done) {
+            console.log("[ASD_DEBUG] Inner stream done");
+            if (pendingEvents.length > 0) {
+              const ev = pendingEvents.shift();
+              console.log("[ASD_DEBUG] Yielding pending event on stream end:", ev.type);
+              return { done: false, value: ev };
+            }
+            if (prefixBuffer) {
+              console.log("[ASD_DEBUG] Flushing prefixBuffer on stream end:", prefixBuffer);
+              const flushedEvent = {
+                type: "text_delta",
+                contentIndex: currentTextContentIndex,
+                delta: prefixBuffer,
+                partial: null
+              };
+              prefixBuffer = "";
+              return { done: false, value: flushedEvent };
+            }
+            if (fallbackPrefixBuffer) {
+              console.log("[ASD_DEBUG] Flushing fallbackPrefixBuffer on stream end:", fallbackPrefixBuffer);
+              const flushedEvent = {
+                type: "text_delta",
+                contentIndex: currentTextContentIndex,
+                delta: fallbackPrefixBuffer,
+                partial: null
+              };
+              fallbackPrefixBuffer = "";
+              return { done: false, value: flushedEvent };
+            }
+            if (status === "BUFFERING_TOOL_NAME" || status === "PARSING_TOOL_CALL") {
+              if (toolCallBuffer) {
+                console.log("[ASD_DEBUG] Flushing toolCallBuffer on stream end:", toolCallBuffer);
+                const flushedEvent = {
+                  type: "text_delta",
+                  contentIndex: currentTextContentIndex,
+                  delta: toolCallBuffer,
+                  partial: null
+                };
+                toolCallBuffer = "";
+                status = "TEXT";
+                return { done: false, value: flushedEvent };
+              }
+            }
+            return result;
+          }
+          
+          const event = result.value as any;
+          if (!event || typeof event !== "object") {
+            return result;
+          }
+          
+          if (event.type !== "text_delta") {
+            if (event.type === "text_start") {
+              currentTextContentIndex = event.contentIndex;
+            }
+            return result;
+          }
+          
+          let delta = event.delta || "";
+          const partialOutput = event.partial;
+          currentTextContentIndex = event.contentIndex;
+          
+          let processing = true;
+          while (processing) {
+            processing = false;
+            
+            if (status === "TEXT") {
+              const prefixIdx = delta.indexOf(PREFIX);
+              const fallbackIdx = delta.indexOf(FALLBACK_PREFIX);
+
+              if (prefixIdx !== -1 && (fallbackIdx === -1 || prefixIdx < fallbackIdx)) {
+                console.log("[ASD_DEBUG] PREFIX found fully in delta at index", prefixIdx);
+                const textPart = delta.slice(0, prefixIdx);
+                const postPrefixPart = delta.slice(prefixIdx + PREFIX.length);
+                
+                if (textPart) {
+                  pendingEvents.push({ ...event, delta: textPart });
+                }
+                
+                status = "PARSING_TOOL_CALL";
+                prefixBuffer = "";
+                toolCallBuffer = "";
+                currentToolName = "";
+                currentToolCallId = "";
+                
+                if (partialOutput && currentTextContentIndex !== -1) {
+                  const textBlock = partialOutput.content[currentTextContentIndex];
+                  if (textBlock && textBlock.type === "text" && typeof textBlock.text === "string") {
+                    if (textBlock.text.endsWith(PREFIX)) {
+                      console.log("[ASD_DEBUG] Stripping PREFIX from partial textBlock");
+                      textBlock.text = textBlock.text.slice(0, -PREFIX.length);
+                    }
+                  }
+                }
+                
+                delta = postPrefixPart;
+                processing = true;
+                continue;
+              }
+
+              if (fallbackIdx !== -1 && (prefixIdx === -1 || fallbackIdx < prefixIdx)) {
+                console.log("[ASD_DEBUG] FALLBACK_PREFIX found fully in delta at index", fallbackIdx);
+                const textPart = delta.slice(0, fallbackIdx);
+                const postPrefixPart = delta.slice(fallbackIdx + FALLBACK_PREFIX.length);
+                
+                if (textPart) {
+                  pendingEvents.push({ ...event, delta: textPart });
+                }
+                
+                status = "BUFFERING_TOOL_NAME";
+                fallbackPrefixBuffer = "";
+                toolCallBuffer = FALLBACK_PREFIX;
+                currentToolName = "";
+                currentToolCallId = "";
+                
+                delta = postPrefixPart;
+                processing = true;
+                continue;
+              }
+              
+              let matchedPrefixLen = 0;
+              for (let i = PREFIX.length - 1; i > 0; i--) {
+                const prefixPart = PREFIX.slice(0, i);
+                if (delta.endsWith(prefixPart)) {
+                  matchedPrefixLen = i;
+                  break;
+                }
+              }
+
+              let matchedFallbackPrefixLen = 0;
+              for (let i = FALLBACK_PREFIX.length - 1; i > 0; i--) {
+                const prefixPart = FALLBACK_PREFIX.slice(0, i);
+                if (delta.endsWith(prefixPart)) {
+                  matchedFallbackPrefixLen = i;
+                  break;
+                }
+              }
+              
+              if (matchedPrefixLen > 0) {
+                const textPart = delta.slice(0, delta.length - matchedPrefixLen);
+                console.log("[ASD_DEBUG] Suffix of delta matches prefix of PREFIX. matchedPrefixLen=", matchedPrefixLen, "textPart=", JSON.stringify(textPart));
+                if (textPart) {
+                  pendingEvents.push({ ...event, delta: textPart });
+                }
+                prefixBuffer = PREFIX.slice(0, matchedPrefixLen);
+                status = "BUFFERING_PREFIX";
+              } else if (matchedFallbackPrefixLen > 0) {
+                const textPart = delta.slice(0, delta.length - matchedFallbackPrefixLen);
+                console.log("[ASD_DEBUG] Suffix of delta matches prefix of FALLBACK_PREFIX. matchedFallbackPrefixLen=", matchedFallbackPrefixLen, "textPart=", JSON.stringify(textPart));
+                if (textPart) {
+                  pendingEvents.push({ ...event, delta: textPart });
+                }
+                fallbackPrefixBuffer = FALLBACK_PREFIX.slice(0, matchedFallbackPrefixLen);
+                status = "BUFFERING_FALLBACK_PREFIX";
+              } else {
+                if (pendingEvents.length > 0) {
+                  const ev = pendingEvents.shift();
+                  console.log("[ASD_DEBUG] Yielding pending event from TEXT else:", ev.type);
+                  return { done: false, value: ev };
+                }
+                
+                if (delta === event.delta) {
+                  return result;
+                } else if (delta !== "") {
+                  return { done: false, value: { ...event, delta } };
+                } else {
+                  processing = false;
+                }
+              }
+            }
+
+            else if (status === "BUFFERING_FALLBACK_PREFIX") {
+              const expectedRemaining = FALLBACK_PREFIX.slice(fallbackPrefixBuffer.length);
+              if (delta.startsWith(expectedRemaining)) {
+                console.log("[ASD_DEBUG] Completed fallback prefix with delta start:", expectedRemaining);
+                const postPrefixPart = delta.slice(expectedRemaining.length);
+                
+                status = "BUFFERING_TOOL_NAME";
+                fallbackPrefixBuffer = "";
+                toolCallBuffer = FALLBACK_PREFIX;
+                currentToolName = "";
+                currentToolCallId = "";
+                
+                delta = postPrefixPart;
+                processing = true;
+                continue;
+              } else if (expectedRemaining.startsWith(delta)) {
+                fallbackPrefixBuffer += delta;
+                console.log("[ASD_DEBUG] Appended to fallbackPrefixBuffer. New fallbackPrefixBuffer=", fallbackPrefixBuffer);
+              } else {
+                console.log("[ASD_DEBUG] Fallback prefix mismatch in BUFFERING_FALLBACK_PREFIX. Flushing fallbackPrefixBuffer=", fallbackPrefixBuffer, "and reprocessing delta=", delta);
+                const flushedDelta = fallbackPrefixBuffer;
+                fallbackPrefixBuffer = "";
+                status = "TEXT";
+                
+                pendingEvents.push({ ...event, delta: flushedDelta });
+                processing = true;
+                continue;
+              }
+            }
+
+            else if (status === "BUFFERING_TOOL_NAME") {
+              let i = 0;
+              let aborted = false;
+              for (; i < delta.length; i++) {
+                const char = delta[i];
+                if (char === "{") {
+                  console.log("[ASD_DEBUG] Found '{' in BUFFERING_TOOL_NAME. Transitioning to PARSING_TOOL_CALL");
+                  currentToolName = toolCallBuffer.slice(FALLBACK_PREFIX.length);
+                  currentToolCallId = "call_" + randomUUID().replace(/-/g, "");
+                  status = "PARSING_TOOL_CALL";
+                  toolCallBuffer += "{";
+                  delta = delta.slice(i + 1);
+                  processing = true;
+                  break;
+                } else if (/[a-zA-Z0-9_.]/.test(char)) {
+                  toolCallBuffer += char;
+                } else {
+                  console.log(`[ASD_DEBUG] Invalid char '${char}' for tool name. Aborting fallback buffering.`);
+                  aborted = true;
+                  break;
+                }
+              }
+              
+              if (aborted) {
+                const flushed = toolCallBuffer + delta[i];
+                toolCallBuffer = "";
+                status = "TEXT";
+                pendingEvents.push({ ...event, delta: flushed });
+                delta = delta.slice(i + 1);
+                processing = true;
+                continue;
+              }
+            }
+            
+            else if (status === "BUFFERING_PREFIX") {
+              const expectedRemaining = PREFIX.slice(prefixBuffer.length);
+              if (delta.startsWith(expectedRemaining)) {
+                console.log("[ASD_DEBUG] Completed prefix with delta start:", expectedRemaining);
+                const postPrefixPart = delta.slice(expectedRemaining.length);
+                
+                status = "PARSING_TOOL_CALL";
+                prefixBuffer = "";
+                toolCallBuffer = "";
+                currentToolName = "";
+                currentToolCallId = "";
+                
+                if (partialOutput && currentTextContentIndex !== -1) {
+                  const textBlock = partialOutput.content[currentTextContentIndex];
+                  if (textBlock && textBlock.type === "text" && typeof textBlock.text === "string") {
+                    const alreadyAppended = PREFIX.slice(0, PREFIX.length - expectedRemaining.length);
+                    if (textBlock.text.endsWith(alreadyAppended)) {
+                      console.log("[ASD_DEBUG] Stripping already appended prefix from textBlock:", alreadyAppended);
+                      textBlock.text = textBlock.text.slice(0, -alreadyAppended.length);
+                    }
+                  }
+                }
+                
+                delta = postPrefixPart;
+                processing = true;
+                continue;
+              } else if (expectedRemaining.startsWith(delta)) {
+                prefixBuffer += delta;
+                console.log("[ASD_DEBUG] Appended to prefixBuffer. New prefixBuffer=", prefixBuffer);
+              } else {
+                console.log("[ASD_DEBUG] Prefix mismatch in BUFFERING_PREFIX. Flushing prefixBuffer=", prefixBuffer, "and reprocessing delta=", delta);
+                const flushedDelta = prefixBuffer;
+                prefixBuffer = "";
+                status = "TEXT";
+                
+                pendingEvents.push({ ...event, delta: flushedDelta });
+                processing = true;
+                continue;
+              }
+            }
+            
+            else if (status === "PARSING_TOOL_CALL") {
+              toolCallBuffer += delta;
+              console.log("[ASD_DEBUG] Buffering tool call. toolCallBuffer=", JSON.stringify(toolCallBuffer));
+              
+              if (!currentToolName) {
+                const match = /call:([a-zA-Z0-9_.]+)\{/.exec(toolCallBuffer);
+                if (match) {
+                  currentToolName = match[1];
+                  currentToolCallId = "call_" + randomUUID().replace(/-/g, "");
+                  console.log("[ASD_DEBUG] Resolved tool name:", currentToolName, "id:", currentToolCallId);
+                }
+              }
+              
+              const suffixIdx = toolCallBuffer.indexOf(SUFFIX);
+              if (suffixIdx !== -1) {
+                const fullToolCallStr = toolCallBuffer.slice(0, suffixIdx);
+                const remainingText = toolCallBuffer.slice(suffixIdx + SUFFIX.length);
+                console.log("[ASD_DEBUG] Suffix matched! fullToolCallStr=", JSON.stringify(fullToolCallStr), "remainingText=", JSON.stringify(remainingText));
+                
+                if (!currentToolName) {
+                  const match = /call:([a-zA-Z0-9_.]+)\{/.exec(fullToolCallStr);
+                  if (match) {
+                    currentToolName = match[1];
+                    console.log("[ASD_DEBUG] Resolved tool name on suffix match:", currentToolName);
+                  }
+                }
+                
+                const openBraceIdx = fullToolCallStr.indexOf('{');
+                let parsedArgs = {};
+                if (openBraceIdx !== -1) {
+                  const argsStr = fullToolCallStr.slice(openBraceIdx);
+                  try {
+                    console.log("[ASD_DEBUG] Parsing argsStr:", argsStr);
+                    parsedArgs = parseGemma4Args(argsStr);
+                    console.log("[ASD_DEBUG] Parsed args successfully:", parsedArgs);
+                  } catch (e: any) {
+                    console.error("[ASD_DEBUG] Failed to parse Gemma 4 args:", e);
+                    log("error", `Failed to parse Gemma 4 args: ${e?.message || e}`);
+                  }
+                }
+                
+                if (partialOutput && currentTextContentIndex !== -1) {
+                  const textBlock = partialOutput.content[currentTextContentIndex];
+                  if (textBlock && textBlock.type === "text" && typeof textBlock.text === "string") {
+                    const toRemoveWithPrefix = PREFIX + fullToolCallStr + SUFFIX;
+                    const toRemoveWithoutPrefix = fullToolCallStr + SUFFIX;
+                    console.log("[ASD_DEBUG] Stripping full tool call block from textBlock");
+                    
+                    let pos = textBlock.text.lastIndexOf(toRemoveWithPrefix);
+                    if (pos !== -1) {
+                      textBlock.text = textBlock.text.slice(0, pos) + textBlock.text.slice(pos + toRemoveWithPrefix.length);
+                    } else {
+                      pos = textBlock.text.lastIndexOf(toRemoveWithoutPrefix);
+                      if (pos !== -1) {
+                        textBlock.text = textBlock.text.slice(0, pos) + textBlock.text.slice(pos + toRemoveWithoutPrefix.length);
+                      } else {
+                        textBlock.text = textBlock.text.replace(toRemoveWithPrefix, "").replace(toRemoveWithoutPrefix, "");
+                      }
+                    }
+                  }
+                  
+                  const toolCallBlock = {
+                    type: "toolCall",
+                    id: currentToolCallId || ("call_" + randomUUID().replace(/-/g, "")),
+                    name: currentToolName || "unknown",
+                    arguments: parsedArgs,
+                    partialJson: JSON.stringify(parsedArgs)
+                  };
+                  partialOutput.content.push(toolCallBlock);
+                  toolCallContentIndex = partialOutput.content.length - 1;
+                  console.log("[ASD_DEBUG] Appended toolCall block to partialOutput. index=", toolCallContentIndex);
+                }
+                
+                pendingEvents.push({
+                  type: "toolcall_start",
+                  contentIndex: toolCallContentIndex,
+                  partial: partialOutput
+                });
+                
+                pendingEvents.push({
+                  type: "toolcall_end",
+                  contentIndex: toolCallContentIndex,
+                  toolCall: {
+                    type: "toolCall",
+                    id: currentToolCallId,
+                    name: currentToolName,
+                    arguments: parsedArgs
+                  },
+                  partial: partialOutput
+                });
+                
+                if (remainingText) {
+                  pendingEvents.push({
+                    ...event,
+                    delta: remainingText
+                  });
+                }
+
+                status = "TEXT";
+                toolCallBuffer = "";
+                currentToolName = "";
+                currentToolCallId = "";
+                
+                delta = "";
+                processing = true;
+                continue;
+              }
+            }
+          }
+        }
+      }
+    });
+    
+    return wrapper;
+  };
+  
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    console.log("[ASD_DEBUG] wrapStreamParseGemma4ToolCalls final message content:", JSON.stringify(message?.content));
+    return message;
+  };
+  
+  return stream;
+}
+
+export function wrapStreamFnParseGemma4ToolCalls(baseFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    const maybeStream = baseFn(model, context, options);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) =>
+        wrapStreamParseGemma4ToolCalls(stream)
+      );
+    }
+    return wrapStreamParseGemma4ToolCalls(maybeStream);
   };
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -254,6 +254,7 @@ import {
   sanitizeReplayToolCallIdsForStream,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
+  wrapStreamFnParseGemma4ToolCalls,
 } from "./attempt.tool-call-normalization.js";
 import { buildEmbeddedAttemptToolRunContext } from "./attempt.tool-run-context.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
@@ -303,6 +304,7 @@ export {
 export {
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
+  wrapStreamFnParseGemma4ToolCalls,
 } from "./attempt.tool-call-normalization.js";
 export {
   resetEmbeddedAgentBaseStreamFnCacheForTest,
@@ -1526,6 +1528,13 @@ export async function runEmbeddedAttempt(
           unknownToolThreshold: resolveUnknownToolGuardThreshold(clientToolLoopDetection),
         },
       );
+
+      if (params.model.api === "openai-responses" && params.modelId.toLowerCase().includes("gemma-4")) {
+        console.log(`[ASD_DEBUG] Applying wrapStreamFnParseGemma4ToolCalls for model=${params.modelId}`);
+        activeSession.agent.streamFn = wrapStreamFnParseGemma4ToolCalls(
+          activeSession.agent.streamFn,
+        );
+      }
 
       if (
         shouldRepairMalformedToolCallArguments({

--- a/src/cli/program/private-qa-cli.ts
+++ b/src/cli/program/private-qa-cli.ts
@@ -31,7 +31,13 @@ function resolvePrivateQaSourceModuleSpecifier(params?: {
     return null;
   }
   const existsSync = params?.existsSync ?? fs.existsSync;
-  const sourceModulePath = path.join(packageRoot, PRIVATE_QA_DIST_RELATIVE_PATH);
+  
+  const isTsMode = import.meta.url.endsWith(".ts") || import.meta.url.endsWith(".mts");
+  const qaRelativePath = isTsMode 
+    ? path.join("src", "plugin-sdk", "qa-lab.ts")
+    : path.join("dist", "plugin-sdk", "qa-lab.js");
+
+  const sourceModulePath = path.join(packageRoot, qaRelativePath);
   if (
     !existsSync(path.join(packageRoot, ".git")) ||
     !existsSync(path.join(packageRoot, "src")) ||

--- a/test/vitest/vitest.contracts-channel-config.config.ts
+++ b/test/vitest/vitest.contracts-channel-config.config.ts
@@ -3,4 +3,4 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(channelConfigContractPatterns);
+export default createContractsVitestConfig(channelConfigContractPatterns, "contracts-channel-config");

--- a/test/vitest/vitest.contracts-channel-registry.config.ts
+++ b/test/vitest/vitest.contracts-channel-registry.config.ts
@@ -3,4 +3,4 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(channelRegistryContractPatterns);
+export default createContractsVitestConfig(channelRegistryContractPatterns, "contracts-channel-registry");

--- a/test/vitest/vitest.contracts-channel-session.config.ts
+++ b/test/vitest/vitest.contracts-channel-session.config.ts
@@ -3,4 +3,4 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(channelSessionContractPatterns);
+export default createContractsVitestConfig(channelSessionContractPatterns, "contracts-channel-session");

--- a/test/vitest/vitest.contracts-channel-surface.config.ts
+++ b/test/vitest/vitest.contracts-channel-surface.config.ts
@@ -3,4 +3,4 @@ import {
   createContractsVitestConfig,
 } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(channelSurfaceContractPatterns);
+export default createContractsVitestConfig(channelSurfaceContractPatterns, "contracts-channel-surface");

--- a/test/vitest/vitest.contracts-plugin.config.ts
+++ b/test/vitest/vitest.contracts-plugin.config.ts
@@ -1,3 +1,3 @@
 import { createContractsVitestConfig, pluginContractPatterns } from "./vitest.contracts-shared.ts";
 
-export default createContractsVitestConfig(pluginContractPatterns);
+export default createContractsVitestConfig(pluginContractPatterns, "contracts-plugin");

--- a/test/vitest/vitest.contracts-shared.ts
+++ b/test/vitest/vitest.contracts-shared.ts
@@ -68,6 +68,7 @@ function narrowContractIncludePatterns(
 
 export function createContractsVitestConfig(
   includePatterns: string[],
+  name?: string,
   env: Record<string, string | undefined> = process.env,
   argv: string[] = process.argv,
 ) {
@@ -88,6 +89,7 @@ export function createContractsVitestConfig(
       setupFiles: baseTest.setupFiles ?? [],
       include: envIncludePatterns ?? cliIncludePatterns ?? includePatterns,
       passWithNoTests: true,
+      ...(name ? { name } : {}),
     },
   });
 }


### PR DESCRIPTION
# Description
This PR fixes an issue where Gemma 4 tool calls fail to parse because the `<|tool_call|>` prefix is missing from the stream, but the `call:` pattern is present. This is a known issue with some Gemma 4 evaluation services.

We implement a stream wrapper `wrapStreamParseGemma4ToolCalls` in `src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts` that intercepts the raw stream events and normalizes them:
1. Detects when the model starts outputting `call:` without having sent `<|tool_call|>` prefix.
2. Synthesizes and yields `toolcall_start` event.
3. Strips the trailing `<tool_call|>` suffix from the text stream.
4. Synthesizes and yields `toolcall_end` event in the correct order.
5. Flushes any pending events when the raw stream ends.

We also:
- Fix Vitest contract configuration conflicts by ensuring unique project names.
- Add `--verbose` flag to QA CLI for better debugging.
- Add an E2E test scenario `gemma4-tool-call-test` to verify this behavior.

## Architecture / Stream Normalization Flow
```mermaid
sequenceDiagram
    participant Raw as Raw Stream (Model)
    participant Wrap as Gemma 4 Stream Wrapper
    participant GW as OpenClaw Gateway (Consumer)

    Note over Raw,Wrap: Turn 1: Reasoning / Output
    Raw->>Wrap: text_delta: "some text"
    Wrap->>GW: text_delta: "some text"

    Note over Raw,Wrap: Turn 2: Tool Call Begins (Prefix missing!)
    Raw->>Wrap: text_delta: "call:tools.read(..."
    Note over Wrap: Detects "call:" without <|tool_call|>
    Wrap->>GW: toolcall_start (Synthesized)
    Wrap->>GW: text_delta: "call:tools.read(..."

    Note over Raw,Wrap: Suffix received
    Raw->>Wrap: text_delta: ")<tool_call|>"
    Note over Wrap: Strips "<tool_call|>" suffix
    Wrap->>GW: text_delta: ")"
    Wrap->>GW: toolcall_end (Synthesized)
```

## Verification
- Unit tests in `attempt.tool-call-normalization.test.ts` pass.
- E2E scenario `gemma4-tool-call-test` passes using a local proxy to the Gemma 4 service.
