### PR TITLE
fix(site): stop the community renderer eating trailing underscores in Reddit handles

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -1450,11 +1450,15 @@ def clean_markdown(text):
     text = re.sub(r'\*([^*]+)\*', r'\1', text)
     text = re.sub(r'(?<![A-Za-z0-9])__([^_]+)__(?![A-Za-z0-9])', r'\1', text)
     text = re.sub(r'(?<![A-Za-z0-9])_([^_]+)_(?![A-Za-z0-9])', r'\1', text)
-    # Every matched emphasis pair is gone by now, so any underscore still sitting at
-    # a word boundary is an unclosed delimiter (Reddit summaries are truncated
-    # mid-span all the time) and would render as a literal stray _. Drop those and
-    # keep only the intraword ones, which belong to identifiers like Q4_K_M.
-    text = re.sub(r'(?<![A-Za-z0-9])_|_(?![A-Za-z0-9])', '', text)
+    # Every matched emphasis pair is gone by now, so an underscore that opened a span
+    # and never closed it is left over (Reddit summaries get truncated mid-span all
+    # the time) and would render as a literal stray _. Drop only that shape: a run of
+    # underscores with no alphanumeric before and a word right after, which is what a
+    # stranded CommonMark opener looks like. A TRAILING underscore is deliberately
+    # left alone, because it is far more often the tail of a real Reddit handle
+    # (u/jipok_, /u/mjsxi__) than a stranded closer, and eating it misattributes a
+    # named person. Intraword underscores survive either way; they belong to Q4_K_M.
+    text = re.sub(r'(?<![A-Za-z0-9])_+(?=[A-Za-z0-9])', '', text)
     # Remove markdown escape backslashes
     text = re.sub(r'\\([_*#\[\]()])', r'\1', text)
     # Remove markdown headings

--- a/scripts/site/test_generate_site.py
+++ b/scripts/site/test_generate_site.py
@@ -221,6 +221,27 @@ class TestQuantSearchNormalization(unittest.TestCase):
             "2026-05-07 edit: I do not recommend q4_0 KV cache",
         )
 
