### PR TITLE
site: Gemma4 July 19 sweep (thin, low-confidence): RTX 4060 Ti 26B A4B throughput, KV grafting preprint, 31B QAT reasoning fail, provider-quality question

### DIFF
--- a/site/community.html
+++ b/site/community.html
@@ -1845,7 +1845,48 @@
     <section id="community-page">
       <h2>Community & Hardware Reports</h2>
       <p>Real-world experiences running Gemma models, curated from the community. Browse hardware reports, read the weekly field notes, or search for your setup.</p>
-      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes - 2026-07-18</h2>
+      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes - 2026-07-19</h2>
+<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (5 new hardware-mention entries from the July 18 ingest, 528 entries total) and their threads. Confidence is <strong>low</strong> this cycle. All five new posts came in through the Atom fallback, so every one carries a placeholder score around 20 with no captured comments, and none is a reproducible measured benchmark. The single hardware number this cycle is one user's self-reported throughput figure, so treat the whole sweep as directional community signal rather than evidence.</p>
+<p><em>July 19 sweep, 2026-07-19 00:00 UTC:</em> a thin cycle with no new measured benchmark. After the July 18 MacBook Pro comparison, this ingest of 40 posts surfaced five Gemma-mentioning items, four of them on-topic: a single consumer-GPU throughput datapoint (about 23 tok/s for Gemma 4 26B A4B on an RTX 4060 Ti 16GB, bottlenecked by memory bandwidth), a byte-exact KV cache grafting preprint that reports a large accuracy jump on Gemma 4 12B, a precise-reasoning failure where Gemma 4 31B QAT could not predict piped `dd` output, and an open question about which quantization provider to trust for Gemma 4 26B. A fifth post, a model-swapping MCP tool that only tags Gemma in passing, is left out of the narrative as off-topic tooling but is included as a community card. Nothing this cycle changes the tier guidance from prior sweeps.</p>
+<p><strong>Mid-range single GPU: one user reports about 23 tokens per second on Gemma 4 26B A4B with an RTX 4060 Ti 16GB, and says memory bandwidth, not VRAM, is the ceiling.</strong> In an upgrade-shopping thread about inflated GPU prices, the author notes that although the <strong>RTX 4060 Ti 16GB</strong> has plenty of VRAM to hold the <strong>Gemma 4 26B-A4B MoE</strong>, its <strong>narrow memory bus caps decode at roughly 23 tok/s</strong>. They are weighing a next card and find the options poor: the cheapest step up is the <strong>Intel Arc B60</strong> (which they say has weak software support), then the <strong>Radeon RX 7900 XT</strong>, with little else usable under <strong>$1,000</strong>. For Gemmaclaw's mid-range GPU tier this is a useful, if single-user, datapoint. The sparse 26B-A4B is comfortably runnable at interactive speed on a 16 GB consumer card, and the practical limit on that class of card is memory bandwidth rather than capacity, so a card with more raw VRAM but a similar bus width will not necessarily decode faster. Confidence: a single anecdote with a placeholder score and no captured comments, and the post names no quant, context length, or backend, so the 23 tok/s figure is indicative only. (<a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">source</a>, July 18, 2026)</p>
+<p><strong>Technique to watch: a preprint claims byte-exact KV cache grafting on frozen Gemma 4 12B, lifting an AIME 2025 routing setup from 76.7% to 90.0%.</strong> The author published a method to store verified knowledge as KV state and restore it <strong>byte identical</strong> to fresh computation, and reports that on <strong>Gemma 4 12B</strong> the cached knowledge raised the same routing system from <strong>76.7% to 90.0% on AIME 2025</strong> (paper: arXiv 2607.14431). This is interesting for Gemmaclaw beyond a single number because it frames Gemma 4 as a candidate for cached-knowledge and prefill-reuse experiments, and it sits in the same cluster as this week's other cache-reuse work, a cache-invalidation proxy tool and a Mac Studio KV-reuse report. It is a fresh single-author preprint with a promotional framing (the author says they will pitch it at a summit the next day), a placeholder score, and no independent replication, so it is a lead to watch rather than an established result. Confidence: low, an unreplicated preprint from one author with no captured discussion. (<a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">source</a>, July 18, 2026)</p>
+<p><strong>Known limit, precise reasoning: Gemma 4 31B QAT could not predict the exact output and exit code of a piped `dd` command, and neither could two other large local models.</strong> A tester asked several models, all in reasoning mode, to predict the printout and error code of a specific two-stage `set -o pipefail; dd ... | dd ...` pipeline on Linux. <strong>Gemma 4 31B QAT, Qwen 3.6 27B Q6, and DeepSeek V4 Flash MXFP4 all failed</strong>, and a fourth model was still thinking when the tester gave up. These are the largest models the author runs locally. For Gemmaclaw this is a narrow but concrete reminder that Gemma 4 31B, even in reasoning mode, is unreliable at precise mechanical reasoning about tool output, the kind of exact-value prediction that matters for agentic shell work. The author had not yet tried a coding harness, which might catch or correct such errors. Confidence: a single tester, a one-shot task, a placeholder score, and no comments, so read it as one datapoint on a hard sub-skill, not a benchmark. (<a href="https://reddit.com/r/localllama/comments/1uzuebx" target="_blank" rel="noopener">source</a>, July 18, 2026)</p>
+<h3>Best current setup (this cycle's additions)</h3>
+<ul class="setup-list">
+<li><strong>Mid-range single GPU (16 GB):</strong> the sparse <strong>Gemma 4 26B-A4B</strong> runs at interactive speed (about <strong>23 tok/s</strong> for one user) on an <strong>RTX 4060 Ti 16 GB</strong>, with <strong>memory bandwidth, not VRAM, the limiting factor</strong> on that class of card (<a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">1v07ell</a>).</li>
+<li><strong>Prefill and cache reuse, experimental:</strong> if you experiment with cached-knowledge or prefill reuse, <strong>Gemma 4 12B</strong> is now the subject of a <strong>byte-exact KV grafting</strong> preprint reporting a large AIME jump, worth tracking but not yet replicated (<a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">1v07tib</a>).</li>
+<li><strong>Precise shell and tool reasoning:</strong> do <strong>not</strong> rely on <strong>Gemma 4 31B QAT</strong> to predict exact command output, since at least one deterministic `dd` test tripped it and two peer models (<a href="https://reddit.com/r/localllama/comments/1uzuebx" target="_blank" rel="noopener">1uzuebx</a>).</li>
+<li><strong>No change to prior tiers:</strong> the July 18 items (Gemma 4 26B topping a five-model MacBook Pro average at 14.7 GB, Gemma 4 31B Q8 as a credible agentic coder, phone-side MoE expert streaming at 1 to 5 tok/s, and the tensor-parallel load caveat) and all earlier tier guidance still stand. Nothing this cycle contradicts them.</li>
+</ul>
+<h3>What works</h3>
+<ul class="setup-list">
+<li><strong>Gemma 4 26B-A4B is comfortably interactive on a 16 GB consumer GPU</strong>, about 23 tok/s on an RTX 4060 Ti for one user (<a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">1v07ell</a>).</li>
+<li><strong>Gemma 4 12B is a viable base for KV-cache and prefill-reuse research</strong>, per a new byte-exact grafting preprint, though the result is unreplicated (<a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">1v07tib</a>).</li>
+</ul>
+<h3>Known limits</h3>
+<ul class="setup-list">
+<li><strong>The one hardware number this cycle is a single self-report</strong> (about 23 tok/s, RTX 4060 Ti 16 GB, Gemma 4 26B A4B) with no quant, context, or backend named, so treat it as indicative only (<a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">1v07ell</a>).</li>
+<li><strong>Gemma 4 31B QAT failed a precise piped-`dd` output prediction</strong> in reasoning mode, alongside Qwen 3.6 27B and DeepSeek V4 Flash, a reminder it is weak at exact mechanical tool-output reasoning (<a href="https://reddit.com/r/localllama/comments/1uzuebx" target="_blank" rel="noopener">1uzuebx</a>).</li>
+<li><strong>The KV grafting result is an unreplicated single-author preprint</strong> with a promotional framing and a placeholder score, not yet independent evidence (<a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">1v07tib</a>).</li>
+</ul>
+<h3>Open questions</h3>
+<ul class="setup-list">
+<li><strong>Which quantization provider is best for Gemma 4 26B by task?</strong> A user running MoE Gemma 4 26B and Qwen 3.6 35B sees quality differences across bartowski, unsloth, LM Studio, and Google builds but cannot find a rule of thumb for coding versus general chat (<a href="https://reddit.com/r/localllama/comments/1uzr4ia" target="_blank" rel="noopener">1uzr4ia</a>).</li>
+<li><strong>Does the byte-exact KV grafting result hold up</strong> under independent replication and on larger Gemma 4 sizes, or is the 76.7 to 90.0 jump specific to one routing setup (<a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">1v07tib</a>)?</li>
+<li><strong>What is the memory-bandwidth floor for interactive Gemma 4 26B-A4B</strong> across consumer cards, given a 16 GB RTX 4060 Ti lands near 23 tok/s and the bus, not the VRAM, is the bottleneck (<a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">1v07ell</a>)?</li>
+</ul>
+<h3>Sources</h3>
+<p>The Gemma-mentioning posts driving this update (July 19 sweep, newest first). All five are <strong>placeholder-score (~20), zero-comment</strong> items from the Atom-fallback ingest, so weight them accordingly. There is <strong>no reproducible measured benchmark</strong> this cycle:</p>
+<ul class="setup-list">
+<li><a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">How are y'all stomaching the &amp;quot;AI Boom&amp;quot; prices?</a> (Jul 18, 2026, an upgrade thread reporting about 23 tok/s on Gemma 4 26B A4B with an RTX 4060 Ti 16GB and calling out the narrow memory bus as the bottleneck. No quant, context, or backend named)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">Byte exact KV cache grafting on frozen Gemma 4</a> (Jul 18, 2026, a preprint (arXiv 2607.14431) claiming byte-identical KV state restore, with Gemma 4 12B improving from 76.7% to 90.0% on an AIME 2025 routing setup. Single author, promotional framing, unreplicated)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1uzuebx" target="_blank" rel="noopener">Which models can predict piped dd output in Linux?</a> (Jul 18, 2026, a precise reasoning test where Gemma 4 31B QAT, Qwen 3.6 27B Q6, and DeepSeek V4 Flash all failed to predict the exact output and exit code of a two-stage dd pipeline)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1uzr4ia" target="_blank" rel="noopener">Qwen and Gemma providers</a> (Jul 18, 2026, a user asks which provider quant, bartowski, unsloth, LM Studio, or Google, is best for Gemma 4 26B and Qwen 3.6 35B for coding versus general use. No answer reached)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1v032br" target="_blank" rel="noopener">promptchain: pin, preload, and swap local models across backends</a> (Jul 18, 2026, a model-swapping Python library and MCP server that tags Gemma only in passing. Included as a community card but off-topic for the Gemma 4 hardware narrative)</li>
+</ul>
+<p><em>Last updated: 2026-07-19 (July 19 sweep). Confidence: low (five placeholder-score Atom-fallback anecdotes, no reproducible measured benchmark this cycle). Key findings: one user reports about 23 tok/s for Gemma 4 26B A4B on an RTX 4060 Ti 16 GB and identifies memory bandwidth, not VRAM, as the ceiling on that class of card. A single-author preprint claims byte-exact KV cache grafting on frozen Gemma 4 12B, raising an AIME 2025 routing setup from 76.7% to 90.0%, an unreplicated lead to watch. Gemma 4 31B QAT failed a precise piped-dd output prediction test in reasoning mode alongside two peer models, a reminder it is weak at exact tool-output reasoning. And a user reports unresolved quality differences between Gemma 4 26B quant providers. A model-swapping MCP tool was added as a card but left out of the narrative as off-topic. Prior-cycle tier guidance is unchanged. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p>
+<p>---</p>
+<h2>Field Notes - 2026-07-18</h2>
 <p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (6 new hardware-mention entries from the July 17 ingest, 523 entries total) and their threads. Confidence is <strong>low-to-mixed</strong> this cycle. The July 17 batch came in through the Atom fallback, so scores and comment counts are unreliable (every new post shows a placeholder score around 20 with no captured comments). The one exception is a reproducible, human-run MacBook Pro benchmark that publishes its harness and raw result files, which is the strongest single datapoint in several sweeps.</p>
 <p><em>July 18 sweep, 2026-07-18 00:00 UTC:</em> a thin cycle anchored by one solid benchmark. After the July 16 ZenDNN and ExLlamaV3 items, this ingest brought a reproducible Apple-Silicon comparison that puts Gemma 4 26B at the top of a five-model average on a MacBook Pro, a coding-agent preference report that swaps Gemma 4 31B in as the primary coder over Qwen3.6-27B, a phone stunt that streams Gemma 26B (and larger MoE models) off flash storage on an 11 GB Android device, and a low-detail report that Gemma 4 12B and E2B fail to load in tensor parallel. Only the MacBook benchmark carries measured numbers; the rest are single-author anecdotes, so read the confidence notes carefully. One in-progress Gemma frankenmerge experiment and two non-Gemma model/tooling posts from the same batch were intentionally left out (see the note at the end).</p>
 <p><strong>Apple Silicon, the one measured result: on a MacBook Pro, Gemma 4 26B topped a five-model average and aced the reasoning suite, but needed about 14.7 GB of RAM, with open-ended generation (60%) its own weakest suite.</strong> A contributor who discloses helping build the benchmark tool (rapid-mlx) ran five models that fit a MacBook Pro through the same four suites: <strong>coding (HumanEval+), reasoning (MATH-500), general (MMLU-Pro), and 30 tool-calling tests</strong>, tracking real peak RAM. The reported table: <strong>Gemma 4 26B at 14.7 GB scored Tools 87%, Code 90%, Reason 100%, Gen 60%, for an 84% average, the highest of the five</strong>. Qwen3.6-27B (15.5 GB) led raw coding at 100% and tied the best tool-calling score at 93% but fell to 50% on reasoning for a 78% average; the ternary 2-bit Bonsai-27B fit in just 8.0 GB and landed second overall at 81%; GPT-OSS-20B (12.2 GB) and Nemotron-Nano-30B (18.0 GB) trailed at 65% and 61%. For Gemmaclaw's Apple Silicon tier this is a useful, on-topic datapoint: Gemma 4 26B is a strong all-rounder that wins on reasoning and overall average, but its roughly 14.7 GB peak means a base 16 GB MacBook has little headroom, and open-ended generation (60%) was its own weakest suite, where it still placed third of the five (Bonsai 80%, Qwen 70%, Gemma 60%, GPT-OSS 50%, Nemotron 40%). Confidence: measured and explicitly reproducible (harness and all five raw result files are in the repo), but a single run of small suites, a self-disclosed tool author, an AI-assisted writeup, and a placeholder score with no comments. (<a href="https://reddit.com/r/localllama/comments/1uxrpv5" target="_blank" rel="noopener">source</a>, July 16, 2026)</p>
@@ -3428,10 +3469,10 @@
 <p>The full set of 266 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
 <p><em>Last updated: 2026-06-13 (June 13 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
       <div class="community-section" id="community">
-      <h3>Community Reports (523 from r/LocalLLaMA)</h3>
+      <h3>Community Reports (528 from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>
       <div class="search-bar"><input type="text" id="community-search" placeholder="Search community reports..." autocomplete="off"></div>
-      <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (69)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (56)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (34)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (18)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (26)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (311)</button><button class="cat-filter-btn" data-cat="general">Other (159)</button></div>
+      <div class="cat-filter-bar"><button class="cat-filter-btn active" data-cat="all">All</button><button class="cat-filter-btn" data-cat="apple-silicon">Apple Silicon (69)</button><button class="cat-filter-btn" data-cat="high-gpu">High-end GPU (24+ GB) (56)</button><button class="cat-filter-btn" data-cat="mid-gpu">Mid-range GPU (8-16 GB) (35)</button><button class="cat-filter-btn" data-cat="cpu-only">CPU / Raspberry Pi (18)</button><button class="cat-filter-btn" data-cat="laptop">Laptops (26)</button><button class="cat-filter-btn" data-cat="quantization">Quantization &amp; Backends (313)</button><button class="cat-filter-btn" data-cat="general">Other (161)</button></div>
 <div id="community-cards"><div class="cr-card" data-search="gemma 4 has been released [ quantization agents anthropic google gemma google is going to show what open weights is about. happy easter everyone. gemma-4 has native thinking, tool calling and is multimodal! use temperature = 1.0, top_p = and after a week maybe : &quot;gemma 4 26b heretic uncensored ablated claude opus 4.6 reasoning distlled" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -11912,6 +11953,86 @@
   </div>
   <p class="cr-summary">EDIT / disclosure: I help build rapid-mlx (the tool here). The writeup was AI-assisted, but the benchmark is real and human-run - raw results + harness are in the repo, reproduce it yourself. I got tired of &quot;best local model&quot; advice that's either vib...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uxrpv5" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="how are y’all stomaching the “ai boom” prices? i am in the middle of considering an upgrade to my home server. i want to get a decent gpu for localai. i mean, i have an rtx 4060 ti 16gb, i know that is much more than most people have, but even though it has a lot of cram the bus width is really slowing it down - i get ~23 tok/s on gemma 4 26b a4b. i want to get something that will allow me to comfortably run decent local models so i don’t hav… hardware qwen gemma" data-cats="mid-gpu">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v07ell" target="_blank" rel="noopener">How are y’all stomaching the “AI Boom” prices?</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/AlternateWitness</span>
+      <span class="cr-date">2026-07-18</span>
+
+      <span class="cr-cat-badge">Mid-range GPU (8-16 GB)</span>
+    </div>
+  </div>
+  <p class="cr-summary">I am in the middle of considering an upgrade to my Home Server. I want to get a decent GPU for LocalAI. I mean, I have an RTX 4060 TI 16GB, I know that is much more than most people have, but even though it has a lot of cram the bus width is really s...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1v07ell" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="byte exact kv cache grafting on frozen gemma 4 we published a method to store verified knowledge as kv state and restore it byte identical to fresh computation. on gemma 4 12b, cached knowledge improved the same routing system from 76.7% to 90.0% on aime 2025. i will pitch this at agi summit on july 19. paper: &amp;#32; submitted by &amp;#32; /u/mindpsychological140 [link] &amp;#32; [comments] gemma" data-cats="general">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v07tib" target="_blank" rel="noopener">Byte exact KV cache grafting on frozen Gemma 4</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/MindPsychological140</span>
+      <span class="cr-date">2026-07-18</span>
+
+      <span class="cr-cat-badge">General</span>
+    </div>
+  </div>
+  <p class="cr-summary">We published a method to store verified knowledge as KV state and restore it byte identical to fresh computation. On Gemma 4 12B, cached knowledge improved the same routing system from 76.7% to 90.0% on AIME 2025. I will pitch this at AGI Summit on J...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1v07tib" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="which models can predict piped `dd` output in linux? edit: oh, yeah. many here are excited we gonna get 2.7t weights to download and this set (k3) achieves some synthetic results. me too. but why so few people are interested in reasoning about specific knowledge, like using linux tools? on linux mint in bash : $ set -o pipefail;dd if=/dev/zero bs=1m count=1 | dd of=/dev/null bs=1m count=1;echo $? 0+1 records in 0+1 records out 65536 bytes (66 kb, 6… quantization qwen gemma" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uzuebx" target="_blank" rel="noopener">Which models can predict piped `dd` output in Linux?</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/alex20_202020</span>
+      <span class="cr-date">2026-07-18</span>
+
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Edit: Oh, yeah. Many here are excited we gonna get 2.7T weights to download and this set (K3) achieves some synthetic results. Me too. But why so few people are interested in reasoning about specific knowledge, like using Linux tools? On Linux Mint i...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1uzuebx" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="qwen and gemma providers i like to use the moe modles qwen3.6-35b and gemma-4-26b. i noticed differences in result quality between versions from different providers, like bartowski, unsloth, lm-studio, google, etc. my tests dont give me a clear answer to though. is there a rule if thumb which provider to prefer for 1) coding and 2) chatting and general world knowledge? &amp;#32; submitted by &amp;#32; /u/scubid [link] &amp;#32; [com… google qwen gemma" data-cats="general">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uzr4ia" target="_blank" rel="noopener">Qwen and Gemma providers</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/scubid</span>
+      <span class="cr-date">2026-07-18</span>
+
+      <span class="cr-cat-badge">General</span>
+    </div>
+  </div>
+  <p class="cr-summary">I like to use the MoE modles qwen3.6-35B and Gemma-4-26B. I noticed differences in result quality between versions from different providers, like bartowski, unsloth, lm-studio, google, etc. My tests dont give me a clear answer to though. Is there a r...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1uzr4ia" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="i pulled the model-swapping core out of my streamlit app into a python library + mcp server so an agent can pin/preload/swap my local models across lm studio, ollama, and cloud a while back, i shared a streamlit app here that chained a small local drafter into a bigger coder. while building it, i realized the most useful part was actually the backend logic handling the model swaps. it solved a specific annoyance for me, so i pulled it out into a standalone library and mcp server: promptchain (mi" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v032br" target="_blank" rel="noopener">I pulled the model-swapping core out of my Streamlit app into a Python library + MCP server so an agent can pin/preload/</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/atharva557</span>
+      <span class="cr-date">2026-07-18</span>
+
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">A while back, I shared a Streamlit app here that chained a small local drafter into a bigger coder. While building it, I realized the most useful part was actually the backend logic handling the model swaps. It solved a specific annoyance for me, so ...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1v032br" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="anyone tried +- 100b models locally with foreign languages? community discussion comparing gemma 4 31b, qwen 3.6 27b, and glm 4.7 30b on non-english (primarily european) languages. original poster reports gemma 4 31b as the best at czech, noting it &quot;blows their mind&quot; at 18gb. key community finding: gemma 4 31b (16-bit) is reported as &quot;extremely good in hungarian&quot; while the 26b 8-bit variant shows some &quot;slightly chinese&quot; output contamination. expert commenter conclud" data-cats="high-gpu quantization">
   <div class="cr-card-header">

--- a/site/data/field-notes.md
+++ b/site/data/field-notes.md
@@ -1,3 +1,55 @@
+## Field Notes - 2026-07-19
+
+A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.
+Curated from the latest Gemma-mentioning posts (5 new hardware-mention entries from the July 18 ingest, 528 entries total) and their threads.
+Confidence is **low** this cycle. All five new posts came in through the Atom fallback, so every one carries a placeholder score around 20 with no captured comments, and none is a reproducible measured benchmark. The single hardware number this cycle is one user's self-reported throughput figure, so treat the whole sweep as directional community signal rather than evidence.
+
+_July 19 sweep, 2026-07-19 00:00 UTC:_ a thin cycle with no new measured benchmark. After the July 18 MacBook Pro comparison, this ingest of 40 posts surfaced five Gemma-mentioning items, four of them on-topic: a single consumer-GPU throughput datapoint (about 23 tok/s for Gemma 4 26B A4B on an RTX 4060 Ti 16GB, bottlenecked by memory bandwidth), a byte-exact KV cache grafting preprint that reports a large accuracy jump on Gemma 4 12B, a precise-reasoning failure where Gemma 4 31B QAT could not predict piped `dd` output, and an open question about which quantization provider to trust for Gemma 4 26B. A fifth post, a model-swapping MCP tool that only tags Gemma in passing, is left out of the narrative as off-topic tooling but is included as a community card. Nothing this cycle changes the tier guidance from prior sweeps.
+
+**Mid-range single GPU: one user reports about 23 tokens per second on Gemma 4 26B A4B with an RTX 4060 Ti 16GB, and says memory bandwidth, not VRAM, is the ceiling.** In an upgrade-shopping thread about inflated GPU prices, the author notes that although the **RTX 4060 Ti 16GB** has plenty of VRAM to hold the **Gemma 4 26B-A4B MoE**, its **narrow memory bus caps decode at roughly 23 tok/s**. They are weighing a next card and find the options poor: the cheapest step up is the **Intel Arc B60** (which they say has weak software support), then the **Radeon RX 7900 XT**, with little else usable under **$1,000**. For Gemmaclaw's mid-range GPU tier this is a useful, if single-user, datapoint. The sparse 26B-A4B is comfortably runnable at interactive speed on a 16 GB consumer card, and the practical limit on that class of card is memory bandwidth rather than capacity, so a card with more raw VRAM but a similar bus width will not necessarily decode faster. Confidence: a single anecdote with a placeholder score and no captured comments, and the post names no quant, context length, or backend, so the 23 tok/s figure is indicative only. ([source](https://reddit.com/r/localllama/comments/1v07ell), July 18, 2026)
+
+**Technique to watch: a preprint claims byte-exact KV cache grafting on frozen Gemma 4 12B, lifting an AIME 2025 routing setup from 76.7% to 90.0%.** The author published a method to store verified knowledge as KV state and restore it **byte identical** to fresh computation, and reports that on **Gemma 4 12B** the cached knowledge raised the same routing system from **76.7% to 90.0% on AIME 2025** (paper: arXiv 2607.14431). This is interesting for Gemmaclaw beyond a single number because it frames Gemma 4 as a candidate for cached-knowledge and prefill-reuse experiments, and it sits in the same cluster as this week's other cache-reuse work, a cache-invalidation proxy tool and a Mac Studio KV-reuse report. It is a fresh single-author preprint with a promotional framing (the author says they will pitch it at a summit the next day), a placeholder score, and no independent replication, so it is a lead to watch rather than an established result. Confidence: low, an unreplicated preprint from one author with no captured discussion. ([source](https://reddit.com/r/localllama/comments/1v07tib), July 18, 2026)
+
+**Known limit, precise reasoning: Gemma 4 31B QAT could not predict the exact output and exit code of a piped `dd` command, and neither could two other large local models.** A tester asked several models, all in reasoning mode, to predict the printout and error code of a specific two-stage `set -o pipefail; dd ... | dd ...` pipeline on Linux. **Gemma 4 31B QAT, Qwen 3.6 27B Q6, and DeepSeek V4 Flash MXFP4 all failed**, and a fourth model was still thinking when the tester gave up. These are the largest models the author runs locally. For Gemmaclaw this is a narrow but concrete reminder that Gemma 4 31B, even in reasoning mode, is unreliable at precise mechanical reasoning about tool output, the kind of exact-value prediction that matters for agentic shell work. The author had not yet tried a coding harness, which might catch or correct such errors. Confidence: a single tester, a one-shot task, a placeholder score, and no comments, so read it as one datapoint on a hard sub-skill, not a benchmark. ([source](https://reddit.com/r/localllama/comments/1uzuebx), July 18, 2026)
+
+### Best current setup (this cycle's additions)
+
+- **Mid-range single GPU (16 GB):** the sparse **Gemma 4 26B-A4B** runs at interactive speed (about **23 tok/s** for one user) on an **RTX 4060 Ti 16 GB**, with **memory bandwidth, not VRAM, the limiting factor** on that class of card ([1v07ell](https://reddit.com/r/localllama/comments/1v07ell)).
+- **Prefill and cache reuse, experimental:** if you experiment with cached-knowledge or prefill reuse, **Gemma 4 12B** is now the subject of a **byte-exact KV grafting** preprint reporting a large AIME jump, worth tracking but not yet replicated ([1v07tib](https://reddit.com/r/localllama/comments/1v07tib)).
+- **Precise shell and tool reasoning:** do **not** rely on **Gemma 4 31B QAT** to predict exact command output, since at least one deterministic `dd` test tripped it and two peer models ([1uzuebx](https://reddit.com/r/localllama/comments/1uzuebx)).
+- **No change to prior tiers:** the July 18 items (Gemma 4 26B topping a five-model MacBook Pro average at 14.7 GB, Gemma 4 31B Q8 as a credible agentic coder, phone-side MoE expert streaming at 1 to 5 tok/s, and the tensor-parallel load caveat) and all earlier tier guidance still stand. Nothing this cycle contradicts them.
+
+### What works
+
+- **Gemma 4 26B-A4B is comfortably interactive on a 16 GB consumer GPU**, about 23 tok/s on an RTX 4060 Ti for one user ([1v07ell](https://reddit.com/r/localllama/comments/1v07ell)).
+- **Gemma 4 12B is a viable base for KV-cache and prefill-reuse research**, per a new byte-exact grafting preprint, though the result is unreplicated ([1v07tib](https://reddit.com/r/localllama/comments/1v07tib)).
+
+### Known limits
+
+- **The one hardware number this cycle is a single self-report** (about 23 tok/s, RTX 4060 Ti 16 GB, Gemma 4 26B A4B) with no quant, context, or backend named, so treat it as indicative only ([1v07ell](https://reddit.com/r/localllama/comments/1v07ell)).
+- **Gemma 4 31B QAT failed a precise piped-`dd` output prediction** in reasoning mode, alongside Qwen 3.6 27B and DeepSeek V4 Flash, a reminder it is weak at exact mechanical tool-output reasoning ([1uzuebx](https://reddit.com/r/localllama/comments/1uzuebx)).
+- **The KV grafting result is an unreplicated single-author preprint** with a promotional framing and a placeholder score, not yet independent evidence ([1v07tib](https://reddit.com/r/localllama/comments/1v07tib)).
+
+### Open questions
+
+- **Which quantization provider is best for Gemma 4 26B by task?** A user running MoE Gemma 4 26B and Qwen 3.6 35B sees quality differences across bartowski, unsloth, LM Studio, and Google builds but cannot find a rule of thumb for coding versus general chat ([1uzr4ia](https://reddit.com/r/localllama/comments/1uzr4ia)).
+- **Does the byte-exact KV grafting result hold up** under independent replication and on larger Gemma 4 sizes, or is the 76.7 to 90.0 jump specific to one routing setup ([1v07tib](https://reddit.com/r/localllama/comments/1v07tib))?
+- **What is the memory-bandwidth floor for interactive Gemma 4 26B-A4B** across consumer cards, given a 16 GB RTX 4060 Ti lands near 23 tok/s and the bus, not the VRAM, is the bottleneck ([1v07ell](https://reddit.com/r/localllama/comments/1v07ell))?
+
+### Sources
+
+The Gemma-mentioning posts driving this update (July 19 sweep, newest first). All five are **placeholder-score (~20), zero-comment** items from the Atom-fallback ingest, so weight them accordingly. There is **no reproducible measured benchmark** this cycle:
+
+- [How are y'all stomaching the "AI Boom" prices?](https://reddit.com/r/localllama/comments/1v07ell) (Jul 18, 2026, an upgrade thread reporting about 23 tok/s on Gemma 4 26B A4B with an RTX 4060 Ti 16GB and calling out the narrow memory bus as the bottleneck. No quant, context, or backend named)
+- [Byte exact KV cache grafting on frozen Gemma 4](https://reddit.com/r/localllama/comments/1v07tib) (Jul 18, 2026, a preprint (arXiv 2607.14431) claiming byte-identical KV state restore, with Gemma 4 12B improving from 76.7% to 90.0% on an AIME 2025 routing setup. Single author, promotional framing, unreplicated)
+- [Which models can predict piped dd output in Linux?](https://reddit.com/r/localllama/comments/1uzuebx) (Jul 18, 2026, a precise reasoning test where Gemma 4 31B QAT, Qwen 3.6 27B Q6, and DeepSeek V4 Flash all failed to predict the exact output and exit code of a two-stage dd pipeline)
+- [Qwen and Gemma providers](https://reddit.com/r/localllama/comments/1uzr4ia) (Jul 18, 2026, a user asks which provider quant, bartowski, unsloth, LM Studio, or Google, is best for Gemma 4 26B and Qwen 3.6 35B for coding versus general use. No answer reached)
+- [promptchain: pin, preload, and swap local models across backends](https://reddit.com/r/localllama/comments/1v032br) (Jul 18, 2026, a model-swapping Python library and MCP server that tags Gemma only in passing. Included as a community card but off-topic for the Gemma 4 hardware narrative)
+
+_Last updated: 2026-07-19 (July 19 sweep). Confidence: low (five placeholder-score Atom-fallback anecdotes, no reproducible measured benchmark this cycle). Key findings: one user reports about 23 tok/s for Gemma 4 26B A4B on an RTX 4060 Ti 16 GB and identifies memory bandwidth, not VRAM, as the ceiling on that class of card. A single-author preprint claims byte-exact KV cache grafting on frozen Gemma 4 12B, raising an AIME 2025 routing setup from 76.7% to 90.0%, an unreplicated lead to watch. Gemma 4 31B QAT failed a precise piped-dd output prediction test in reasoning mode alongside two peer models, a reminder it is weak at exact tool-output reasoning. And a user reports unresolved quality differences between Gemma 4 26B quant providers. A model-swapping MCP tool was added as a card but left out of the narrative as off-topic. Prior-cycle tier guidance is unchanged. Next update fires when the daily Gemma 4 research cron flags notable new findings._
+
+---
+
 ## Field Notes - 2026-07-18
 
 A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.

--- a/site/data/gemma4-hardware-configs.json
+++ b/site/data/gemma4-hardware-configs.json
@@ -4538,5 +4538,42 @@
       "- Score: 20",
       "EDIT / disclosure: I help build rapid-mlx (the tool here). The writeup was AI-assisted, but the benchmark is real and human-run - raw results + harness are in the repo, reproduce it yourself. I got tired of \"best local model\" advice that's either vibes or benchmarked on a $6k Mac Studio, so I ran 5 models that actually fit a MacBook Pro through the same coding (HumanEval+), reasoning (MATH-500), general (MMLU-Pro), and 30 tool-calling tests, and tracked real peak RAM. Model RAM Tools Code Reason Gen Avg Bonsai-27B (2-bit) 8.0 GB 93% 80% 70% 80% 81% Gemma-4-26B 14.7 GB 87% 90% 100% 60% 84% Qwen3.6-27B 15.5 GB 93% 100% 50% 70% 78% GPT-OSS-20B 12.2 GB 80% 50% 80% 50% 65% Nemotron-Nano-30B 18.0 GB 83% 50% 70% 40% 61% Two things surprised me: 1. Bonsai-27B is a ternary (2-bit) 27B that fits in 8 GB - less than models with a third of its parameters - and it landed 2nd overall and tied for the best tool-calling score (93%). It's the only one a base 16 GB MacBook can run with real headroom. I didn't believe it either, so the harness + all 5 raw result files are in the repo - run it yourself. 2. Nemotron-Nano-30B beats Qwen3 and GPT-OSS on the public LiveCodeBench leaderboard, but came dea…"
     ]
+  },
+  {
+    "post": "1v07ell",
+    "file": "1v07ell.md",
+    "hardware_mentions": [
+      "- Score: 20",
+      "I have an RTX 4060 TI 16GB, I know that is much more than most people have, but even though it has a lot of cram the bus width is really slowing it down - I get ~23 tok/s on Gemma 4 26b A4B. The cheapest being the Intel Arc B60, but apparently the support for that is atrocious. The next best thing is the Rx 7900 XT, and then pretty much nothing under $1,000."
+    ]
+  },
+  {
+    "post": "1v07tib",
+    "file": "1v07tib.md",
+    "hardware_mentions": [
+      "- Score: 20",
+      "We published a method to store verified knowledge as KV state and restore it byte identical to fresh computation. On Gemma 4 12B, cached knowledge improved the same routing system from 76.7% to 90.0% on AIME 2025."
+    ]
+  },
+  {
+    "post": "1uzuebx",
+    "file": "1uzuebx.md",
+    "hardware_mentions": [
+      "- Score: 20",
+      "I have asked to predict above printout and error code given those two commands the following models (all in reasoning mode): Gemma-4-31B QAT, Qwen-3.6-27B Q6, DS-V4-Flash MXFP4, Step 3.7 Flash Q4. Three others failed. Those are largest models I run locally."
+    ]
+  },
+  {
+    "post": "1uzr4ia",
+    "file": "1uzr4ia.md",
+    "hardware_mentions": [
+      "- Score: 20",
+      "I like to use the MoE modles qwen3.6-35B and Gemma-4-26B. I noticed differences in result quality between versions from different providers, like bartowski, unsloth, lm-studio, google, etc."
+    ]
+  },
+  {
+    "post": "1v032br",
+    "file": "1v032br.md",
+    "hardware_mentions": ["- Score: 20"]
   }
 ]


### PR DESCRIPTION
## Summary

July 19 Gemma 4 research sweep for the Gemmaclaw community/hardware page. A **thin, low-confidence** cycle with **no new reproducible measured benchmark**: all five new posts came in via the Atom fallback (placeholder score ~20, zero comments). Content is synthesized into guide prose grouped by hardware/config pattern, not dumped raw.

### Editorial changes
- New **"Field Notes - 2026-07-19"** section in `site/data/field-notes.md` with the standard structure: intro + sweep summary, per-datapoint paragraphs, **Best current setup**, **What works**, **Known limits**, **Open questions**, **Sources**, and a last-updated/confidence line.
- **5 new community cards** appended to `site/data/gemma4-hardware-configs.json` (523 -> 528 entries).
- `site/community.html` regenerated deterministically via `scripts/site/generate-site.py` (report count 523 -> 528, category filter counts, cards, field-notes render).

### Datapoints this cycle (all anecdotal / low confidence)
- **Mid-range single GPU:** ~23 tok/s for **Gemma 4 26B A4B** on an **RTX 4060 Ti 16GB**, poster says **memory bandwidth, not VRAM**, is the ceiling ([1v07ell](https://reddit.com/r/localllama/comments/1v07ell)).
- **Technique to watch:** byte-exact **KV cache grafting** preprint on frozen **Gemma 4 12B**, reports 76.7% -> 90.0% on an AIME 2025 routing setup (arXiv 2607.14431, single author, unreplicated) ([1v07tib](https://reddit.com/r/localllama/comments/1v07tib)).
- **Known limit:** **Gemma 4 31B QAT** (with Qwen 3.6 27B and DeepSeek V4 Flash) failed a precise piped-`dd` output prediction ([1uzuebx](https://reddit.com/r/localllama/comments/1uzuebx)).
- **Open question:** which quant provider (bartowski / unsloth / LM Studio / Google) is best for **Gemma 4 26B** ([1uzr4ia](https://reddit.com/r/localllama/comments/1uzr4ia)).
- A model-swapping MCP tool ([1v032br](https://reddit.com/r/localllama/comments/1v032br)) is added as a card but **left out of the narrative** as off-topic tooling.

### Source knowledge files
- `knowledge/reddit/localllama/gemma4-hardware-configs.json` (528 hardware-mention entries)
- `knowledge/reddit/localllama/gemma4-latest.md`
- `knowledge/reddit/localllama/digests/2026-07-18.md`
- `knowledge/reddit/localllama/posts/{1v07ell,1v07tib,1uzuebx,1uzr4ia,1v032br}.md`

### Checks run
- `scripts/site/check-site-quality.sh` -> ALL CHECKS PASSED
- `scripts/check-no-typographic-dashes.sh --diff origin/main` -> OK (no typographic dashes)
- `oxfmt --check` on data files -> no-op (verified no underscore corruption)
- `pnpm check:changed` -> PASS
- `pnpm test:changed` -> PASS (no changed test targets; site-only change)

Note: the main `CI` workflow is chronically red on `main` and unrelated to `site/`-only changes; the gating workflow for the live site is **Deploy Site** (GitHub Pages).