+    def test_clean_markdown_keeps_a_trailing_handle_underscore(self):
+        """Reddit handles routinely end in one or more underscores. Stripping the
+        trailing run to tidy up stranded emphasis closers renames a real person, so
+        the cleanup deliberately only fires on the opener shape."""
+        self.assertEqual(
+            gen.clean_markdown("sincerely thank u/jipok_ for helping out"),
+            "sincerely thank u/jipok_ for helping out",
+        )
+        self.assertEqual(
+            gen.clean_markdown("submitted by /u/mjsxi__ [link]"),
+            "submitted by /u/mjsxi__ [link]",
+        )
+
+    def test_trailing_handle_underscore_does_not_leak_into_search(self):
+        """The handle keeps its underscore for display, but the search index and the
+        typed query both drop identifier punctuation, so it stays reachable."""
+        post = self._post(title="Credit", summary="thanks u/jipok_ for the audit")
+        self.assertIn("jipok", self._data_search(post))
+        for query in ("jipok", "jipok_", "u/jipok_"):
+            self.assertTrue(self._matches(post, query), f"query {query!r} must match")
+
     def test_adjacent_tokens_stay_searchable(self):
         post = self._post(
             title="Mixed token soak test",

--- a/site/community.html
+++ b/site/community.html
@@ -9543,7 +9543,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Link to last post Before anything else, I'd like to sincerely thank u/jipok for helping out by highlighting a few weak questions, categories and scoring issues, which have now been addressed (Dropping &gt;100 questions, tuning the scoring methodology fo...</p>
+  <p class="cr-summary">Link to last post Before anything else, I'd like to sincerely thank u/jipok_ for helping out by highlighting a few weak questions, categories and scoring issues, which have now been addressed (Dropping &gt;100 questions, tuning the scoring methodology f...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u6y5l5" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="best models in 3x3090 (72gb vram) in q2 2026? sometime around the beginning of the year i setup my llm computer 3x3090 in a very old ddr4 computer, so i only use the 72gb vram to load the models (for speed) i’ve been mostly using these three models: gptoss 120b still pretty sold qwen35 122b very (very!!) good for one shot coding but extremely over thinking in my opinion glm air 45 106b in nonthink by default which i use a lot for… hardware quantization qwen gemma" data-cats="high-gpu quantization">
@@ -10441,7 +10441,7 @@
       <span class="cr-cat-badge">Apple Silicon</span>
     </div>
   </div>
-  <p class="cr-summary">the MLX version of the QAT 4bit is like 27gb but the none QAT version is 17gb and the regular 4bit MLX version is also 17gb… anyone know why? &amp;#32; submitted by &amp;#32; /u/mjsxi [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">the MLX version of the QAT 4bit is like 27gb but the none QAT version is 17gb and the regular 4bit MLX version is also 17gb… anyone know why? &amp;#32; submitted by &amp;#32; /u/mjsxi__ [link] &amp;#32; [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u0cu9e" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="need some help from someone who knows llamacpp vulkan builds (docker in this case) this morning i noticed gemma4 31b's reasoning phase was being completely skipped confused, i started troubleshooting i knew for a fact this worked a few days ago after about an hour, i realized something: llamacpp has been updated a lot in light of the new gemma 4 12b unified s… metallama gemma" data-cats="general">


### PR DESCRIPTION
Follow-up to #358, found while QA-verifying that PR against production.

## The defect

#358 added a cleanup pass to drop stranded markdown emphasis delimiters, left over once identifier underscores stopped being read as emphasis:

```python
re.sub(r'(?<![A-Za-z0-9])_|_(?![A-Za-z0-9])', '', text)
```

The **first** alternative does the intended work: it removes the orphaned opener in a truncated summary such as `_2026-05-07 edit: ... q4_0 ...`.

The **second** alternative removes any underscore not followed by an alphanumeric. A Reddit handle ending in an underscore is exactly that shape, so two real people are named wrong on the live page right now:

| source data | live page today |
| --- | --- |
| `thank u/jipok_ for helping` | `thank u/jipok` |
| `submitted by /u/mjsxi__ [link]` | `submitted by /u/mjsxi` |

Both are correct in `site/data/gemma4-hardware-configs.json` and both rendered correctly before #358. The second is visibly inconsistent with itself on the page: the comment byline still reads `mjsxi__` while the summary directly below reads `mjsxi`.

## The fix

A trailing underscore is genuinely ambiguous between a stranded emphasis closer and the tail of a handle. Getting a person's name right matters more than tidying a stray underscore, so the cleanup now only fires on the opener shape: a run of underscores with no alphanumeric before it and a word immediately after.

```python
re.sub(r'(?<![A-Za-z0-9])_+(?=[A-Za-z0-9])', '', text)
```

Search is unaffected either way, because `normalize_search_text()` drops underscores on both the index side and the query side. `u/jipok_` stays reachable by `jipok`, `jipok_` and `u/jipok_` alike. Two tests pin both halves: one for the display form, one for the search form.

## Blast radius

Regenerating the entire site changes **exactly two lines**, the two summaries above. Every quant-recall number from #358 is untouched.

## Checks run

- `pytest scripts/site/test_generate_site.py` -> 31 passed (29 from #358 plus 2 new)
- the new display test fails against the #358 generator, so it guards the defect rather than describing the code
- `scripts/site/check-site-quality.sh` -> ALL CHECKS PASSED, exit 0
- `pnpm check:changed` -> exit 0, oxlint 0 warnings 0 errors
- `pnpm test:changed` -> exit 0, no changed vitest targets
- added-line dash gate clean vs `origin/main`
- pre-commit `oxfmt --write` left the tree clean, so it was a no-op