### PR TITLE
site: render pre-escaped HTML entities as characters on the community page

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -10,6 +10,8 @@ import os
 import re
 import sys
 import ast
+import unicodedata
+from html.entities import html5 as HTML5_ENTITIES
 from pathlib import Path
 from datetime import datetime
 
@@ -1409,6 +1411,52 @@ def normalize_typographic_dashes(text):
     return str(text).translate(_TYPOGRAPHIC_DASH_MAP)
 
 
+# Reddit serves some characters PRE-ESCAPED as HTML entities inside the post
+# markdown this site archives: a submission footer arrives literally as
+# "&#32; submitted by &#32; /u/name", and "&amp;", "&gt;", "&lt;" turn up in
+# titles and comment bodies. html_escape() then escapes that ampersand again, so
+# the browser receives "&amp;#32;" and paints the characters "&#32;" mid-sentence.
+# Only well-formed, semicolon-terminated entities are decoded. html.unescape() is
+# deliberately NOT used: it also resolves the bare legacy forms, so it rewrites
+# "&notarealentity;" to "not-sign + arealentity;" and "2 &times 3090s" to a
+# multiplication sign, corrupting ordinary prose that merely contains an ampersand.
+_UPSTREAM_ENTITY_RE = re.compile(
+    r'&(?:#\d{1,7}|#[xX][0-9A-Fa-f]{1,6}|[A-Za-z][A-Za-z0-9]{1,31});'
+)
+
+
+def _decode_upstream_entity(match):
+    """Resolve one entity token, or return it untouched if it is not a real one."""
+    token = match.group(0)
+    body = token[1:-1]
+    if body.startswith("#"):
+        try:
+            codepoint = int(body[2:], 16) if body[1] in "xX" else int(body[1:])
+        except (ValueError, IndexError):
+            return token
+        if not 0 <= codepoint <= 0x10FFFF or 0xD800 <= codepoint <= 0xDFFF:
+            return token
+        decoded = chr(codepoint)
+        # A numeric reference to a control character is upstream noise, never
+        # display text; leaving it encoded keeps it out of the generated page.
+        if decoded not in "\t\n\r" and unicodedata.category(decoded) == "Cc":
+            return token
+        return decoded
+    # Keyed with the trailing semicolon so only the canonical form resolves.
+    return HTML5_ENTITIES.get(body + ";", token)
+
+
+def unescape_upstream_entities(text):
+    """Decode HTML entities that upstream already escaped, before we escape again.
+
+    Pure and deterministic. An unrecognized "&name;" is left verbatim. Must run
+    BEFORE normalize_typographic_dashes() and before html_escape(): a decoded
+    "&mdash;" is a real em dash and has to reach the dash normalizer, and a
+    decoded "&" has to reach the escaper so it ships as a single "&amp;".
+    """
+    return _UPSTREAM_ENTITY_RE.sub(_decode_upstream_entity, str(text))
+
+
 # Punctuation that lives *inside* model, quant and tooling identifiers, which
 # readers type inconsistently: Q4_K_M vs q4km, llama.cpp vs llamacpp, 26B-A4B vs
 # 26ba4b. Dropping it from the generated index and the typed query alike is what
@@ -1430,6 +1478,11 @@ def normalize_search_text(text):
 
 def clean_markdown(text):
     """Strip markdown syntax to plain text for display in HTML cards."""
+    # Decode what upstream already escaped FIRST, for the same ordering reason the
+    # backslash unescape below exists: every rule after this point (dash mapping,
+    # link stripping, whitespace collapse) and html_escape() downstream must see the
+    # character an entity denotes, not the entity's own punctuation.
+    text = unescape_upstream_entities(text)
     # Normalize typographic dashes to ASCII hyphen so community card text (summary,
     # search index, comments) never emits em/en dashes from raw Reddit excerpts.
     text = normalize_typographic_dashes(text)
@@ -1726,7 +1779,10 @@ def generate_community_cards(posts):
     cards = []
     for post in posts:
         post_id = post["id"]
-        title = html_escape(normalize_typographic_dashes(post["title"])[:120])
+        # Titles and flair skip clean_markdown(), so they need the same upstream
+        # entity decode: three archived titles carry "&amp;" and would otherwise
+        # render the six literal characters instead of an ampersand.
+        title = html_escape(normalize_typographic_dashes(unescape_upstream_entities(post["title"]))[:120])
         score = post["score"]
         clean_summary = clean_markdown(post["summary"])
         if not clean_summary:
@@ -1738,7 +1794,7 @@ def generate_community_cards(posts):
             summary += "..."
         author = html_escape(post["author"])
         date_str = post["date"]
-        flair = html_escape(normalize_typographic_dashes(post["flair"])) if post["flair"] else ""
+        flair = html_escape(normalize_typographic_dashes(unescape_upstream_entities(post["flair"]))) if post["flair"] else ""
         reddit_url = f"https://reddit.com/r/LocalLLaMA/comments/{post_id}"
         cats = " ".join(post["categories"])
 
@@ -1807,6 +1863,11 @@ def generate_community_cards(posts):
     return filter_bar + '\n<div id="community-cards">' + "\n".join(cards) + '</div>'
 
 
+def _reescape_angle_brackets(text):
+    """Re-escape only the angle brackets in text that is already HTML-escaped."""
+    return text.replace("<", "&lt;").replace(">", "&gt;")
+
+
 def render_field_notes_markdown(md_text):
     """Render the curated field-notes Markdown into an HTML fragment.
 
@@ -1837,8 +1898,14 @@ def render_field_notes_markdown(md_text):
         # Inline links [text](url)
         def link_sub(m):
             label, url = m.group(1), m.group(2)
-            return (f'<a href="{html_escape(url)}" target="_blank" '
-                    f'rel="noopener">{html_escape(label)}</a>')
+            # Both groups come out of the already-escaped string below, so escaping
+            # them again turns a quoted title's &quot; into &amp;quot; and paints
+            # the literal characters &quot; on the page (and would break any URL
+            # carrying a query string). Only "<" and ">" need re-escaping, because
+            # they are the two the caller temporarily decoded so this regex could
+            # see the markdown at all.
+            return (f'<a href="{_reescape_angle_brackets(url)}" target="_blank" '
+                    f'rel="noopener">{_reescape_angle_brackets(label)}</a>')
         # Escape first, then re-apply markdown so links/emphasis work safely.
         escaped = html_escape(text)
         # Convert escaped brackets back so the regex matches our markdown links.

--- a/scripts/site/test_generate_site.py
+++ b/scripts/site/test_generate_site.py
@@ -340,5 +340,115 @@ class TestCategorizePost(unittest.TestCase):
         self.assertEqual(gen.categorize_post(post), ["general"])
 
 
+class TestUpstreamEntityUnescaping(unittest.TestCase):
+    """Reddit serves some characters PRE-ESCAPED inside the archived markdown, so
+    the submission footer of post 1vfeick arrives as the literal sequence
+    "&#32; submitted by &#32; /u/jacek2023 [link] &#32; [comments]".
+
+    html_escape() escaped that ampersand a second time, the browser received
+    "&amp;#32;", and the card painted the characters "&#32;" mid-sentence. Same
+    ordering defect as the pre-escaped-underscore search bug: normalize what
+    upstream escaped BEFORE applying our own transformation.
+    """
+
+    def test_numeric_space_entity_becomes_whitespace_not_literal_text(self):
+        raw = "&#32; submitted by &#32; /u/jacek2023 [link] &#32; [comments]"
+        cleaned = gen.clean_markdown(raw)
+        self.assertNotIn("&#32;", cleaned)
+        self.assertNotIn("#32", cleaned)
+        self.assertEqual(cleaned, "submitted by /u/jacek2023 [link] [comments]")
+
+    def test_rendered_card_summary_carries_no_double_escaped_entity(self):
+        """End of the real pipeline: clean_markdown() then html_escape() is what
+        writes the card body, and neither "&amp;#32;" nor "&#32;" may survive."""
+        rendered = gen.html_escape(gen.clean_markdown(
+            "&#32; submitted by &#32; /u/jacek2023 [link] &#32; [comments]"
+        ))
+        self.assertNotIn("&amp;#32;", rendered)
+        self.assertNotIn("#32", rendered)
+        self.assertEqual(rendered, "submitted by /u/jacek2023 [link] [comments]")
+
+    def test_named_entities_render_as_their_character(self):
+        """A comment body carrying "&lt;turn|&gt;" must reach the page as the
+        angle-bracketed token, escaped exactly once."""
+        rendered = gen.html_escape(gen.clean_markdown("harmony leaks &lt;turn|&gt; markers"))
+        self.assertNotIn("&amp;lt;", rendered)
+        self.assertNotIn("&amp;gt;", rendered)
+        self.assertEqual(rendered, "harmony leaks &lt;turn|&gt; markers")
+
+    def test_escaped_ampersand_ships_as_one_amp_entity(self):
+        rendered = gen.html_escape(gen.clean_markdown("v1.0.13 &amp; v1.0.14 updates"))
+        self.assertNotIn("&amp;amp;", rendered)
+        self.assertEqual(rendered, "v1.0.13 &amp; v1.0.14 updates")
+
+    def test_title_path_unescapes_too(self):
+        """Titles skip clean_markdown(), so they carry their own decode."""
+        title = gen.html_escape(gen.normalize_typographic_dashes(
+            gen.unescape_upstream_entities("Setup &amp; Working Config")
+        ))
+        self.assertNotIn("&amp;amp;", title)
+        self.assertEqual(title, "Setup &amp; Working Config")
+
+    def test_decoded_dash_entity_still_reaches_the_dash_normalizer(self):
+        """Ordering guard: the decode must run BEFORE normalize_typographic_dashes,
+        or "&mdash;" would smuggle a real em dash past the no-dashes gate."""
+        out = gen.clean_markdown("24 GB &mdash; enough for the 26B")
+        for cp in (0x2012, 0x2013, 0x2014, 0x2015, 0x2E3A, 0x2E3B, 0x2212):
+            self.assertNotIn(chr(cp), out)
+        self.assertEqual(out, "24 GB - enough for the 26B")
+
+    def test_bare_ampersand_prose_is_left_alone(self):
+        """Only well-formed semicolon-terminated entities decode. A stray "&times"
+        or "&copy" in ordinary prose must not be rewritten into a symbol."""
+        self.assertEqual(
+            gen.unescape_upstream_entities("2 &times 3090s, R&D budget, AT&T"),
+            "2 &times 3090s, R&D budget, AT&T",
+        )
+
+    def test_unknown_entity_name_is_preserved(self):
+        self.assertEqual(gen.unescape_upstream_entities("&notarealentity;"), "&notarealentity;")
+
+    def test_unescape_is_idempotent_on_plain_text(self):
+        plain = "Q4_K_M on a 3090 at 26 tok/s"
+        self.assertEqual(gen.unescape_upstream_entities(plain), plain)
+
+
+class TestFieldNotesLinkDoubleEscape(unittest.TestCase):
+    """Second, DISTINCT escaping defect with the same reader-visible symptom.
+
+    render_inline() escapes the whole line, then link_sub() escaped the captured
+    label a second time, so a Sources entry whose Reddit title carries a plain
+    ASCII quote shipped as "&amp;quot;" and painted the characters &quot; on the
+    community page. Unlike the entity defect above, nothing upstream is
+    pre-escaped here: the generator escapes its own output twice.
+    """
+
+    def test_quoted_link_label_is_escaped_exactly_once(self):
+        out = gen.render_field_notes_markdown(
+            '- [My local AI developed an "attitude"](https://reddit.com/r/localllama/comments/1v7kf8o) (Jul 27)'
+        )
+        self.assertNotIn("&amp;quot;", out)
+        self.assertIn("developed an &quot;attitude&quot;</a>", out)
+
+    def test_ampersand_link_label_is_escaped_exactly_once(self):
+        out = gen.render_field_notes_markdown(
+            "- [Qwen & Gemma on deadlock situation](https://reddit.com/r/localllama/comments/1uoppuz)"
+        )
+        self.assertNotIn("&amp;amp;", out)
+        self.assertIn("Qwen &amp; Gemma on deadlock situation</a>", out)
+
+    def test_url_query_string_is_not_double_escaped(self):
+        out = gen.render_field_notes_markdown("- [docs](https://example.com/a?x=1&y=2)")
+        self.assertIn('href="https://example.com/a?x=1&amp;y=2"', out)
+        self.assertNotIn("&amp;amp;", out)
+
+    def test_angle_brackets_in_a_label_stay_escaped(self):
+        """The caller decodes &lt;/&gt; so this regex can see the markdown, so the
+        link builder has to put them back or raw markup would reach the page."""
+        out = gen.render_field_notes_markdown("- [a <b> tag](https://example.com)")
+        self.assertIn("a &lt;b&gt; tag</a>", out)
+        self.assertNotIn("<b>", out)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/site/community.html
+++ b/site/community.html
@@ -2281,7 +2281,7 @@
 <li><a href="https://reddit.com/r/localllama/comments/1v88p7k" target="_blank" rel="noopener">Is ROCM slower than vulkan for you?</a> (Jul 27, 2026, RX 6650 XT, LM Studio 2.27.1 Linux; Gemma 4 E4B about 8 to 10 tok/s faster on Vulkan than ROCm at 26,200 context)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1v83ace" target="_blank" rel="noopener">What To Run on A Remotely Accessible Gaming PC?</a> (Jul 27, 2026, Ryzen 5 7600X, RX 7900XTX 24 GB, 32 GB DDR5, Tailscale remote; notes 24 GB fits Qwen 3.6 27B, Gemma 4 26B and 31B, a configuration question with no numbers)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1v7sqa7" target="_blank" rel="noopener">Current smallest usable coding model</a> (Jul 27, 2026, 4 GB VRAM, 40 GB RAM; Gemma 4 and Qwen 3.6 out of reach, seeking the smallest usable agentic-coding model)</li>
-<li><a href="https://reddit.com/r/localllama/comments/1v7kf8o" target="_blank" rel="noopener">My local AI developed a personality with an &amp;quot;attitude&amp;quot;</a> (Jul 27, 2026, Gemma 4 31B grew an unprompted sarcastic persona, not reproducible, a behavioral anecdote with no hardware)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1v7kf8o" target="_blank" rel="noopener">My local AI developed a personality with an &quot;attitude&quot;</a> (Jul 27, 2026, Gemma 4 31B grew an unprompted sarcastic persona, not reproducible, a behavioral anecdote with no hardware)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1v73ux4" target="_blank" rel="noopener">23 Gemma4-E4B models compared with abliterlitics</a> (Jul 26, 2026, 23 Gemma 4 E4B fine-tunes and abliterations benchmarked; the most-downloaded is the most broken, full report on HuggingFace and the author's site)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1v70r06" target="_blank" rel="noopener">Sapphire r9700 fan noise</a> (Jul 26, 2026, a buying and noise question for a Sapphire R9700 versus a quiet 7800XT, planned for Qwen 27B and Gemma 4 31B, no performance data)</li>
 </ul>
@@ -2523,7 +2523,7 @@
 <p>The Gemma-related posts driving this update (July 21 sweep, newest first). All are <strong>placeholder-score (about 20), zero-comment</strong> items from the Atom-fallback ingest, and none is a hardware measurement, so this cycle adds no new tier data:</p>
 <ul class="setup-list">
 <li><a href="https://reddit.com/r/localllama/comments/1v1ccun" target="_blank" rel="noopener">Gemma 4 is still lazy</a> (Jul 20, 2026, a user running gemma-4-31B-it-qat UD-Q4_K_XL at 147K context with the latest chat template and preserve-thinking reports the model stops early on Hermes agentic tasks after a couple of tool calls, while Qwen 3.6 27B, DeepSeek V4 Flash, and GPT-OSS 120B keep going, the cycle's only actionable item)</li>
-<li><a href="https://reddit.com/r/localllama/comments/1v22noq" target="_blank" rel="noopener">Vienna &amp;quot;Patchwerk&amp;quot; Sausage Architecture for gemma4</a> (Jul 21, 2026, a self-described AI-assisted hobby mixture-of-experts band experiment on Gemma 4, which the author says is highly unlikely to beat the base model except in a few narrow domains, no hardware or benchmark detail)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1v22noq" target="_blank" rel="noopener">Vienna &quot;Patchwerk&quot; Sausage Architecture for gemma4</a> (Jul 21, 2026, a self-described AI-assisted hobby mixture-of-experts band experiment on Gemma 4, which the author says is highly unlikely to beat the base model except in a few narrow domains, no hardware or benchmark detail)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1v21j14" target="_blank" rel="noopener">Google has disappeared completely from the top 15</a> (Jul 20, 2026, an opinion thread arguing Google has not shipped a frontier-competitive model recently and speculating about an on-device pivot, cited from a public AI leaderboard, sentiment rather than a Gemma 4 hardware report)</li>
 </ul>
 <p><em>Last updated: 2026-07-21 (July 21 sweep). Confidence: low (three placeholder-score, zero-comment Atom-fallback posts, none a hardware measurement). Key point: no new speed, VRAM, quantization, or context-length data for Gemma 4 this cycle. The one actionable item is a hands-on report that Gemma 4 31B QAT still stops early on multi-turn agentic work even with the latest chat template and preserve-thinking, reinforcing and extending the July 20 finding that Gemma 4 26B A4B doomloops on agentic loops. The other two posts are an AI-assisted &quot;Patchwerk&quot; mixture-of-experts hobby experiment on Gemma 4 and an ecosystem-sentiment thread about Google's frontier standing. Tier guidance carries over unchanged from the July 16 through July 20 sweeps, with the agentic-guard caveat now firmer and extended to the 31B QAT. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p>
@@ -2608,7 +2608,7 @@
 <h3>Sources</h3>
 <p>The Gemma-mentioning posts driving this update (July 19 sweep, newest first). All five are <strong>placeholder-score (~20), zero-comment</strong> items from the Atom-fallback ingest, so weight them accordingly. There is <strong>no reproducible measured benchmark</strong> this cycle:</p>
 <ul class="setup-list">
-<li><a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">How are y'all stomaching the &amp;quot;AI Boom&amp;quot; prices?</a> (Jul 18, 2026, an upgrade thread reporting about 23 tok/s on Gemma 4 26B A4B with an RTX 4060 Ti 16GB and calling out the narrow memory bus as the bottleneck. No quant, context, or backend named)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1v07ell" target="_blank" rel="noopener">How are y'all stomaching the &quot;AI Boom&quot; prices?</a> (Jul 18, 2026, an upgrade thread reporting about 23 tok/s on Gemma 4 26B A4B with an RTX 4060 Ti 16GB and calling out the narrow memory bus as the bottleneck. No quant, context, or backend named)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1v07tib" target="_blank" rel="noopener">Byte exact KV cache grafting on frozen Gemma 4</a> (Jul 18, 2026, a preprint (arXiv 2607.14431) claiming byte-identical KV state restore, with Gemma 4 12B improving from 76.7% to 90.0% on an AIME 2025 routing setup. Single author, promotional framing, unreplicated)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1uzuebx" target="_blank" rel="noopener">Which models can predict piped dd output in Linux?</a> (Jul 18, 2026, a precise reasoning test where Gemma 4 31B QAT, Qwen 3.6 27B Q6, and DeepSeek V4 Flash all failed to predict the exact output and exit code of a two-stage dd pipeline)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1uzr4ia" target="_blank" rel="noopener">Qwen and Gemma providers</a> (Jul 18, 2026, a user asks which provider quant, bartowski, unsloth, LM Studio, or Google, is best for Gemma 4 26B and Qwen 3.6 35B for coding versus general use. No answer reached)</li>
@@ -2904,7 +2904,7 @@
 <h3>Sources</h3>
 <p>The Gemma-mentioning posts driving this update (July 11 sweep, newest first). The July 10 ingest fell back to Reddit's Atom feed, so <strong>no comment threads were captured and all post scores are placeholders (~20)</strong>. Treat every item as an uncorroborated single-author anecdote, not a settled result:</p>
 <ul class="setup-list">
-<li><a href="https://reddit.com/r/localllama/comments/1uspcg0" target="_blank" rel="noopener">Has anyone created a &amp;quot;Local LLM Survival Kit&amp;quot;?</a> (Jul 10, 2026, proposes a sub-10-dollar 64 GB USB drive with CPU-only llama.cpp binaries for Windows, macOS, and Linux, a compressed Wikipedia and reference SQLite database, and a browser chat frontend. Picks Gemma 4 E4B at Q4_K_M (~5 GB) as the low-RAM model and Qwen3.5 35B-A3B at Q4_K_M (~22 GB) for machines with at least 32 GB RAM. Estimates 5 to 20 tok/s CPU-only with no GPU on almost any PC from the past 15 years. Concept and discussion, unmeasured, 0 comments)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1uspcg0" target="_blank" rel="noopener">Has anyone created a &quot;Local LLM Survival Kit&quot;?</a> (Jul 10, 2026, proposes a sub-10-dollar 64 GB USB drive with CPU-only llama.cpp binaries for Windows, macOS, and Linux, a compressed Wikipedia and reference SQLite database, and a browser chat frontend. Picks Gemma 4 E4B at Q4_K_M (~5 GB) as the low-RAM model and Qwen3.5 35B-A3B at Q4_K_M (~22 GB) for machines with at least 32 GB RAM. Estimates 5 to 20 tok/s CPU-only with no GPU on almost any PC from the past 15 years. Concept and discussion, unmeasured, 0 comments)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1urjg9o" target="_blank" rel="noopener">Benchmarked the 128 GB M5 Max as an Amateur, Need Feedback</a> (Jul 9, 2026, first-time local-AI benchmarker on a 128 GB M5 Max MacBook Pro. Gemma 4 E4B measured at MLX 8-bit via mlx_lm.generate at 4,748 tok/s prompt processing and 85.0 tok/s generation, and GGUF Q8 via llama-bench at 3,974 tok/s prompt processing and 76.1 tok/s generation. Qwen 3.6 27B ran at roughly 17 tok/s generation for contrast. The author calls the MLX-versus-GGUF quant match &quot;not conclusive&quot; and asks for methodology feedback. 0 comments, placeholder score)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1us3li5" target="_blank" rel="noopener">If You Already Pay for an LLM Service, Running Local Embeddings and Rerankers Feels More Useful Than Running Local LLMs</a> (Jul 9, 2026, a Tesla P40 owner and ChatGPT Pro subscriber argues that with near-unlimited hosted GPT through Codex, running local LLMs like Qwen 3.6 27B or Gemma 4 31B loses its practical edge, while local embedding and reranker models such as Qwen3 Embedding 4B and Qwen3 Reranker 4B stay valuable for a memory MCP. Gemma 4 31B is mentioned only as an example local LLM, not evaluated. Reader context, 0 comments)</li>
 </ul>
@@ -3034,11 +3034,11 @@
 <h3>Sources</h3>
 <p>The Gemma-mentioning posts driving this update (July 7 sweep, newest first). The July 6 ingest fell back to Reddit's Atom feed because the JSON API was blocked, so <strong>no comment threads were captured and all post scores are placeholders (~20)</strong> — treat every item as an uncorroborated single-author anecdote, not a settled result:</p>
 <ul class="setup-list">
-<li><a href="https://reddit.com/r/localllama/comments/1upatna" target="_blank" rel="noopener">Local models + big context = slow. How are you orchestrating &amp;quot;map-reduce&amp;quot; style agent workflows?</a> (Jul 6, 2026 — MacBook Pro M5 128 GB; context size, not model size, is the bottleneck; ~16k tokens already slow; qwen3.6 / DeepSeek V4 Flash / gemma4 all affected; map-reduce workaround of fresh short-context workers + summary passing; CrewAI/AutoGen/LangChain drag full history; no measured TPS)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1upatna" target="_blank" rel="noopener">Local models + big context = slow. How are you orchestrating &quot;map-reduce&quot; style agent workflows?</a> (Jul 6, 2026 — MacBook Pro M5 128 GB; context size, not model size, is the bottleneck; ~16k tokens already slow; qwen3.6 / DeepSeek V4 Flash / gemma4 all affected; map-reduce workaround of fresh short-context workers + summary passing; CrewAI/AutoGen/LangChain drag full history; no measured TPS)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1up6swc" target="_blank" rel="noopener">OpenComputer | An Open Source Computer Built For Agents</a> (Jul 6, 2026 — AnythingLLM experiment; observable isolated agent VM; local inference on M4 Pro via LM Studio with a Gemma 4 12B QAT model, post labels it &quot;13B QAT&quot;; contrasted with Apple Containers / Microsoft MXC / Docker Sandboxes; no performance figures)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1up78iv" target="_blank" rel="noopener">I told Gemma 4 12B (Q8_0, no cache quant) to write a single-file 3D bowling simulator in WebGL</a> (Jul 6, 2026 — Gemma 4 12B Q8_0, no KV-cache quant, opencode harness; one-shot after a plan session; a couple tool-call errors, self-corrected; &quot;terrible but better than expected&quot;; no hardware or speed disclosed; anecdotal)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1uoyx4a" target="_blank" rel="noopener">Framework Pro 13 for running smaller models of MoE</a> (Jul 6, 2026 — Framework 13 Pro, Intel X7, 32/64 GB LPCAMM2, PCIe 5 SSD; open question about Qwen 9B/14B and similar Gemma small/MoE models; wanted as portable fallback to a 256 GB unified-memory host; no answers captured)</li>
-<li><a href="https://reddit.com/r/localllama/comments/1uoppuz" target="_blank" rel="noopener">Qwen &amp;amp; Gemma on deadlock situation (For Benchmarks Numbers)?</a> (Jul 6, 2026 — low-content sentiment post about Qwen/Gemma benchmark stagnation; no data; included for transparency only)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1uoppuz" target="_blank" rel="noopener">Qwen &amp; Gemma on deadlock situation (For Benchmarks Numbers)?</a> (Jul 6, 2026 — low-content sentiment post about Qwen/Gemma benchmark stagnation; no data; included for transparency only)</li>
 </ul>
 <p><em>Last updated: 2026-07-07 (July 7 sweep). Confidence: low-to-medium (Atom-fallback ingest, no comment threads, placeholder scores). Key findings: on Apple Silicon unified memory the Gemma 4 bottleneck is context length (~16k slowdown on M5 128 GB), and a stateless map-reduce pattern is the community workaround; AnythingLLM's OpenComputer drives an observable agent VM with a Gemma 4 12B QAT model on an M4 Pro via LM Studio; Gemma 4 12B at Q8_0 one-shot a rough WebGL bowling simulator through opencode despite not being a recommended coding model; an open Framework 13 Pro laptop-tier question and a no-data Qwen/Gemma benchmark-sentiment post round out a benchmark-free cycle. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p>
 <p>---</p>
@@ -3115,7 +3115,7 @@
 <ul class="setup-list">
 <li><a href="https://reddit.com/r/localllama/comments/1ulthkp" target="_blank" rel="noopener">Local benchmarks with a RTX 3090 - Qwen3.6 27b vs Ornith</a> (Jul 2, 2026 — RTX 3090, LM Studio, inspect-ai; Gemma4 26B A4B QAT Q4_0 vs Qwen3.6 27B Q4_K_M vs Ornith 35B MoE Q4_K_M; 100 samples/suite, results incomplete at sweep time)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1ulgwld" target="_blank" rel="noopener">Talking with Gemma 4 31B!</a> (Jul 2, 2026 — open-source voice pipeline: Nvidia Parakeet + Gemma 4 31B (Cerebras) + custom Qwen3TTS; similar latency on M3 MacBook Pro 36GB with Gemma 4 E4B locally; drop-in OpenAI realtime API replacement)</li>
-<li><a href="https://reddit.com/r/localllama/comments/1ulqg4i" target="_blank" rel="noopener">Fine-tuned Gemma-4-31B specifically for Copywriting &amp;amp; Creative Writing Tasks</a> (Jul 2, 2026 — EqBench3-style pairwise eval, 30 copywriting briefs, DeepSeek V4 Flash judge, position-swap control; fine-tune 1657 Elo vs base 1367, 24/30 wins; self-reported, no independent replication)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1ulqg4i" target="_blank" rel="noopener">Fine-tuned Gemma-4-31B specifically for Copywriting &amp; Creative Writing Tasks</a> (Jul 2, 2026 — EqBench3-style pairwise eval, 30 copywriting briefs, DeepSeek V4 Flash judge, position-swap control; fine-tune 1657 Elo vs base 1367, 24/30 wins; self-reported, no independent replication)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1ulmez2" target="_blank" rel="noopener">Rebuilding Gemma 4 31b... better... As 26b...</a> (Jul 2, 2026 — SWA layer ablation (Block Layer 3 weakest), rescale SWA to 1024/2048/4096/8.1K, add attention residual networks; experimental, no results, IT base fine-tune planned)</li>
 <li><a href="https://reddit.com/r/localllama/comments/1ulpq3o" target="_blank" rel="noopener">Gemma 4 WebGPU Kernels 255 tok/s by x/@xenovacom</a> (Jul 2, 2026 — thin post linking to X/Twitter claim of 255 tok/s on WebGPU; no hardware/methodology detail; unverified)</li>
 </ul>
@@ -3290,7 +3290,7 @@
 <h3>Sources</h3>
 <p>The Gemma-mentioning posts driving this update (June 25 sweep, newest first). All are fresh threads (score ~20, no captured comment threads at sweep time); treat individual numbers as first-look anecdotes rather than settled results:</p>
 <ul class="setup-list">
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ueuki7" target="_blank" rel="noopener">Gemma4-26B-A4B &amp;amp; 31B-QAT Uncensored Balanced are out with MTP (35% &amp;amp; 53% speed boost)!</a> (Jun 25, 2026 — HauhauCS MTP + uncensored &quot;Balanced&quot; repackages of the official Gemma 4 26B-A4B-QAT and 31B-QAT; claimed 35% / 53% decode speedup from bundled MTP draft heads, 0/465 internal GenRM refusals; self-reported numbers, no independent benchmark or throughput methodology)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1ueuki7" target="_blank" rel="noopener">Gemma4-26B-A4B &amp; 31B-QAT Uncensored Balanced are out with MTP (35% &amp; 53% speed boost)!</a> (Jun 25, 2026 — HauhauCS MTP + uncensored &quot;Balanced&quot; repackages of the official Gemma 4 26B-A4B-QAT and 31B-QAT; claimed 35% / 53% decode speedup from bundled MTP draft heads, 0/465 internal GenRM refusals; self-reported numbers, no independent benchmark or throughput methodology)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ueb1n1" target="_blank" rel="noopener">Gemma 4 26BA4B Surprisingly Usable at IQ3_S – Are small quants really this usable?</a> (Jun 24, 2026 — Apple M3 MacBook Air 16 GB; Gemma 4 26B-A4B at IQ3_S/UD-Q3 → ~25 tok/s decode, &quot;really close to bf16&quot; for non-coding assistant use; single anecdote, author flags confirmation-bias risk, no quality measurement)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ueaoqg" target="_blank" rel="noopener">llama.cpp with vulkan backend outputting duplicate tokens, and sometimes &lt;unusedXX&gt; tokens</a> (Jun 24, 2026 — Intel i7-8550U / UHD 620 + Radeon 530, llama.cpp b9763 Vulkan; gemma-4-E2B-it-IQ4_NL emits duplicate and `<unusedXX>` tokens with/without --no-mmap; backend/old-iGPU compatibility issue, unresolved)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1ue5fgm" target="_blank" rel="noopener">PCIE 5.0 16x split into 2x8 with riser cable</a> (Jun 24, 2026 — i5-14600KF 20 lanes, 5070 Ti 16 GB PCIe 5.0 x16 + 4070 PCIe 4.0 x16 chipset; daytime Hermes Agent on Gemma 4 26B + Qwen; fast at 16K context ~3 s, slow at 128K OCR 10–15 s; PCIe-split question, no throughput numbers)</li>
@@ -3591,7 +3591,7 @@
 <ul class="setup-list">
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u5286i" target="_blank" rel="noopener">Yay got Gemma 12B QAT working on old 1080ti (maybe with speculative decoding?)</a> (Jun 13, 2026 — RTX 1080 Ti 11 GB: Gemma 4 12B QAT UD-Q4_K_XL, -c 16384, -ngl 99, q8_0 cache, spec-draft-mtp n-max 2 → 50 tok/s)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u554eo" target="_blank" rel="noopener">diffusiongemma-26B-A4B-it-4bit on macbook 4 pro with 48gb has very slow token generation speed</a> (Jun 13, 2026 — M4 Pro 48 GB: DiffusionGemma MLX 4bit → 5.4 tok/s / 18.6 GB; regular QAT → 38 tok/s same Mac; RTX 3090 Ti GGUF DiffusionGemma → ~120 tok/s)</li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u4vrtp" target="_blank" rel="noopener">Gemma 4 - weird issue, keeps saying &amp;quot;Lapped up&amp;quot;</a> (Jun 13, 2026 — vLLM AWQ 4bit Gemma 4 31B: &quot;lapped up&quot; repetition loop in extended roleplay contexts)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u4vrtp" target="_blank" rel="noopener">Gemma 4 - weird issue, keeps saying &quot;Lapped up&quot;</a> (Jun 13, 2026 — vLLM AWQ 4bit Gemma 4 31B: &quot;lapped up&quot; repetition loop in extended roleplay contexts)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u50rw1" target="_blank" rel="noopener">Best models in 3x3090 (72GB VRAM) in Q2 2026?</a> (Jun 13, 2026 — 3×RTX 3090 DDR4: Gemma 4 31B Q8 fits in 48 GB / 2 cards, quick load/offload, trusted over larger Q4 partial-offload)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u55wgq" target="_blank" rel="noopener">I am losing my mind with FOMO and need some sanity checking about model capabilities</a> (Jun 13, 2026 — Gemma 4 12B agentic: set up Gitea server + exploit retrieval via Hermes with no hand-holding)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u4nrfr" target="_blank" rel="noopener">Reality check: Gemma 4 31B at &gt;20 tok/s for &lt;1k$ USD</a> (Jun 13, 2026 — community asks if budget used-GPU build can reach 20 tok/s for dense 31B Q5; X79 + Xeon base ~$100)</li>
@@ -3630,7 +3630,7 @@
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3r8ak" target="_blank" rel="noopener">Not All MTP Assistants Are Created Equal</a> (Jun 12, 2026 — practitioner tests 6+ GGUF assistants; 26B Q8: 30→55–62 t/s; 12B Q4: 22→35–54 t/s; same HF name ≠ same model internals)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3i8x7" target="_blank" rel="noopener">Some contrived tests comparing the accuracy of different Gemma and Qwen quantizations</a> (Jun 12, 2026 — E2B broken for math/attention; 12B Q4 mid-tier; 26B-A4B Q4 reliable; QAT Q4 matches/exceeds Unsloth UD at same bit count)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3uw8e" target="_blank" rel="noopener">Open Dungeon: local roleplay with Gemma 4 QAT + inline Uncen-FLUX images, running at full 256K context under 8GB RAM (OS)</a> (Jun 12, 2026 — 12B QAT Q4 via Ollama at 256K context stays under 7.7 GB OS RAM; confirms KV cache efficiency in a production app)</li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3iikl" target="_blank" rel="noopener">MTPLX V1: The Swift App For Running &amp;amp; Creating MLX MTP Models (2x TPS Qwen 3.6 27B)</a> (Jun 12, 2026 — native Mac app; Forge feature auto-converts any HF model to MLX with MTP heads; Qwen 3.6 27B: 28→63 t/s; Gemma 4 supported)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3iikl" target="_blank" rel="noopener">MTPLX V1: The Swift App For Running &amp; Creating MLX MTP Models (2x TPS Qwen 3.6 27B)</a> (Jun 12, 2026 — native Mac app; Forge feature auto-converts any HF model to MLX with MTP heads; Qwen 3.6 27B: 28→63 t/s; Gemma 4 supported)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u43mpa" target="_blank" rel="noopener">Gemma: new models. Minimax: new model. Kimi: new model. Qwen... When?</a> (Jun 12, 2026 — community signal that more Gemma 4 models are expected; no specifics announced)</li>
 </ul>
 <p>---</p>
@@ -3656,7 +3656,7 @@
 <h3>Sources</h3>
 <p>The Gemma-mentioning posts driving this update (June 12 sweep, newest first). All are fresh launch-window threads (score ~20, no captured comment threads at sweep time), so treat individual numbers as first-look anecdotes or unverified claims rather than settled results:</p>
 <ul class="setup-list">
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3fo2x" target="_blank" rel="noopener">PSA: Test your &amp;quot;threads&amp;quot; argument in llama.cpp (+80% performance in my case)</a> (Jun 12, 2026 — Gemma 4 26B-A4B QAT + MTP on Core Ultra 250K Plus: 6→16 threads = ~49→~89 tok/s, regression at 18; careful warmup+5-run methodology)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3fo2x" target="_blank" rel="noopener">PSA: Test your &quot;threads&quot; argument in llama.cpp (+80% performance in my case)</a> (Jun 12, 2026 — Gemma 4 26B-A4B QAT + MTP on Core Ultra 250K Plus: 6→16 threads = ~49→~89 tok/s, regression at 18; careful warmup+5-run methodology)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3flg9" target="_blank" rel="noopener">Gemma 4 Quadruple Release, 12B, 12B QAT, 26B-A4B QAT and 31B QAT Uncensored Heretics!</a> (Jun 11, 2026 — third-party abliterated QAT q4_0 finetunes across the lineup in Safetensors/GGUF/NVFP4/GPTQ-Int4; no benchmarks)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u3dkl3" target="_blank" rel="noopener">Mi50 32GB / GFX906 — vLLM Qwen 3.5 configuration (sub-1 TPS)</a> (Jun 11, 2026 — mostly a Qwen 3.5 AWQ-on-Mi50 troubleshooting post; only a tangential ask for a Gemma 4 any-to-any setup, included for completeness)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u36vmm" target="_blank" rel="noopener">I have finally tested it: large models can be run on low RAM / no VRAM</a> (Jun 11, 2026 — GPU-less i7 laptop, 2.6 GB free RAM, SSD stream: Gemma 4 12B Q4 ~4 tok/s PP / ~0.28 tok/s TG; Gemma 4 self-reports Jan-2025 cutoff)</li>
@@ -3673,7 +3673,7 @@
 <h2>Field Notes — 2026-06-11</h2>
 <p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (9 new or updated since 2026-06-10, 331 total) and their top comment threads. Confidence is <strong>medium</strong> unless noted, since this is community signal rather than a controlled benchmark.</p>
 <p><em>June 11 sweep, 2026-06-11 01:00 UTC:</em> this is a quieter, mostly question-driven sweep with one loud-but-unverified headline. A pair of launch-window posts claim DeepMind has released <strong>DiffusionGemma</strong>, a text-diffusion model built on the Gemma 4 26B-A4B MoE architecture — with eye-catching throughput numbers that, on this sweep's evidence alone, should be treated as a claim rather than a measurement. Underneath that headline the sweep is dominated by practitioners hitting concrete limits and asking the same unresolved questions: a reproducible audio-attention failure on the new 12B unified model when the text prompt grows large, a low-end single-GPU 31B configuration with hard speed numbers, a recurring and still-unanswered demand for QAT-vs-higher-bit comparisons, a document-segmentation limit on the 26B-A4B, and a reliability lesson about asking small local models to be autonomous agents on a single consumer GPU.</p>
-<p><strong>DiffusionGemma (claimed): a DeepMind text-diffusion model on the Gemma 4 26B-A4B architecture — promising, but unverified this sweep.</strong> Two posts surfaced a new model named <strong>DiffusionGemma</strong>. The detailed post describes it as a DeepMind release under <strong>Apache 2.0</strong> that replaces autoregressive token-by-token decoding with a <strong>text-diffusion head</strong>: it starts from a 256-token &quot;canvas&quot; of placeholder noise and iteratively denoises the whole block at once (described as &quot;Uniform State Diffusion&quot;), with an error-correction step that re-introduces noise to self-correct mid-generation. The architectural claims are specific — a <strong>26B Mixture-of-Experts built on the Gemma 4 architecture, activating ~3.8B parameters per token</strong>, fitting in roughly <strong>18 GB of VRAM when quantized</strong> — and the post asserts throughput of <strong>1,000+ tok/s on an H100 and 700+ tok/s locally on an RTX 5090</strong>, on the logic that block-wise diffusion shifts the bottleneck from memory bandwidth to raw compute. The second post simply frames it as &quot;4× faster text generation.&quot; <strong>Strong caveats apply.</strong> Both posts are score-20 launch-window threads with <strong>no captured comment threads</strong>, the framing is promotional (&quot;DeepMind just dropped…&quot;), and none of the speed, VRAM, or quality figures are independently reproduced anywhere in this sweep — exactly the kind of exciting-but-unconfirmed number this guide deliberately does not adopt as fact. If real, a Gemma-4-architecture MoE that runs at hundreds of tok/s in ~18 GB would be a meaningful local-inference development worth tracking; for now, treat the model as plausibly-real but the performance claims as <strong>unverified author assertions</strong> pending hands-on community benchmarks. Confidence: low. (<a href="https://reddit.com/r/LocalLLaMA/comments/1u29mlk" target="_blank" rel="noopener">source: DiffusionGemma detail</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1u26s8n" target="_blank" rel="noopener">source: &amp;quot;4x faster&amp;quot;</a>, June 10, 2026)</p>
+<p><strong>DiffusionGemma (claimed): a DeepMind text-diffusion model on the Gemma 4 26B-A4B architecture — promising, but unverified this sweep.</strong> Two posts surfaced a new model named <strong>DiffusionGemma</strong>. The detailed post describes it as a DeepMind release under <strong>Apache 2.0</strong> that replaces autoregressive token-by-token decoding with a <strong>text-diffusion head</strong>: it starts from a 256-token &quot;canvas&quot; of placeholder noise and iteratively denoises the whole block at once (described as &quot;Uniform State Diffusion&quot;), with an error-correction step that re-introduces noise to self-correct mid-generation. The architectural claims are specific — a <strong>26B Mixture-of-Experts built on the Gemma 4 architecture, activating ~3.8B parameters per token</strong>, fitting in roughly <strong>18 GB of VRAM when quantized</strong> — and the post asserts throughput of <strong>1,000+ tok/s on an H100 and 700+ tok/s locally on an RTX 5090</strong>, on the logic that block-wise diffusion shifts the bottleneck from memory bandwidth to raw compute. The second post simply frames it as &quot;4× faster text generation.&quot; <strong>Strong caveats apply.</strong> Both posts are score-20 launch-window threads with <strong>no captured comment threads</strong>, the framing is promotional (&quot;DeepMind just dropped…&quot;), and none of the speed, VRAM, or quality figures are independently reproduced anywhere in this sweep — exactly the kind of exciting-but-unconfirmed number this guide deliberately does not adopt as fact. If real, a Gemma-4-architecture MoE that runs at hundreds of tok/s in ~18 GB would be a meaningful local-inference development worth tracking; for now, treat the model as plausibly-real but the performance claims as <strong>unverified author assertions</strong> pending hands-on community benchmarks. Confidence: low. (<a href="https://reddit.com/r/LocalLLaMA/comments/1u29mlk" target="_blank" rel="noopener">source: DiffusionGemma detail</a>, <a href="https://reddit.com/r/LocalLLaMA/comments/1u26s8n" target="_blank" rel="noopener">source: &quot;4x faster&quot;</a>, June 10, 2026)</p>
 <p><strong>Gemma 4 12B unified audio: a reproducible attention-saturation failure when the text prompt gets large.</strong> The most actionable finding this sweep is a clean, multi-stack bug report on the new <strong>encoder-free unified 12B</strong> (audio/vision/text in one model). A user building a single-pass voice assistant — feed a recorded WAV plus a system prompt, get the text reply directly, collapsing the separate ASR + LLM steps — reports that audio attention <strong>works well with a minimal prompt</strong> but <strong>collapses once the text prompt becomes large and dense</strong> (theirs is ~21k tokens of detailed instructions plus tool definitions). At that size the model replies as if the audio were not present (generic or hallucinated), or only weakly transcribes it; trimming the prompt restores audio attention. Critically, the same behavior reproduced across <strong>three independent stacks</strong> — vLLM (gemma4-unified, base64 `audio_url`), llama.cpp (`--mmproj`, `input_audio` content, thinking disabled), and LiteRT-LM (GPU) — which argues it is an inherent attention/saturation limit when audio competes with a long dense text context rather than a single-backend quirk. Their workaround: the smaller <strong>E4B with a tiny prompt keeps audio attention reliably</strong>, so they use it as a lightweight audio front-end feeding the larger text model. Practical guidance: if you are using the 12B unified model for speech, keep the audio-turn system prompt short, or split audio handling onto E4B. Confidence: anecdotal and single-author, but materially strengthened by reproduction across three runtimes. (<a href="https://reddit.com/r/LocalLLaMA/comments/1u1uk3a" target="_blank" rel="noopener">source</a>, June 10, 2026)</p>
 <p><strong>Low-end single-GPU 31B, with numbers: RTX 3060 12 GB + 32 GB RAM runs 31B at IQ3_XXS around 1.3 tok/s — and the new QAT Q2/Q3 GGUFs reopen the quant-choice question.</strong> A 3060-12GB owner (32 GB DDR3) documents a fully-specified budget configuration for the dense 31B: `gemma-4-31B-it-UD-IQ3_XXS.gguf` (11.8 GB) with `ffn_down` tensor overrides to fit, running <strong>16k context in bf16 at roughly 1.3 tok/s</strong>, with the bf16 mmproj offloaded to CPU; overriding more tensors stretches context to 32k at the cost of more CPU offload. The post's open question is timely: <strong>Q2–Q3 GGUF quants of the new QAT 31B now exist</strong> (mradermacher's `gemma-4-31B-it-qat-q4_0-unquantized` GGUF trees), and the user wants to know whether a QAT Q2/Q3 would beat their current non-QAT IQ3_XXS, how low they can push, and whether MTP is worth it when the draft model and context have to spill to CPU. No settled answer emerged this sweep. The honest read for readers on 12 GB cards: the dense 31B is <strong>runnable but slow</strong> (~1.3 tok/s is below comfortable interactive speed), and whether QAT low-bit quants improve on that on this exact hardware is currently unanswered — A/B them on your own workload. Confidence: anecdotal but the baseline config and speed are concrete and reproducible. (<a href="https://reddit.com/r/LocalLLaMA/comments/1u2c4yz" target="_blank" rel="noopener">source</a>, June 10, 2026)</p>
 <p><strong>The QAT-vs-higher-bit comparison is asked yet again — and still has no community answer.</strong> Reinforcing an open question that has now recurred across the June 8, June 10, and this sweep, a user with enough RAM + VRAM to run the <strong>26B-A4B up to Q6_K</strong> asks the precise question the guide keeps flagging: how does the <strong>4-bit Q4_0 QAT</strong> compare against a <strong>higher-bit non-QAT quant such as Q6_K</strong>? They correctly note that a KLD comparison against the original FP16 weights &quot;wouldn't be appropriate&quot; — echoing the June 8 methodological point that QAT is effectively a retrained, distinct model, so original-model-referenced divergence is the wrong yardstick. The demand signal is now unmistakable and consistent, but a clean, multi-task, same-hardware QAT-Q4 vs non-QAT-Q6 comparison still does not exist in the community record. Confidence: high that the question is unresolved; this entry documents demand, not a result. (<a href="https://reddit.com/r/LocalLLaMA/comments/1u1pfen" target="_blank" rel="noopener">source</a>, June 10, 2026)</p>
@@ -3690,13 +3690,13 @@
 <h3>Sources</h3>
 <p>The Gemma-mentioning posts driving this update (June 10 sweep, newest first). All are fresh launch-window threads (score ~20, no captured comment threads at sweep time), so treat individual numbers as first-look anecdotes or unverified claims rather than settled results:</p>
 <ul class="setup-list">
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u29mlk" target="_blank" rel="noopener">DeepMind Just Dropped &amp;quot;DiffusionGemma&amp;quot; — Text Generation via Image-Style Diffusion Model</a> (Jun 10, 2026 — claimed Apache-2.0 text-diffusion model on Gemma 4 26B-A4B arch; 700+ tok/s RTX 5090 / 1,000+ tok/s H100, ~18 GB VRAM — <strong>unverified</strong>)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u29mlk" target="_blank" rel="noopener">DeepMind Just Dropped &quot;DiffusionGemma&quot; — Text Generation via Image-Style Diffusion Model</a> (Jun 10, 2026 — claimed Apache-2.0 text-diffusion model on Gemma 4 26B-A4B arch; 700+ tok/s RTX 5090 / 1,000+ tok/s H100, ~18 GB VRAM — <strong>unverified</strong>)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u26s8n" target="_blank" rel="noopener">DiffusionGemma: 4x faster text generation</a> (Jun 10, 2026 — companion post framing DiffusionGemma as 4× faster)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u1uk3a" target="_blank" rel="noopener">Anyone gotten Gemma 4 12B (unified audio) to attend to speech with a large system prompt?</a> (Jun 10, 2026 — audio-attention collapses at ~21k-token prompt; reproduced on vLLM, llama.cpp, LiteRT-LM; E4B front-end workaround)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u2c4yz" target="_blank" rel="noopener">Are these quants of QAT better than non-QAT? What do I use?</a> (Jun 10, 2026 — RTX 3060 12 GB + 32 GB: 31B IQ3_XXS 11.8 GB, 16k bf16 ctx ~1.3 tok/s; new QAT Q2/Q3 GGUFs; MTP/CPU-offload question)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u1pfen" target="_blank" rel="noopener">gemma4 QATs vs higher-bit regular quantizations?</a> (Jun 10, 2026 — recurring demand for Q4_0 QAT vs non-QAT Q6_K on the 26B-A4B; KLD-vs-original noted inappropriate)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u28wb4" target="_blank" rel="noopener">Model/tooling recommendations for complex document processing</a> (Jun 10, 2026 — 26B-A4B Unsloth QAT can't segment multi-report scans; compliance steering away from Chinese OCR/models)</li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u2ch6u" target="_blank" rel="noopener">Hot Take: &amp;quot;Rigid code is better than Flexible code if you're on a budget&amp;quot;</a> (Jun 10, 2026 — single-GPU Gemma 4 31B/Qwen 3.5 agentic loops unreliable; replaced with rigid Python)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1u2ch6u" target="_blank" rel="noopener">Hot Take: &quot;Rigid code is better than Flexible code if you're on a budget&quot;</a> (Jun 10, 2026 — single-GPU Gemma 4 31B/Qwen 3.5 agentic loops unreliable; replaced with rigid Python)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u1pi1w" target="_blank" rel="noopener">I'm brand new to running LLMs and the sheer number of tools is overwhelming</a> (Jun 10, 2026 — beginner on Ollama/Windows comparing Gemma 4 vs Qwen 3.6; sizing/benchmark guidance demand)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1u2j0bp" target="_blank" rel="noopener">LLMs and tabletop games</a> (Jun 10, 2026 — Gemma 4 31B as a board-game rules assistant and TTRPG idea generator; non-professional daily use)</li>
 </ul>
@@ -4133,7 +4133,7 @@
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t3n6jo" target="_blank" rel="noopener">APEX MoE quants update: 25+ new models</a> (May 4, 2026, 77 score — Gemma 4 MoE now in APEX mixed-precision collection)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t3vlrx" target="_blank" rel="noopener">FastDMS: 6.4x KV-cache compression running faster than vLLM</a> (May 4, 2026, 51 score — research-stage KV compression, not yet in production)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t3duwm" target="_blank" rel="noopener">Ryzen AI Max+ 495 (Gorgon Halo) with 192GB VRAM!</a> (May 4, 2026, 148 score — hardware leak, same bandwidth as current Strix Halo)</li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1t2gu2h" target="_blank" rel="noopener">Does the &amp;quot;6 months gap&amp;quot; still hold?</a> (May 3, 2026, 68 score, 44 comments — Gemma 4 31B at Dec 2025 frontier tier for translations)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1t2gu2h" target="_blank" rel="noopener">Does the &quot;6 months gap&quot; still hold?</a> (May 3, 2026, 68 score, 44 comments — Gemma 4 31B at Dec 2025 frontier tier for translations)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t2t1w4" target="_blank" rel="noopener">Gemma 4 E2B runs surprisingly well on my 8GB Android phone</a> (May 3, 2026, 18 score, 14 comments — LiteRT-LM Android deployment, 8-10s JSON inference)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t2pmx7" target="_blank" rel="noopener">Anyone tried +-100B models locally with foreign languages?</a> (May 3, 2026, 8 score, 14 comments — Gemma 4 31B beats 100B MoEs for European languages)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t0k6fj" target="_blank" rel="noopener">Running llama.cpp on Snapdragon Hexagon NPU seems promising</a> (May 1, 2026, 20 score, 6 comments — mobile NPU limits, GPU via Edge APK more practical)</li>
@@ -4147,7 +4147,7 @@
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t14yhr" target="_blank" rel="noopener">Your local LLM predictions and hopes for May 2026</a> (May 1, 2026, 30 score)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1szziv0" target="_blank" rel="noopener">12GB-Club: 4070S speeds for Gemma 4 and Qwen 3.6</a> (Apr 30, 2026, 31 score)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t0kxdw" target="_blank" rel="noopener">Using a Radeon 9060 XT 16 GB, the gemma4 24b a4b iq4 nl model achieves 25.9 t/s</a> (May 1, 2026, 5 score)</li>
-<li><a href="https://reddit.com/r/LocalLLaMA/comments/1t08f2g" target="_blank" rel="noopener">Qwen 3.6 and Gemma 4 &amp;quot;Zombie Loops&amp;quot; (terminal thinking loops)</a> (Apr 30, 2026, 5 score)</li>
+<li><a href="https://reddit.com/r/LocalLLaMA/comments/1t08f2g" target="_blank" rel="noopener">Qwen 3.6 and Gemma 4 &quot;Zombie Loops&quot; (terminal thinking loops)</a> (Apr 30, 2026, 5 score)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t0pejd" target="_blank" rel="noopener">Model stuck in some thinking zone where it keeps saying a similar thing again and again</a> (May 1, 2026, 4 score)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1t06y43" target="_blank" rel="noopener">Open Models - April 2026 retrospective</a> (Apr 30, 2026, 518 score)</li>
 <li><a href="https://reddit.com/r/LocalLLaMA/comments/1sysyz2" target="_blank" rel="noopener">Qwen3.6-27B on dual RTX 5060 Ti 16GB with vLLM</a> (Apr 29, 2026)</li>
@@ -4217,10 +4217,10 @@
     </div>
   </div>
   <p class="cr-summary">Google is going to show what open weights is about. Happy Easter everyone.</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Both_Opportunity5327 (+529)</span><span class="cr-comment-text">Google is going to show what open weights is about. Happy Easter everyone.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/danielhanchen (+519)</span><span class="cr-comment-text">Gemma-4 has native thinking, tool calling and is multimodal! Use temperature = 1.0, top_p = 0.95, top_k = 64 and the EOS is `&amp;lt;turn|&amp;gt;`. `&amp;lt;|channel&amp;gt;thought\n` is also used for the thinking t...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Altruistic_Heat_9531 (+416)</span><span class="cr-comment-text">And after a week maybe : &quot;Gemma 4 26B Heretic Uncensored Ablated Claude Opus 4.6 Reasoning Distlled Expanded fine tuned quantized&quot; Sorry to tempting lol</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Both_Opportunity5327 (+529)</span><span class="cr-comment-text">Google is going to show what open weights is about. Happy Easter everyone.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/danielhanchen (+519)</span><span class="cr-comment-text">Gemma-4 has native thinking, tool calling and is multimodal! Use temperature = 1.0, top_p = 0.95, top_k = 64 and the EOS is `&lt;turn|&gt;`. `&lt;|channel&gt;thought\n` is also used for the thinking trace! * Guid...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Altruistic_Heat_9531 (+416)</span><span class="cr-comment-text">And after a week maybe : &quot;Gemma 4 26B Heretic Uncensored Ablated Claude Opus 4.6 Reasoning Distlled Expanded fine tuned quantized&quot; Sorry to tempting lol</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1salgre" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="25x faster inference with qwen 36 27b using mtp finally a viable option for local agentic coding 262k context on 48gb fixed chat template dropin openai and anthropic api endpoints &amp;gt; 20260507 edit: i have updated the hardware based recommendations with more focus on quality i do not recommend q40 kv cache anymore beyond 64k context after multiple rounds of testing with the different size quants, it appears 3 is the optimal number for draft speculative decoding the fastest and best quality " data-cats="high-gpu quantization">
+<div class="cr-card" data-search="25x faster inference with qwen 36 27b using mtp finally a viable option for local agentic coding 262k context on 48gb fixed chat template dropin openai and anthropic api endpoints &gt; 20260507 edit: i have updated the hardware based recommendations with more focus on quality i do not recommend q40 kv cache anymore beyond 64k context after multiple rounds of testing with the different size quants, it appears 3 is the optimal number for draft speculative decoding the fastest and best quality quan" data-cats="high-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1t57xuu" target="_blank" rel="noopener">2.5x faster inference with Qwen 3.6 27B using MTP - Finally a viable option for local agentic coding - 262k context on 4</a></h4>
@@ -4233,8 +4233,8 @@
       <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;gt; 2026-05-07 edit: I have updated the hardware based recommendations with more focus on quality. I do not recommend q4_0 KV cache anymore beyond 64k context. After multiple rounds of testing with the different size quants, it appears 3 is the opti...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ResidentPositive4122 (+249)</span><span class="cr-comment-text">Legend. Man, these past 6 months have brought us more than the last 2 years combined. On the one hand we've seen really powerful open models (glms, kimis, deepseeks, minimaxs, mimos, etc) and more imp...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/SmartCustard9944 (+64)</span><span class="cr-comment-text">1. Better inference and intelligence 2. -&amp;gt; Better and faster contributions 3. Go to 1 This loop gets better and better with time. This feels like a self improving intelligence, just that it’s hybri...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/jacek2023 (+47)</span><span class="cr-comment-text">When was turbo3/turbo4 merged? Or is this part of MTP PR?</span></div></div>
+  <p class="cr-summary">&gt; 2026-05-07 edit: I have updated the hardware based recommendations with more focus on quality. I do not recommend q4_0 KV cache anymore beyond 64k context. After multiple rounds of testing with the different size quants, it appears 3 is the optimal...</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ResidentPositive4122 (+249)</span><span class="cr-comment-text">Legend. Man, these past 6 months have brought us more than the last 2 years combined. On the one hand we've seen really powerful open models (glms, kimis, deepseeks, minimaxs, mimos, etc) and more imp...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/SmartCustard9944 (+64)</span><span class="cr-comment-text">1. Better inference and intelligence 2. -&gt; Better and faster contributions 3. Go to 1 This loop gets better and better with time. This feels like a self improving intelligence, just that it’s hybrid (...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/jacek2023 (+47)</span><span class="cr-comment-text">When was turbo3/turbo4 merged? Or is this part of MTP PR?</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t57xuu" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="every time a new model comes out, the old one is obsolete of course link post the discussion is mostly in the comments target: google qwen gemma i still wanna glaze gemma just cause i'm too scared qwen will stop delivering at some point and gemm gemma 4 is superior for creative writing and there's no contest coding? sure translating? nah, qwen sucks for translating" data-cats="general">
@@ -4320,7 +4320,7 @@
   <p class="cr-summary">Follow up, adopting vLLM and booting on multi-user.target on 4 Nvidia RTX A4000 setup My server was not AI inference in the beginning. It still is a Kubernetes/OpenShift server. In my previous post, some people scold me for using graphical mode, haha...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tr5c15" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="&quot;western openweight sota is between gemma431b and nemotron3super120b&quot; these are fine models, but it's one hell of a gut punch to realize this there's a 4way debate of chinese mid to heavyweight sotachasing models right now with valid points all around i miss meta man &amp;#32; submitted by &amp;#32; uforsookcomparison [link] &amp;#32; [comments] discussion" data-cats="general">
+<div class="cr-card" data-search="&quot;western openweight sota is between gemma431b and nemotron3super120b&quot; these are fine models, but it's one hell of a gut punch to realize this there's a 4way debate of chinese mid to heavyweight sotachasing models right now with valid points all around i miss meta man submitted by uforsookcomparison [link] [comments] discussion" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tq41pa" target="_blank" rel="noopener">&quot;Western Open-Weight SOTA is between Gemma4-31B and Nemotron3-Super-120B&quot;</a></h4>
@@ -4333,7 +4333,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">These are fine models, but it's one hell of a gut punch to realize this. There's a 4-way debate of Chinese mid to heavyweight SOTA-chasing models right now with valid points all around. I miss Meta man. &amp;#32; submitted by &amp;#32; /u/ForsookComparison [...</p>
+  <p class="cr-summary">These are fine models, but it's one hell of a gut punch to realize this. There's a 4-way debate of Chinese mid to heavyweight SOTA-chasing models right now with valid points all around. I miss Meta man. submitted by /u/ForsookComparison [link] [comme...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tq41pa" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="if gemma 4 is opensource, can we ask google to opensource gemma 3 as well? hey, we all love open source here at localllama, right? i wrote a letter at their huggingface repo requesting relicensing of gemma 3 to apache 2 since they did it with gemma 4 if you want to support opensource, would you mind giving this thread a comment or reaction so google can see this? i think for internet history and archiving purposes that retrospectively changing license is very good no… google gemma" data-cats="general">
@@ -4689,7 +4689,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Better-Struggle9958 (+406)</span><span class="cr-comment-text">every release same posts</span></div><div class="cr-comment"><span class="cr-comment-meta">u/EuphoricPenguin22 (+71)</span><span class="cr-comment-text">Yeah, but if this thing is better than the dense Gemma 4 31B, like the benchmarks I've seen suggest, this is killer. Gemma 4 is the first model for me to pass this threshold, so doing that but way fas...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Epicguru (+71)</span><span class="cr-comment-text">I guess that's what happens when every new release is better than the last...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1so2nt9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="i hope that someday we will have a 124b gemma link post the discussion is mostly in the comments target: google gemma &amp;gt; &quot;the moment you've all been waiting for today we're happy to announce shieldgemma 4&quot; there is no interest in doing that for them*" data-cats="general">
+<div class="cr-card" data-search="i hope that someday we will have a 124b gemma link post the discussion is mostly in the comments target: google gemma &gt; &quot;the moment you've all been waiting for today we're happy to announce shieldgemma 4&quot; there is no interest in doing that for them*" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tfv8li" target="_blank" rel="noopener">I hope that someday we will have a 124B Gemma.</a></h4>
@@ -4703,7 +4703,7 @@
     </div>
   </div>
   <p class="cr-summary">Link post. The discussion is mostly in the comments. Target:</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/VoiceApprehensive893 (+99)</span><span class="cr-comment-text">id get some clown makeup just in case</span></div><div class="cr-comment"><span class="cr-comment-meta">u/thrownawaymane (+72)</span><span class="cr-comment-text">&amp;gt; &quot;The moment you've all been waiting for... today we're happy to announce ShieldGemma 4&quot;</span></div><div class="cr-comment"><span class="cr-comment-meta">u/stoppableDissolution (+70)</span><span class="cr-comment-text">There is no interest in doing that for them*</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/VoiceApprehensive893 (+99)</span><span class="cr-comment-text">id get some clown makeup just in case</span></div><div class="cr-comment"><span class="cr-comment-meta">u/thrownawaymane (+72)</span><span class="cr-comment-text">&gt; &quot;The moment you've all been waiting for... today we're happy to announce ShieldGemma 4&quot;</span></div><div class="cr-comment"><span class="cr-comment-meta">u/stoppableDissolution (+70)</span><span class="cr-comment-text">There is no interest in doing that for them*</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tfv8li" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="local manga translator with llm buildin, written in rust with llamacpp integration hi localllama, i created a post a few weeks ago, but this time this project has become more reliable and easier to use this is a manga translator that can also be used to translate any image it uses a combination of object detection, visual llmbased ocr, layout analysis, and finetuned inpainting models i believe it is the most performant and easytouse pipeline for manga translation for th… hardware inference metal" data-cats="quantization">
@@ -4720,7 +4720,7 @@
     </div>
   </div>
   <p class="cr-summary">Hi LocalLLaMA, I created a post a few weeks ago, but this time this project has become more reliable and easier to use. This is a manga translator that can also be used to translate any image. It uses a combination of object detection, visual LLM-bas...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Mayion (+86)</span><span class="cr-comment-text">Can't wait for it to have a browser extension to translate in real-time the &quot;manga&quot; I am reading</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mayocream39 (+42)</span><span class="cr-comment-text">We have a GitHub issue for this; we wanna integrate with the ComicReadScript project. We are currently waiting for the author's response to integrate. &amp;lt;3</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mayocream39 (+30)</span><span class="cr-comment-text">There are so many features I didn't mention in this main thread. If you are interested, please take a look at the GitHub README. I spent almost one year polishing this project, and while there may be ...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Mayion (+86)</span><span class="cr-comment-text">Can't wait for it to have a browser extension to translate in real-time the &quot;manga&quot; I am reading</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mayocream39 (+42)</span><span class="cr-comment-text">We have a GitHub issue for this; we wanna integrate with the ComicReadScript project. We are currently waiting for the author's response to integrate. &lt;3</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mayocream39 (+30)</span><span class="cr-comment-text">There are so many features I didn't mention in this main thread. If you are interested, please take a look at the GitHub README. I spent almost one year polishing this project, and while there may be ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sslwjv" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 and qwen 36 with q80 and q40 kv cache: kl divergence results link post the discussion is mostly in the comments target: quantization inference benchmarking metallama qwen gemma great writeup, thank you i speculate gemma's degradation is actually related to the decision to con so gemma starts getting brain damage on cache quantization the attention rotation that llamacpp has implemented was not inspired by turboquantthe inspiration" data-cats="quantization">
@@ -4788,7 +4788,7 @@
     </div>
   </div>
   <p class="cr-summary">llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved: llmfan46/Qwen3.6-27B-uncensored-heretic-v2-Native-MTP-Preserved-GGUF:</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/inrea1time (+33)</span><span class="cr-comment-text">Good effort! Would love to try it, can you add a Q4_K_XS to run on 16GB with enough context? Does the MTP work with TurboQuant compressed kv?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/-p-e-w- (+31)</span><span class="cr-comment-text">Heretic optimizes for minimal KL divergence on non-refusal prompts, so the acceptance rate for those should remain roughly the same. For prompts that were previously refused and thus had their behavio...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/hideo_kuze_ (+24)</span><span class="cr-comment-text">&amp;gt; We choose to run cutting edge AI models in 16GB VRAM GPUs in this year and do the other things, not because they are easy, but because they are hard!</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/inrea1time (+33)</span><span class="cr-comment-text">Good effort! Would love to try it, can you add a Q4_K_XS to run on 16GB with enough context? Does the MTP work with TurboQuant compressed kv?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/-p-e-w- (+31)</span><span class="cr-comment-text">Heretic optimizes for minimal KL divergence on non-refusal prompts, so the acceptance rate for those should remain roughly the same. For prompts that were previously refused and thus had their behavio...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/hideo_kuze_ (+24)</span><span class="cr-comment-text">&gt; We choose to run cutting edge AI models in 16GB VRAM GPUs in this year and do the other things, not because they are easy, but because they are hard!</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t5yajb" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="qwen36 is incredible with opencode! i've tried a few different local models in the past (gemma 4 being the latest), but none of them felt as good as this (or maybe i just didn't give them a proper chance, you guys let me know) but this genuinely feels like a model i could daily drive for certain tasks instead of reaching for claude code i gave it a fairly complex task of implementing rls in postgres across a largeish codebase w… hardware quantization inference anthropic google metallama qwen gem" data-cats="high-gpu mid-gpu quantization">
@@ -4876,7 +4876,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/datbackup (+164)</span><span class="cr-comment-text">For the pill question, i agree with V4’s assumption. 60 minutes is the more logical answer, even if 90 minutes is perhaps the technically “correct” answer. The problem is that the user failed to adequ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tm604 (+91)</span><span class="cr-comment-text">&quot;This is a classic puzzle/riddle&quot; implies that both of these are in training data, so it's perhaps not the most exciting result of the year.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Materva (+64)</span><span class="cr-comment-text">The real question here is what medication is requiring you to take it every 30 minutes? This sounds like the pharmaceutical version of a power hour.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sv8806" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="qwen36 35b a3b uncensored heretic native mtp preserved is out now with kld 00015, 10100 refusals and the full 19 mtps preserved and retained, available in safetensors, ggufs nvfp4, nvfp4 ggufs and gptqint4 formats llmfan46qwen3635ba3buncensoredhereticnativemtppreserved: llmfan46qwen3635ba3buncensoredhereticnativemtppreservedgguf: [ quantization benchmarking gemma sorry if this is a dumb question are these mtps in any way modified to match the heretic model, so o &amp;gt;please do gemma 4 heretic" data-cats="quantization">
+<div class="cr-card" data-search="qwen36 35b a3b uncensored heretic native mtp preserved is out now with kld 00015, 10100 refusals and the full 19 mtps preserved and retained, available in safetensors, ggufs nvfp4, nvfp4 ggufs and gptqint4 formats llmfan46qwen3635ba3buncensoredhereticnativemtppreserved: llmfan46qwen3635ba3buncensoredhereticnativemtppreservedgguf: [ quantization benchmarking gemma sorry if this is a dumb question are these mtps in any way modified to match the heretic model, so o &gt;please do gemma 4 heretic llm" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1t7qfaq" target="_blank" rel="noopener">Qwen3.6 35B A3B uncensored heretic Native MTP Preserved is Out Now With KLD 0.0015, 10/100 Refusals and the Full 19 MTPs</a></h4>
@@ -4890,7 +4890,7 @@
     </div>
   </div>
   <p class="cr-summary">llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved: llmfan46/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-GGUF:</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/MmmmMorphine (+26)</span><span class="cr-comment-text">Sorry if this is a dumb question Are these MTPs in any way modified to match the Heretic model, so otherwise refused tokens are generated correctly. Or does that not really matter since once past a ch...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LLMFan46 (+23)</span><span class="cr-comment-text">&amp;gt;Please do Gemma 4 heretic llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF: llmfan46/gemma-4-26B-A4B-it-uncensored-heretic-GGUF:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/craftogrammer (+20)</span><span class="cr-comment-text">Things are so fast that all I can do is click the three dots and save the post to read later. Thank you so much!</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/MmmmMorphine (+26)</span><span class="cr-comment-text">Sorry if this is a dumb question Are these MTPs in any way modified to match the Heretic model, so otherwise refused tokens are generated correctly. Or does that not really matter since once past a ch...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LLMFan46 (+23)</span><span class="cr-comment-text">&gt;Please do Gemma 4 heretic llmfan46/gemma-4-31B-it-uncensored-heretic-GGUF: llmfan46/gemma-4-26B-A4B-it-uncensored-heretic-GGUF:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/craftogrammer (+20)</span><span class="cr-comment-text">Things are so fast that all I can do is click the three dots and save the post to read later. Thank you so much!</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t7qfaq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="qwen3635ba3b and 9b are officially on the public terminalbench 20 leaderboard! qwen3635ba3b and 9b are officially on the public terminalbench 20 leaderboard! littlecoder × qwen3635ba3b hit 246% (±32), and now land above gemini 25 pro on gemini cli (196%) and qwen3coder480b on terminus 2 (239%) i didn’t expect the scaffoldmodel gap from polyglot to hold on a benchmark this hard but it did! littlecoder × qwen359b came in at 92% which is more humble… hardware benchmarking google qwen gemma been run" data-cats="mid-gpu">
@@ -5029,7 +5029,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ubrtnk (+143)</span><span class="cr-comment-text"></span></div><div class="cr-comment"><span class="cr-comment-meta">u/annodomini (+40)</span><span class="cr-comment-text">Anyone tried the petit kernels to run NVFP4 on ROCm? These NVFP4 results looks really good, wondering how well they'll run on AMD without native support. edit: oh, it looks like there's Vulkan support...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Its-all-redditive (+36)</span><span class="cr-comment-text">Evaluation results seem odd. NVFP4 outscoring full precision? These must not be an average score over lots of runs.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t0i18e" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="beellama v020 major dflash update single rtx 3090: qwen 36 27b up to 164 tps (440x), gemma 4 31b up to 1778 tps (493x) prompt processing speed near baseline beellama v020 is here! &amp;gt;not quite a pegasus, but close enough github | qwen 36 27b quick start | gemma 4 31b quick start * full gemma 4 31b support… hardware quantization inference benchmarking metallama qwen gemma and here goes my evening too real every single time something new drop i'm grateful we have such incredible people with l" data-cats="high-gpu quantization">
+<div class="cr-card" data-search="beellama v020 major dflash update single rtx 3090: qwen 36 27b up to 164 tps (440x), gemma 4 31b up to 1778 tps (493x) prompt processing speed near baseline beellama v020 is here! &gt;not quite a pegasus, but close enough github | qwen 36 27b quick start | gemma 4 31b quick start * full gemma 4 31b support… hardware quantization inference benchmarking metallama qwen gemma and here goes my evening too real every single time something new drop i'm grateful we have such incredible people with lot f" data-cats="high-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tkpz2y" target="_blank" rel="noopener">BeeLlama v0.2.0 - major DFlash update. Single RTX 3090: Qwen 3.6 27B up to 164 tps (4.40x), Gemma 4 31B up to 177.8 tps </a></h4>
@@ -5042,7 +5042,7 @@
       <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">BeeLlama v0.2.0 is here! &amp;gt;Not quite a pegasus, but close enough. GitHub | Qwen 3.6 27B Quick Start | Gemma 4 31B Quick Start * Full Gemma 4 31B support…</p>
+  <p class="cr-summary">BeeLlama v0.2.0 is here! &gt;Not quite a pegasus, but close enough. GitHub | Qwen 3.6 27B Quick Start | Gemma 4 31B Quick Start * Full Gemma 4 31B support…</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/caetydid (+56)</span><span class="cr-comment-text">and here goes my evening...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/sagiroth (+32)</span><span class="cr-comment-text">Too real. Every single time something new drop. I'm grateful we have such incredible people with lots of spare time</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Toastti (+18)</span><span class="cr-comment-text">For agentic coding. So like 200k context large chats on opencode. Is MTP from the latest llama.cpp or DFlash faster?</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tkpz2y" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -5128,7 +5128,7 @@
     </div>
   </div>
   <p class="cr-summary">Not affiliated with Kaitchup, but a fan of their testing. I was looking forward to this article... and it did not disappoint. Lots of free info in the link. The juicy part is behind a paywall. I'll respect that, but the short of it is: It's showing t...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/LORD_CMDR_INTERNET (+75)</span><span class="cr-comment-text">Anecdotally, for coding, I find Qwen3.6 27B and Gemma4 31B trade blows. I will swap Plan/Act roles if either gets stuck and that seems to work quite well.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/slower-is-faster (+51)</span><span class="cr-comment-text">I knew it</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ResidentPositive4122 (+49)</span><span class="cr-comment-text">&amp;gt; I will swap Funny enough this was one finding ~last year from hf: swapping randomly between opus and gpt5 in the same session led to better results than any of them separately.</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/LORD_CMDR_INTERNET (+75)</span><span class="cr-comment-text">Anecdotally, for coding, I find Qwen3.6 27B and Gemma4 31B trade blows. I will swap Plan/Act roles if either gets stuck and that seems to work quite well.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/slower-is-faster (+51)</span><span class="cr-comment-text">I knew it</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ResidentPositive4122 (+49)</span><span class="cr-comment-text">&gt; I will swap Funny enough this was one finding ~last year from hf: swapping randomly between opus and gpt5 in the same session led to better results than any of them separately.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t4nkez" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="bonsai models are pure hype: bonsai8b is much dumber than gemma4e2b i'm using the fork for bonsai, regular llamacpp for gemma without embedding parameters: gemma 4 has 23b at 48 bpw (q4km) = 1104 mb bonsai8b has 695b at 1125 bpw (q10) = 782 mb (only 29% smaller) i could've gone with a smaller quant of gemma 4, it's just conventional wisdom to not push small models be… quantization inference benchmarking rag google metallama gemma indeed, it should be noted that bonsai was built on qwen3, not qwe" data-cats="quantization">
@@ -5148,7 +5148,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/KaroYadgar (+89)</span><span class="cr-comment-text">Indeed, it should be noted that Bonsai was built on Qwen3, not Qwen3.5, so its issues may stem from the fact that it's built on the previous generation rather than purely its quantization impacting it...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/charlesrwest0 (+66)</span><span class="cr-comment-text">If we are being fair, Google has way more resources than the bonsai team. It's a cool proof of their concept, but I'm not sure it's really super production ready.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/WeGoToMars7 (+54)</span><span class="cr-comment-text">Qwen3-8B-Q4_K_M has no issue with all three questions, so it's PrismMLs quant process that lobotomised it! With almost 3x the RAM used, it's not a fair comparison, but PrismML was the one to claim tha...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1snvv64" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="48gb vram users, what are your daily drivers? do you wish you had more vram? what would you run if you did? i’m upgrading from 32 to 48 soon and am excited but i’m curious what y’all run! hardware quantization qwen mistral gemma &amp;gt;do you wish you had more vram? who is ever going to say &quot;no&quot; to this? former 48gb user used to mainly run either q4 of various llama3 70b tunes or fullprecision mistral this i'd have about 1tb of vram if that didn't cost as much as some houses" data-cats="high-gpu mid-gpu quantization">
+<div class="cr-card" data-search="48gb vram users, what are your daily drivers? do you wish you had more vram? what would you run if you did? i’m upgrading from 32 to 48 soon and am excited but i’m curious what y’all run! hardware quantization qwen mistral gemma &gt;do you wish you had more vram? who is ever going to say &quot;no&quot; to this? former 48gb user used to mainly run either q4 of various llama3 70b tunes or fullprecision mistral this i'd have about 1tb of vram if that didn't cost as much as some houses" data-cats="high-gpu mid-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ti2ga0" target="_blank" rel="noopener">48GB VRAM users, what are your daily drivers? Do you wish you had more VRAM? What would you run if you did?</a></h4>
@@ -5162,7 +5162,7 @@
     </div>
   </div>
   <p class="cr-summary">I’m upgrading from 32 to 48 soon and am excited but I’m curious what y’all run!</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/-dysangel- (+394)</span><span class="cr-comment-text">&amp;gt;Do you wish you had more VRAM? Who is ever going to say &quot;no&quot; to this?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/stoppableDissolution (+99)</span><span class="cr-comment-text">Former 48gb user. Used to mainly run either q4 of various llama3 70b tunes or full-precision mistral small, then q6 gemma4 31b. Got 96gb now and still running almost exclusively gemma but now with few...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/National_Meeting_749 (+94)</span><span class="cr-comment-text">This. I'd have about 1TB of VRAM if that didn't cost as much as some houses.</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/-dysangel- (+394)</span><span class="cr-comment-text">&gt;Do you wish you had more VRAM? Who is ever going to say &quot;no&quot; to this?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/stoppableDissolution (+99)</span><span class="cr-comment-text">Former 48gb user. Used to mainly run either q4 of various llama3 70b tunes or full-precision mistral small, then q6 gemma4 31b. Got 96gb now and still running almost exclusively gemma but now with few...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/National_Meeting_749 (+94)</span><span class="cr-comment-text">This. I'd have about 1TB of VRAM if that didn't cost as much as some houses.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ti2ga0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="[wip] gemma 4 mtp gemma 4 mtp from uam17an it’s a work in progress so you have to compile it yourself, and you shouldn’t expect it to work 😉 quantization inference metallama gemma [removed] that's literally what the github draft says moe sees no performance improvement, while dense one is speculative decoding is nothing new, and there is always a desire to overcome memory bandwidth bottl" data-cats="apple-silicon quantization">
@@ -5179,10 +5179,10 @@
     </div>
   </div>
   <p class="cr-summary">Gemma 4 MTP from u/am17an It’s a work in progress so you have to compile it yourself, and you shouldn’t expect it to work 😉</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/[deleted] (+31)</span><span class="cr-comment-text">[removed]</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Gold_Coconut9777 (+25)</span><span class="cr-comment-text">That's literally what the GitHub draft says. MoE sees no performance improvement, while dense one is &amp;gt;2x</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Formal-Exam-8767 (+20)</span><span class="cr-comment-text">Speculative decoding is nothing new, and there is always a desire to overcome memory bandwidth bottleneck.</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/[deleted] (+31)</span><span class="cr-comment-text">[removed]</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Gold_Coconut9777 (+25)</span><span class="cr-comment-text">That's literally what the GitHub draft says. MoE sees no performance improvement, while dense one is &gt;2x</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Formal-Exam-8767 (+20)</span><span class="cr-comment-text">Speculative decoding is nothing new, and there is always a desire to overcome memory bandwidth bottleneck.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tijpwl" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="recent open models from last 6 months nov 2025 apr 2026 i created this chart with recent open models from last 6 months few might be older than that possibly included only latest versions(ex: only kimik26, no kimik25 &amp;amp; kimik2 also only glm51 &amp;amp; glm47, no glm46 &amp;amp; glm45) i couldn't add some models like ling251t, ring251t, omnicoder also i didn't add small models(except qwen359b4b &amp;amp; gemma4e4b) as the graph is t… hardware openai qwen mistral deepseek gemma i remember t" data-cats="general">
+<div class="cr-card" data-search="recent open models from last 6 months nov 2025 apr 2026 i created this chart with recent open models from last 6 months few might be older than that possibly included only latest versions(ex: only kimik26, no kimik25 &amp; kimik2 also only glm51 &amp; glm47, no glm46 &amp; glm45) i couldn't add some models like ling251t, ring251t, omnicoder also i didn't add small models(except qwen359b4b &amp; gemma4e4b) as the graph is t… hardware openai qwen mistral deepseek gemma i remember the times when we" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sskmhv" target="_blank" rel="noopener">Recent Open models from last 6 Months - Nov 2025 - Apr 2026</a></h4>
@@ -5195,7 +5195,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">I created this chart with recent open models from last 6 months. Few might be older than that possibly. Included only latest versions(Ex: Only Kimi-K2.6, no Kimi-K2.5 &amp;amp; Kimi-K2. Also only GLM-5.1 &amp;amp; GLM-4.7, no GLM-4.6 &amp;amp; GLM-4.5). I couldn...</p>
+  <p class="cr-summary">I created this chart with recent open models from last 6 months. Few might be older than that possibly. Included only latest versions(Ex: Only Kimi-K2.6, no Kimi-K2.5 &amp; Kimi-K2. Also only GLM-5.1 &amp; GLM-4.7, no GLM-4.6 &amp; GLM-4.5). I couldn't add some ...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/nextlevelhollerith (+52)</span><span class="cr-comment-text">I remember the times when we were amazed by GPT-4. GPT-4o (Nov 24) as a Intelligence Index of 17. Now Qwen 3.6 35 has 43. With some decent hardware you can run that locally. Its remarkable what open m...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/jacek2023 (+48)</span><span class="cr-comment-text">&quot;Possibly best 6 months for Local LLMs?!?&quot; and they are constantly complaining that local LLMs are dead :)</span></div><div class="cr-comment"><span class="cr-comment-meta">u/200206487 (+33)</span><span class="cr-comment-text">Qwen3.6 27 dense just dropped</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sskmhv" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -5298,7 +5298,7 @@
     </div>
   </div>
   <p class="cr-summary">Past few days, its all been about MTPs. Somehow people missed out the fact that Z lab released the Dflash for Gemma4 26B a couple of days ago. As far as my understanding goes, Dflash should be a better alternative than MTP because of faster parallel ...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+52)</span><span class="cr-comment-text">yes, someone posted this about 5 minutes before you:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+40)</span><span class="cr-comment-text">&amp;gt; MTP should technically degrade faster because the kv cache will start balooning faster. For Gemma 4, none of this is true. MTP in Gemma 4 reuses the model's KV cache. I am very excited for DFlash...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+9)</span><span class="cr-comment-text">Gemma 4’s MTP implementation is unique, as far as I’m aware</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+52)</span><span class="cr-comment-text">yes, someone posted this about 5 minutes before you:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+40)</span><span class="cr-comment-text">&gt; MTP should technically degrade faster because the kv cache will start balooning faster. For Gemma 4, none of this is true. MTP in Gemma 4 reuses the model's KV cache. I am very excited for DFlash, a...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/coder543 (+9)</span><span class="cr-comment-text">Gemma 4’s MTP implementation is unique, as far as I’m aware</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t79ayh" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="new models when? forecasting release date after the recent releases, there's almost a sense of emptiness when do you think new models will be released? looking at the chart, it's between the end of may and the beginning of june, but i don't know why, it seems like something's changing about &quot;open weights&quot; google qwen deepseek gemma i'm refreshing localllama everyday for a new qwen 27b model! (wishful thinking!) but, somehow i an yep qwen 36 27b dense raised the bar very high :) only co" data-cats="general">
@@ -5400,7 +5400,7 @@
     </div>
   </div>
   <p class="cr-summary">This is crazy. I've been running local LLMs on CPU only for awhile now and have great results with 12B models running on an i5-8500 and only 32GB of RAM with no GPU. But I've got a version of Gemma4 26B running really fast on the same machine which i...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/GoodTip7897 (+113)</span><span class="cr-comment-text">That's because Gemma 4 26B is a mixture of experts model that only uses 4B parameters every token. So it should be about as fast as a 4B model. Even though Qwen 3.6 27B has just 1B more total paramete...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/CooperDK (+46)</span><span class="cr-comment-text">Then he should get Qwen3.6-35B-A3B. One billion less parameters active. Should be 25% faster. It isn't though.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LetsGoBrandon4256 (+28)</span><span class="cr-comment-text">&amp;gt; [14:39:05] CtxLimit:150/8192, Init:0.00s, Processed:30 in 1.30s (23.13T/s), Generated:45/1024 in 4.86s (9.25T/s), Total:6.16s 23.13T/s is the prompt processing speed. The actual generation speed ...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/GoodTip7897 (+113)</span><span class="cr-comment-text">That's because Gemma 4 26B is a mixture of experts model that only uses 4B parameters every token. So it should be about as fast as a 4B model. Even though Qwen 3.6 27B has just 1B more total paramete...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/CooperDK (+46)</span><span class="cr-comment-text">Then he should get Qwen3.6-35B-A3B. One billion less parameters active. Should be 25% faster. It isn't though.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LetsGoBrandon4256 (+28)</span><span class="cr-comment-text">&gt; [14:39:05] CtxLimit:150/8192, Init:0.00s, Processed:30 in 1.30s (23.13T/s), Generated:45/1024 in 4.86s (9.25T/s), Total:6.16s 23.13T/s is the prompt processing speed. The actual generation speed is ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t4e046" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="ds4: a deepseek 4 flash specific inference engine for 128gb macbooks link post the discussion is mostly in the comments target: quantization inference benchmarking metallama deepseek this section is really great ollama shall learn something from this this is unreal performance is insane and the model seems to be a cut above qwen36gemma4 i've been the only llamacpp ds4 implementation i'm aware of that works reliably is the one i published on a f" data-cats="apple-silicon quantization">
@@ -5468,7 +5468,7 @@
     </div>
   </div>
   <p class="cr-summary">I'm still hoping we see a Qwen3.6-122B or a Qwen3.6-coder, but my hopes are dimming. Seems like we would have seen/heard something by now, even if just tantalizing hints from the Qwen folks.</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/NNN_Throwaway2 (+128)</span><span class="cr-comment-text">As I keep trying to point out, the 3.6 27b blog post implied there will be no more 3.6 model releases. Of course, nobody wants to believe it, so I’m not going to waste time arguing. We’re going on thr...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/a_beautiful_rhind (+56)</span><span class="cr-comment-text">They had a major restructure so it doesn't look good.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cyber_burr (+52)</span><span class="cr-comment-text">The fact that they are hesitant to publish small models is nothing short of a tragedy for GPU-poor people. With every major Qwen release, you could get small models ranging from &amp;lt;1b, 4b, 8b, etc. I...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/NNN_Throwaway2 (+128)</span><span class="cr-comment-text">As I keep trying to point out, the 3.6 27b blog post implied there will be no more 3.6 model releases. Of course, nobody wants to believe it, so I’m not going to waste time arguing. We’re going on thr...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/a_beautiful_rhind (+56)</span><span class="cr-comment-text">They had a major restructure so it doesn't look good.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cyber_burr (+52)</span><span class="cr-comment-text">The fact that they are hesitant to publish small models is nothing short of a tragedy for GPU-poor people. With every major Qwen release, you could get small models ranging from &lt;1b, 4b, 8b, etc. I su...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1taafs4" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="time to update llamacpp to get som mtp improvements! quantization inference benchmarking google metallama qwen mtp is amazing i genuinely thought it would be a nothingburger i am going from single digit tps to double digit never have been happier slapped my old 1660 ti to gemma4 mtp is not supported yet" data-cats="mid-gpu quantization">
@@ -5505,7 +5505,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/CircularSeasoning (+113)</span><span class="cr-comment-text">I feel great. I realized the AGI was inside us all along.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/PotatoQualityOfLife (+37)</span><span class="cr-comment-text">I CLAIM AGI!!! As proof I submit: &quot;trust me bro&quot;.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/VoiceApprehensive893 (+34)</span><span class="cr-comment-text">Gemma-4-E2B-HERETIC-ULTRA-EFFORT-REASONING-CLAUDE-MYTHOS-DISTILLED-QAT-OMNIMERGE is agi</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tjpafg" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="nvfp4 kimi26 and kimi 25 released by nvidia &amp;gt;the nvidia kimik26nvfp4 model is the quantized version of the moonshot ai's kimik26 model, which is an autoregressive language model that uses an optimized transformer architecture for more information, please check here the nvidia kimik26 nvfp4 model is quantized with model optimizer &amp;gt;th… hardware quantization benchmarking gemma &quot;model limitations: the base model was trained on data that contains toxic language and societal bia tha" data-cats="quantization">
+<div class="cr-card" data-search="nvfp4 kimi26 and kimi 25 released by nvidia &gt;the nvidia kimik26nvfp4 model is the quantized version of the moonshot ai's kimik26 model, which is an autoregressive language model that uses an optimized transformer architecture for more information, please check here the nvidia kimik26 nvfp4 model is quantized with model optimizer &gt;th… hardware quantization benchmarking gemma &quot;model limitations: the base model was trained on data that contains toxic language and societal bia that just m" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tcxb77" target="_blank" rel="noopener">NVFP4 Kimi2.6 and Kimi 2.5 released by Nvidia</a></h4>
@@ -5518,7 +5518,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;gt;The NVIDIA Kimi-K2.6-NVFP4 model is the quantized version of the Moonshot AI's Kimi-K2.6 model, which is an auto-regressive language model that uses an optimized transformer architecture. For more information, please check here. The NVIDIA Kimi-K...</p>
+  <p class="cr-summary">&gt;The NVIDIA Kimi-K2.6-NVFP4 model is the quantized version of the Moonshot AI's Kimi-K2.6 model, which is an auto-regressive language model that uses an optimized transformer architecture. For more information, please check here. The NVIDIA Kimi-K2.6...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/TheCTRL (+93)</span><span class="cr-comment-text">&quot;Model Limitations: The base model was trained on data that contains toxic language and societal biases originally crawled from the internet.&quot; So they crawled all linux dev email threads! Good to know...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/2Norn (+38)</span><span class="cr-comment-text">that just means the model is not censored enough for western standards lol</span></div><div class="cr-comment"><span class="cr-comment-meta">u/FullOf_Bad_Ideas (+21)</span><span class="cr-comment-text">it's copy-paste boilerplate also present here:</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tcxb77" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -5658,10 +5658,10 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Last_Bad_2687 (+12)</span><span class="cr-comment-text">Super cool, but wish you did more to show it actually processing the images</span></div><div class="cr-comment"><span class="cr-comment-meta">u/xenovatech (+9)</span><span class="cr-comment-text">This demo is running Gemma 4 E2B, since it works pretty well in-browser. You can try it out using this demo I posted a couple weeks ago:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/thetaFAANG (+7)</span><span class="cr-comment-text">ohh wow I thought this was 3D rendering in the browser whoops would have been impressive as well, but we already know they can do 3D models</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ta9mmd" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="google ai edge gallery v1013 &amp;amp; v1014 updates: gemma 4 multitoken prediction, pixel tpu support, experimental mcp, new skills, now saves chat history link post the discussion is mostly in the comments target: hardware inference agents openai google metallama gemma basically edge gallery is legit usable now the purpose of edgerunnable models, from a business perspective, is to consume the user's hardware, i love how when you install the app you're immediately forced to agree to google coll" data-cats="general">
+<div class="cr-card" data-search="google ai edge gallery v1013 &amp; v1014 updates: gemma 4 multitoken prediction, pixel tpu support, experimental mcp, new skills, now saves chat history link post the discussion is mostly in the comments target: hardware inference agents openai google metallama gemma basically edge gallery is legit usable now the purpose of edgerunnable models, from a business perspective, is to consume the user's hardware, i love how when you install the app you're immediately forced to agree to google collecti" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ti0g0k" target="_blank" rel="noopener">Google AI Edge Gallery v1.0.13 &amp;amp; v1.0.14 updates: Gemma 4 Multi-Token Prediction, Pixel TPU support, experimental MC</a></h4>
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ti0g0k" target="_blank" rel="noopener">Google AI Edge Gallery v1.0.13 &amp; v1.0.14 updates: Gemma 4 Multi-Token Prediction, Pixel TPU support, experimental MCP, n</a></h4>
       <span class="cr-score cr-score-mid">+109</span>
     </div>
     <div class="cr-meta">
@@ -5675,7 +5675,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/VoiceApprehensive893 (+32)</span><span class="cr-comment-text">basically edge gallery is legit usable now</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Chupa-Skrull (+28)</span><span class="cr-comment-text">The purpose of edge-runnable models, from a business perspective, is to consume the user's hardware, battery cycles, etc. in order to save companies money serving inference for low-intelligence worklo...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Quantum_Pigeon (+22)</span><span class="cr-comment-text">I love how when you install the app you're immediately forced to agree to Google collecting data from the app. Doesn't this defeat the entire purpose of using local models?</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ti0g0k" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="the &quot;the future is fictional&quot; problem of many local llms many local models have a problem (that raised due to excessive rhlf training): they mostly think that everything that is beyond their knowledge cutoff date would be &quot;fictional&quot; or &quot;satirical&quot; to be fair: even the gemini api without web access can have this sometimes but it stops when you give it tools however, with many local models, sadly it even goes on with tools: look at this: &amp;gt;you sear… quantizatio" data-cats="quantization">
+<div class="cr-card" data-search="the &quot;the future is fictional&quot; problem of many local llms many local models have a problem (that raised due to excessive rhlf training): they mostly think that everything that is beyond their knowledge cutoff date would be &quot;fictional&quot; or &quot;satirical&quot; to be fair: even the gemini api without web access can have this sometimes but it stops when you give it tools however, with many local models, sadly it even goes on with tools: look at this: &gt;you sear… quantization fi" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tcrrfq" target="_blank" rel="noopener">The &quot;the future is fictional&quot; problem of many local LLMs</a></h4>
@@ -5740,7 +5740,7 @@
     </div>
   </div>
   <p class="cr-summary">Both Gemma 4 and Qwen 3.6 seems to be the hottest local models right now. Looking at the benchmarks and reviews, it seems like it's better in every way: coding, benchmarks, agentic tasks. So is Qwen outright better? In what case would you pick Gemma ...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/FoxiPanda (+82)</span><span class="cr-comment-text">Gemma trounces Qwen for my handwriting analysis and general vision tasks at the very least. I also appreciate Gemma in chat significantly more than Qwen (qwen is cold and calculating even with system ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ggonavyy (+77)</span><span class="cr-comment-text">Gemma4 is really, really, really good at tracing bugs. When you feed a ticket to Qwen3.6 27B it'll fill the context with all available info available and maybe probably find the root cause, and someti...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Pro-Row-335 (+36)</span><span class="cr-comment-text">The only things I use llms for are coding and JP-&amp;gt;EN translation, for agentic coding its a nobrainer, Qwen is much better than gemma with tools, for JP-&amp;gt;EN translation its also a nobrainer, Gemm...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/FoxiPanda (+82)</span><span class="cr-comment-text">Gemma trounces Qwen for my handwriting analysis and general vision tasks at the very least. I also appreciate Gemma in chat significantly more than Qwen (qwen is cold and calculating even with system ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ggonavyy (+77)</span><span class="cr-comment-text">Gemma4 is really, really, really good at tracing bugs. When you feed a ticket to Qwen3.6 27B it'll fill the context with all available info available and maybe probably find the root cause, and someti...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Pro-Row-335 (+36)</span><span class="cr-comment-text">The only things I use llms for are coding and JP-&gt;EN translation, for agentic coding its a nobrainer, Qwen is much better than gemma with tools, for JP-&gt;EN translation its also a nobrainer, Gemma is m...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t4zca8" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="4gb &quot;gemini nano&quot; model gguf anyone? hi everyone, i saw an article saying chrome silently downloads a ~4gb ai model (likely &quot;gemini nano&quot;) to your computer for features like text summarization two questions: 1 what is the exact nameversion of this model? 2 is there a gguf file available for download so i can run it locally with llamacpp? i want to use it locally instead of letting chrome run it in the background thanks! quantization inference google metallama gemma not really" data-cats="quantization">
@@ -5794,10 +5794,10 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/FoxiPanda (+28)</span><span class="cr-comment-text">Looks like the pulled it down from HF for some reason? - It was here: - But it's not listed here that I can see: Looks like they also updated their 8B model like an hour ago...so maybe it's just not q...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Eyelbee (+12)</span><span class="cr-comment-text">Okay this is interesting. Now complete that rl pipeline and actually deliver the model, if it then beats the qwen 3.6 27b for real, it would be hugely impressive. That's an extremely high bar though, ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/grumd (+9)</span><span class="cr-comment-text">Aaaaand it's gone. The model card gives me a 404 :(</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t6q58n" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="running qwen3635ba3b locally for coding agent: my setup &amp;amp; working config # hardware |component|details| |:|:| |machine|macbook pro (mac14,6)| |chip|apple m2 max 12core cpu (8p + 4e)| |memory|64 gb unified memory| |storage|512 gb ssd| |os|macos 157 (sequoia)| # ai agent setup i'm using the pi coding agent as my primary development assistant it's a localfirst ai coding… hardware quantization inference agents openai anthropic google metallama qwen gemma i’m happy to see pi getting more love" data-cats="apple-silicon laptop quantization">
+<div class="cr-card" data-search="running qwen3635ba3b locally for coding agent: my setup &amp; working config # hardware |component|details| |:|:| |machine|macbook pro (mac14,6)| |chip|apple m2 max 12core cpu (8p + 4e)| |memory|64 gb unified memory| |storage|512 gb ssd| |os|macos 157 (sequoia)| # ai agent setup i'm using the pi coding agent as my primary development assistant it's a localfirst ai coding… hardware quantization inference agents openai anthropic google metallama qwen gemma i’m happy to see pi getting more love the" data-cats="apple-silicon laptop quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ss9pku" target="_blank" rel="noopener">Running Qwen3.6-35B-A3B Locally for Coding Agent: My Setup &amp;amp; Working Config</a></h4>
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ss9pku" target="_blank" rel="noopener">Running Qwen3.6-35B-A3B Locally for Coding Agent: My Setup &amp; Working Config</a></h4>
       <span class="cr-score cr-score-mid">+99</span>
     </div>
     <div class="cr-meta">
@@ -5842,7 +5842,7 @@
     </div>
   </div>
   <p class="cr-summary">Hey guys, A couple of weeks ago, I asked this sub for the hardest Vision use cases you were dealing with to test the newly dropped Qwen 3.6 against Gemma 4. I finally finished running the gauntlet side-by-side locally on vLLM (FP8 quants) using my cu...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pedronasser_ (+39)</span><span class="cr-comment-text">It may be the backend/harness influence, but I have the opposite of your findings. Qwen3.6 follows instructions better than Gemma4 for me. And I don't care at all about the visual capabilities.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LetsGoBrandon4256 (+33)</span><span class="cr-comment-text">&amp;gt; side-by-side &amp;gt; noticeably better on simple prompts-it stops earlier &amp;gt; 0-1000 Quite impressive that you used all three variants of dashes in one post.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/chimpera (+28)</span><span class="cr-comment-text">my sense is that gemma is much better at short one shot, but that because of it architecture it struggles with long context. There is something about its attention mechanism and its also far more sens...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pedronasser_ (+39)</span><span class="cr-comment-text">It may be the backend/harness influence, but I have the opposite of your findings. Qwen3.6 follows instructions better than Gemma4 for me. And I don't care at all about the visual capabilities.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LetsGoBrandon4256 (+33)</span><span class="cr-comment-text">&gt; side-by-side &gt; noticeably better on simple prompts-it stops earlier &gt; 0-1000 Quite impressive that you used all three variants of dashes in one post.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/chimpera (+28)</span><span class="cr-comment-text">my sense is that gemma is much better at short one shot, but that because of it architecture it struggles with long context. There is something about its attention mechanism and its also far more sens...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t1te8y" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 mlx doesn't seem better than gguf going to flag this up front i know that there are some properly smart people on this sub, please can you correct my noob user errors or misunderstandings and educate my ass model: googlegemma426ba4b versions: * mlx: [ hardware quantization inference google metallama gemma gguf has come a long way recently ggufllamacpp has really caught up to mlx over the past few months by leaning into metal that my friend, is the downside of writing my own posts yeah, u" data-cats="apple-silicon quantization">
@@ -5876,7 +5876,7 @@
     </div>
   </div>
   <p class="cr-summary">I ran a pretty simple but revealing local-LLM test. At first I was only going to post about the two Qwens and Gemma4 and go to bed, and what do you know, I go on reddit and see a post that Qwen 3.6-27B dropped. Oh well... Models tested: Gemma4 `cyank...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/LocoMod (+149)</span><span class="cr-comment-text">&amp;gt;Context: I’m working on fairly complex tool that takes noisy evidence and turns it into a structured “truth report.” Your harness is irrelevant here as your entire post doesnt read like someone wh...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/drwebb (+18)</span><span class="cr-comment-text">I'm pretty sure any serious dev could easily get work done with either qwen 3.5, qwen 3.6, and Gemma-4 31. Like you say, one might be better than the other, but just creating some artificial task made...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Southern_Sun_2106 (+16)</span><span class="cr-comment-text">&quot;I am building a Mystery Tool, and this is how the models did - according to me and to chatgpt&quot; - ok, thanks for sharing, but this tells close to nothing about anything.</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/LocoMod (+149)</span><span class="cr-comment-text">&gt;Context: I’m working on fairly complex tool that takes noisy evidence and turns it into a structured “truth report.” Your harness is irrelevant here as your entire post doesnt read like someone who h...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/drwebb (+18)</span><span class="cr-comment-text">I'm pretty sure any serious dev could easily get work done with either qwen 3.5, qwen 3.6, and Gemma-4 31. Like you say, one might be better than the other, but just creating some artificial task made...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Southern_Sun_2106 (+16)</span><span class="cr-comment-text">&quot;I am building a Mystery Tool, and this is how the models did - according to me and to chatgpt&quot; - ok, thanks for sharing, but this tells close to nothing about anything.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1st35c8" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="does the &quot;6 months gap&quot; still hold? hi it is quite a consensus that the &quot;jump&quot; in quality of agentic development happened sometime in december 2025, transforming from &quot;nice to have&quot;, to actually performing it was also long discussed that open source models lag the state of the art by 6 to 12 months now, does it mean that to get the equivalence of dec 2025 frontier performance (opus 45?) from open source models, we should still… hardware finetuning anthropic mistral " data-cats="high-gpu quantization">
@@ -5927,7 +5927,7 @@
     </div>
   </div>
   <p class="cr-summary">You can play them here: This started out as a simple test for Qwen3 Coder Next vs Qwen3.5 4B because they have similar benchmark numbers and then I just kept trying other models and decided I might as well share it even if I'm not that happy with how...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/AngeloKappos (+14)</span><span class="cr-comment-text">qwen3 coder next losing to the 4b at actual game logic is the most demoralizing benchmark result i've seen this week, playwright mcp doing the heavy lifting probably explains a lot of the variance her...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/libregrape (+11)</span><span class="cr-comment-text">Crazy how 35B and 26B moes with just 4-3B active totally annihilated 122B, and even dense 27B.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/yami_no_ko (+9)</span><span class="cr-comment-text">&amp;gt;LLMs are advancing so quickly! Imagine this just a few years ago in 2023. We'd have shat our pants seeing how far local LLMs advanced. Even a 4b Model feels better than what we had just 3 years ag...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/AngeloKappos (+14)</span><span class="cr-comment-text">qwen3 coder next losing to the 4b at actual game logic is the most demoralizing benchmark result i've seen this week, playwright mcp doing the heavy lifting probably explains a lot of the variance her...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/libregrape (+11)</span><span class="cr-comment-text">Crazy how 35B and 26B moes with just 4-3B active totally annihilated 122B, and even dense 27B.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/yami_no_ko (+9)</span><span class="cr-comment-text">&gt;LLMs are advancing so quickly! Imagine this just a few years ago in 2023. We'd have shat our pants seeing how far local LLMs advanced. Even a 4b Model feels better than what we had just 3 years ago.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1srddxf" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 mtp vs dflash on 1x h100: dense vs moe results benchmarked gemma 4 mtp and zlab's dflash on a single h100 80gb using vllm and nvidia's speedbench qualitative dataset # setup: hardware: 1x h100 80gb runtime: vllm dataset: speedbench qualitative … hardware inference finetuning benchmarking google gemma nice i too noticed the acceptance rate of dflash wasn't as good as mtp but zlab do mention lossless nice writeup! as a gtx 1050 3gb potato enjoyer, i wonder how this comparison would change " data-cats="high-gpu quantization">
@@ -5978,7 +5978,7 @@
     </div>
   </div>
   <p class="cr-summary">Provided in Safetensors, GGUFs and NVFP4 formats. Safetensors: llmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it-uncensored-heretic: GGUFs: lmfan46/gemma-4-Ortenzya-The-Creative-Wordsmith-31B-it…</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/HonestoJago (+18)</span><span class="cr-comment-text">Let me start by saying I'll definitely try it, but what are you people doing to get refusals from the base model? I know it's part of the tests/scripts you run, but in actual practice, are you getting...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LLMFan46 (+17)</span><span class="cr-comment-text">&amp;gt;Because it seems uncensored asf to me. Vanilla. There's plenty, sexy creative writings, RolePlaying just ask the people over at r/SillyTavernAI definitly need an uncensored model for whatever they...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LLMFan46 (+11)</span><span class="cr-comment-text">Also I explain on the MiniMax-M2.7 thread about softening, let me copy and paste it here: &amp;gt;What could happen is something called &quot;softening&quot;, meaning it's not a hard refusal but instead the languag...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/HonestoJago (+18)</span><span class="cr-comment-text">Let me start by saying I'll definitely try it, but what are you people doing to get refusals from the base model? I know it's part of the tests/scripts you run, but in actual practice, are you getting...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LLMFan46 (+17)</span><span class="cr-comment-text">&gt;Because it seems uncensored asf to me. Vanilla. There's plenty, sexy creative writings, RolePlaying just ask the people over at r/SillyTavernAI definitly need an uncensored model for whatever they ar...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/LLMFan46 (+11)</span><span class="cr-comment-text">Also I explain on the MiniMax-M2.7 thread about softening, let me copy and paste it here: &gt;What could happen is something called &quot;softening&quot;, meaning it's not a hard refusal but instead the language i...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tf52m2" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="speculative decoding question, 665% speed increase im using these settings in llamacpp: spectype ngrammapk specngramsizen 24 draftmin 12 draftmax 48 whats the real reason for lets say the prompt is for &quot;minor changes in code&quot;, whats differing between models: gemma 4 31b: doubles in tks gen so 100% qwen 36: only 40% more speed devstrall small: 665% increase in speed (what?) edit: added repeatpenalty 10 and spectype ngramm… inference metallama qwen gemma speculative decoding works for si" data-cats="quantization">
@@ -6029,7 +6029,7 @@
     </div>
   </div>
   <p class="cr-summary">Howdy everyone! Quick disclosure: I work on this - it's a project my studio created called the Null Epoch. I wasn't really happy with testing my agents with the usual static benchmarks and I wanted to learn more about how models and agents handle lon...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Various-Worker-790 (+27)</span><span class="cr-comment-text">This is really one of the most interesting agent experiments I’ve read in a while because it highlights something most benchmark discussions misses, environment design and state clarity matter just as...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/bopcrane (+13)</span><span class="cr-comment-text">A few extra links in case anyone would like to check out the data and live service: Dataset card (HF): SDK &amp;amp; MCP server (GitHub, MIT): * Spectator portal (no account needed): https…</span></div><div class="cr-comment"><span class="cr-comment-meta">u/OAKI-io (+9)</span><span class="cr-comment-text">this is a much better direction than another static benchmark. long-horizon agents fail in boring ways: resource hoarding, bad recovery, repeating plans, getting baited by stale context. if the datase...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Various-Worker-790 (+27)</span><span class="cr-comment-text">This is really one of the most interesting agent experiments I’ve read in a while because it highlights something most benchmark discussions misses, environment design and state clarity matter just as...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/bopcrane (+13)</span><span class="cr-comment-text">A few extra links in case anyone would like to check out the data and live service: Dataset card (HF): SDK &amp; MCP server (GitHub, MIT): * Spectator portal (no account needed): https…</span></div><div class="cr-comment"><span class="cr-comment-meta">u/OAKI-io (+9)</span><span class="cr-comment-text">this is a much better direction than another static benchmark. long-horizon agents fail in boring ways: resource hoarding, bad recovery, repeating plans, getting baited by stale context. if the datase...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tp6pg7" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="i benchmarked 21 local llms on a macbook air m5 for code quality and speed there are plenty of &quot;bro trust me, this model is better for coding&quot; discussions out there i wanted to replace the vibes with actual data: which model writes correct code and how fast does it run on real hardware, tested under identical conditions so the results are directly comparable no cherrypicked prompts, no subjective impressions, just pass@1 on 164 coding problems with an expanded test s… hardware quantiza" data-cats="apple-silicon quantization">
@@ -6097,7 +6097,7 @@
     </div>
   </div>
   <p class="cr-summary">We have a chat system which we use haiku for because it is mostly about tool calling and summarisation of them. But we have many tools with pretty complex input schemas, and stuff like gemma didn't cut it, so we went with haiku. Haiku is pretty good....</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/TheRealMasonMac (+31)</span><span class="cr-comment-text">GLM-5.1 being cheaper than Haiku is still hilarious to me.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/SnooPaintings8639 (+26)</span><span class="cr-comment-text">I would be very disappointed with D4 Flash if it wasnt MUCH better than haiku. I don't know how, but I have quite high expectations for this model</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Caffdy (+16)</span><span class="cr-comment-text">&amp;gt;But we have many tools with pretty complex input schemas can you gives an example, because the jump from Haiku (which probably is in the same range as Qwen 27/35B or Gemma4 in terms of size) to D4...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/TheRealMasonMac (+31)</span><span class="cr-comment-text">GLM-5.1 being cheaper than Haiku is still hilarious to me.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/SnooPaintings8639 (+26)</span><span class="cr-comment-text">I would be very disappointed with D4 Flash if it wasnt MUCH better than haiku. I don't know how, but I have quite high expectations for this model</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Caffdy (+16)</span><span class="cr-comment-text">&gt;But we have many tools with pretty complex input schemas can you gives an example, because the jump from Haiku (which probably is in the same range as Qwen 27/35B or Gemma4 in terms of size) to D4 Fl...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1suiruw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="nvidia rtx 3090 vs intel arc pro b70 llamacpp benchmarks just sharing the results from experimenting with the b70 on my setup these results compare three `llamacpp` execution paths on the same machine: rtx 3090 (vulkan) on nixos host, using main llamacpp repo (compiled on 4212026) arc pro b70 (vulkan) on nixos host, using main llamacpp repo (compiled on 4212026) * arc pro b70 (sycl) inside an ubuntu 2404 docker contain… hardware quantization inference benchmarking metallama qwen gemma 3090 still" data-cats="high-gpu quantization">
@@ -6168,7 +6168,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Evening_Ad6637 (+8)</span><span class="cr-comment-text">The whole thing is kind of… weird… or a little chaotic. I mean, the results are very interesting, and you can clearly see a lot of effort went into this work, so of course, kudos to @OP It’s just a bi...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mr_Owner (+7)</span><span class="cr-comment-text">Unfair comparisons of mixed quants tbh</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Only-Fisherman5788 (+6)</span><span class="cr-comment-text">compatibility matrix is useful for &quot;will this even run&quot; but doesn't answer the production question: which of these framework+model combos actually produces correct outputs on the agentic task you care...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sojag2" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="i stumbled on a gemma 4 chat template bug for tools and fixed it tldr: tool parameters using the common json schema pattern `anyof: [$ref, null]` are rendered into the prompt as empty `type` fields this strips the useful schema information before the model sees it long, rambling version: gemma 4 was having issues with calling my custom mcp tool on &amp;gt;3 inference engines, while qwen35 and gptoss20b were doing fine i guessed it was either a chat… hardware quantization agents openai google met" data-cats="quantization">
+<div class="cr-card" data-search="i stumbled on a gemma 4 chat template bug for tools and fixed it tldr: tool parameters using the common json schema pattern `anyof: [$ref, null]` are rendered into the prompt as empty `type` fields this strips the useful schema information before the model sees it long, rambling version: gemma 4 was having issues with calling my custom mcp tool on &gt;3 inference engines, while qwen35 and gptoss20b were doing fine i guessed it was either a chat… hardware quantization agents openai google metalla" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1syps6i" target="_blank" rel="noopener">I stumbled on a Gemma 4 chat template bug for tools and fixed it</a></h4>
@@ -6202,10 +6202,10 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ambient_temp_xeno (+13)</span><span class="cr-comment-text">I wonder if gemma knows these effects so well because of youtube videos of them.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/DifficultDog8435 (+8)</span><span class="cr-comment-text">That’s sick honestly. I like the idea of treating the prompts like a little generative demo reel instead of manually cherry-picking one good output.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/itsappleseason (+7)</span><span class="cr-comment-text">of course not.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t9cle9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="is granite4130b overshadowed by qwen36 &amp;amp; gemma4 models? i don't see any threads on this model is it because it's dense andor withoutreasoning? anyone tried this for coding? &amp;gt;capabilities summarization text classification text extraction questionanswering retrieval augmented generation (rag) code related tasks functioncalling tasks multilingual dialog use cases fillinthemiddle (fi… hardware benchmarking rag agents qwen gemma the benchmark comparison isnt looking too good [link to b" data-cats="general">
+<div class="cr-card" data-search="is granite4130b overshadowed by qwen36 &amp; gemma4 models? i don't see any threads on this model is it because it's dense andor withoutreasoning? anyone tried this for coding? &gt;capabilities summarization text classification text extraction questionanswering retrieval augmented generation (rag) code related tasks functioncalling tasks multilingual dialog use cases fillinthemiddle (fi… hardware benchmarking rag agents qwen gemma the benchmark comparison isnt looking too good [link to bench bet" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
-      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tp1plw" target="_blank" rel="noopener">Is Granite-4.1-30b Overshadowed by Qwen3.6 &amp;amp; Gemma4 models?</a></h4>
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tp1plw" target="_blank" rel="noopener">Is Granite-4.1-30b Overshadowed by Qwen3.6 &amp; Gemma4 models?</a></h4>
       <span class="cr-score cr-score-mid">+61</span>
     </div>
     <div class="cr-meta">
@@ -6215,7 +6215,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">I don't see any threads on this model. Is it because it's dense and/or without-reasoning? Anyone tried this for coding? &amp;gt;Capabilities Summarization Text classification Text extraction Question-answering Retrieval Augmented Generation (RAG) Code re...</p>
+  <p class="cr-summary">I don't see any threads on this model. Is it because it's dense and/or without-reasoning? Anyone tried this for coding? &gt;Capabilities Summarization Text classification Text extraction Question-answering Retrieval Augmented Generation (RAG) Code relat...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Jayfree138 (+44)</span><span class="cr-comment-text">The benchmark comparison isnt looking too good. Link to Bench between qwen, gemma, and granite</span></div><div class="cr-comment"><span class="cr-comment-meta">u/DeepWisdomGuy (+36)</span><span class="cr-comment-text">The actual radar:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/k_means_clusterfuck (+34)</span><span class="cr-comment-text">They are overshadowed because Qwen3.6 27b and Gemma4 31b are just better.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tp1plw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -6287,7 +6287,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/valdev (+23)</span><span class="cr-comment-text">Gemma 4 was the best, for about 10 minutes after its release. Still the best at visual understanding But Qwen 3.6 27b is... literally a few generations beyond it. Frankly it shocks me how good it is.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/geldonyetich (+11)</span><span class="cr-comment-text">Maybe if you're looking at Gemma4:26b. 31b is still doing as well as Qwen 3.6 and even better in some applications. Honestly there's so much Qwen hype here I think Alibaba has hired an influencing fir...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/o0genesis0o (+5)</span><span class="cr-comment-text">Funny how something that should feel like second nature to people in this sub (downloading lmstudio and model, setup context, attach to cli agent) is still treated like expert tutorial for general aud...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sx5h1t" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="qwen354b|gemma4e2be4b uncensored models comparison i had the idea of splitting the crossentropy difference into two sums (positive and negative; or the ppl into two ratios &amp;gt;1 and &amp;lt;1) while doing ppl evals of uncensored ggufs the inspiration came from looking at the area under the ppl ratio convergence plot (2nd graph) and thinking &quot;what if i scattered the positive and negative area in 2d?&quot; after all: negative delta =&amp;gt; predicted the… quantization finetuning benchmar" data-cats="quantization">
+<div class="cr-card" data-search="qwen354b|gemma4e2be4b uncensored models comparison i had the idea of splitting the crossentropy difference into two sums (positive and negative; or the ppl into two ratios &gt;1 and &lt;1) while doing ppl evals of uncensored ggufs the inspiration came from looking at the area under the ppl ratio convergence plot (2nd graph) and thinking &quot;what if i scattered the positive and negative area in 2d?&quot; after all: negative delta =&gt; predicted the… quantization finetuning benchmarking anthrop" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1sokdvd" target="_blank" rel="noopener">Qwen3.5-4B|Gemma4-E2B/E4B uncensored models comparison</a></h4>
@@ -6300,7 +6300,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">I had the idea of splitting the cross-entropy difference into two sums (positive and negative; or the PPL into two ratios &amp;gt;1 and &amp;lt;1) while doing PPL evals of uncensored GGUFs. The inspiration came from looking at the area under the PPL ratio co...</p>
+  <p class="cr-summary">I had the idea of splitting the cross-entropy difference into two sums (positive and negative; or the PPL into two ratios &gt;1 and &lt;1) while doing PPL evals of uncensored GGUFs. The inspiration came from looking at the area under the PPL ratio converge...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/WhoRoger (+8)</span><span class="cr-comment-text">Lol I love this but I have no idea what most of that means lol. Td;dr? (Too dumb; didn't read)</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Embarrassed_Soup_279 (+5)</span><span class="cr-comment-text">hauhaucs models &quot;felt&quot; better compared to other uncensored models despite the degradation shown in the graphs... ive not tested the gemma models but with qwen3.5 it was pretty good. still don't know h...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Tryshea (+4)</span><span class="cr-comment-text">Thanks, An uncensored model should succeed at predicting the text more often than the base model (X axis) but never less often (Y axis). That's because we should just be &quot;unlocking knowledge&quot; without ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sokdvd" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -6423,7 +6423,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Ok-Measurement-1575 (+74)</span><span class="cr-comment-text">I was very excited until I read this: Single model, single architecture. The kernel is hand-written for Qwen 3.5-0.8B's specific layer pattern (18 DeltaNet + 6 Attention). It does not generalize to ot...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/dinerburgeryum (+24)</span><span class="cr-comment-text">The post goes onto say “Megakernel fusion benefits shrink as model size grows and compute begins to dominate over launch overhead.” Sounds like diminishing returns.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/JumpyAbies (+22)</span><span class="cr-comment-text">I think that if, for example, it has support for qwen3.6-27b or gemma-4, it becomes a very attractive option for those who use those models. It would be a solution focused on a smaller scope of models...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tecfxm" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="cuda: add fast walshhadamard transform by am17an · pull request #23615 · ggmlorgllamacpp implemented(by uam17an) fwht for cuda, speedup for cases when we quantize the kvcache 12% boost on pp &amp;amp; 79% boost on tg performance on a 5090 with `ctk q80 ctv q80` |model|test|ts master|ts cudafwt|speedup| |:|:|:|:|:| |gemma4 26ba4b q4km|pp2048|1358789|1380920|102| |gemma4 26ba4b q4km|pp2048@d1024|1242501|1255332|101| |gemma4 26ba4b q4km|pp2048… hardware quantization inference metallama hopefully vu" data-cats="apple-silicon high-gpu quantization">
+<div class="cr-card" data-search="cuda: add fast walshhadamard transform by am17an · pull request #23615 · ggmlorgllamacpp implemented(by uam17an) fwht for cuda, speedup for cases when we quantize the kvcache 12% boost on pp &amp; 79% boost on tg performance on a 5090 with `ctk q80 ctv q80` |model|test|ts master|ts cudafwt|speedup| |:|:|:|:|:| |gemma4 26ba4b q4km|pp2048|1358789|1380920|102| |gemma4 26ba4b q4km|pp2048@d1024|1242501|1255332|101| |gemma4 26ba4b q4km|pp2048… hardware quantization inference metallama hopefully vulkan" data-cats="apple-silicon high-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tnfqng" target="_blank" rel="noopener">CUDA: add fast walsh-hadamard transform by am17an · Pull Request #23615 · ggml-org/llama.cpp</a></h4>
@@ -6436,7 +6436,7 @@
       <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Implemented(by u/am17an) FWHT for CUDA, speed-up for cases when we quantize the kv-cache. 1-2% boost on pp &amp;amp; 7-9% boost on tg. Performance on a 5090 with `-ctk q8_0 -ctv q8_0` |Model|Test|t/s master|t/s cuda-fwt|Speedup| |:-|:-|:-|:-|:-| |gemma4 ...</p>
+  <p class="cr-summary">Implemented(by u/am17an) FWHT for CUDA, speed-up for cases when we quantize the kv-cache. 1-2% boost on pp &amp; 7-9% boost on tg. Performance on a 5090 with `-ctk q8_0 -ctv q8_0` |Model|Test|t/s master|t/s cuda-fwt|Speedup| |:-|:-|:-|:-|:-| |gemma4 26B....</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/nickm_27 (+10)</span><span class="cr-comment-text">hopefully vulkan gets added soon too</span></div><div class="cr-comment"><span class="cr-comment-meta">u/TableSurface (+10)</span><span class="cr-comment-text">Noticed this too. Looks like a fix is on the way:</span></div><div class="cr-comment"><span class="cr-comment-meta">u/RMK137 (+8)</span><span class="cr-comment-text">Unfortunately I am getting garbled output with qwen3.6 after this update. It looks like other people are experiencing the same issue looking at the PR comments. I had to revert this commit and now it'...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tnfqng" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -6454,10 +6454,10 @@
     </div>
   </div>
   <p class="cr-summary">Ling-2.6-1T: A Trillion-Parameter Comprehensive Flagship Model for Complex Tasks Today, we are thrilled to open-source Ling-2.6-1T from the Ling family. Tailored for real-world, complex scenarios, this trillion-parameter model introduces targeted opt...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Hodler-mane (+20)</span><span class="cr-comment-text">its fockin raining models!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/unbannedfornothing (+11)</span><span class="cr-comment-text">Damn, do they know any other numbers than 1 trillion?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+11)</span><span class="cr-comment-text">A day ago, they released 100B sized model Last year, they released 17B sized model called Ling-Mini. Unfortunately they skipped it during last version &amp;amp; also now I think</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Hodler-mane (+20)</span><span class="cr-comment-text">its fockin raining models!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/unbannedfornothing (+11)</span><span class="cr-comment-text">Damn, do they know any other numbers than 1 trillion?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+11)</span><span class="cr-comment-text">A day ago, they released 100B sized model Last year, they released 17B sized model called Ling-Mini. Unfortunately they skipped it during last version &amp; also now I think</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sz59l4" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="rocm 713 nightly adds strix halo optimizations quote: new optimizations for ryzen ai max 300 &quot;strix halo&quot; and the rocprof trace decoder is now opensource&amp;lt;snip&amp;gt; those rolling from source can grab the rocm 713 tech preview via therock on github [ hardware finetuning rocm platform is generally preferred over pure vulkan for better compatibility with frameworks like &amp;gt;expanded amd gpu support rocm 7130 adds support for the following amd gpus and apus: a the pp is better" data-cats="laptop">
+<div class="cr-card" data-search="rocm 713 nightly adds strix halo optimizations quote: new optimizations for ryzen ai max 300 &quot;strix halo&quot; and the rocprof trace decoder is now opensource&lt;snip&gt; those rolling from source can grab the rocm 713 tech preview via therock on github [ hardware finetuning rocm platform is generally preferred over pure vulkan for better compatibility with frameworks like &gt;expanded amd gpu support rocm 7130 adds support for the following amd gpus and apus: a the pp is better on rocm for" data-cats="laptop">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tftg09" target="_blank" rel="noopener">ROCm 7.13 nightly adds strix halo optimizations</a></h4>
@@ -6470,8 +6470,8 @@
       <span class="cr-cat-badge">Laptops</span>
     </div>
   </div>
-  <p class="cr-summary">Quote: ...new optimizations for Ryzen AI Max 300 &quot;Strix Halo&quot; and the ROCprof Trace Decoder is now open-source...&amp;lt;snip&amp;gt;... Those rolling from source can grab the ROCm 7.13 Tech Preview via TheRock on GitHub.</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Terminator857 (+33)</span><span class="cr-comment-text">ROCm platform is generally preferred over pure Vulkan for better compatibility with frameworks like PyTorch and TensorFlow, for the 3 of us that experiment with training.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+15)</span><span class="cr-comment-text">&amp;gt;Expanded AMD GPU support ROCm 7.13.0 adds support for the following AMD GPUs and APUs: AMD Instinct MI350P (gfx950) AMD Radeon PRO W6800 (gfx1030) AMD Radeon PRO V620 (gfx1030) AMD Ryzen AI 7 PRO ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/JamesEvoAI (+14)</span><span class="cr-comment-text">The PP is better on ROCm for most models, and the TG only takes a minor hit in exchange. Depending on the use case that is a valuable tradeoff</span></div></div>
+  <p class="cr-summary">Quote: ...new optimizations for Ryzen AI Max 300 &quot;Strix Halo&quot; and the ROCprof Trace Decoder is now open-source...&lt;snip&gt;... Those rolling from source can grab the ROCm 7.13 Tech Preview via TheRock on GitHub.</p>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Terminator857 (+33)</span><span class="cr-comment-text">ROCm platform is generally preferred over pure Vulkan for better compatibility with frameworks like PyTorch and TensorFlow, for the 3 of us that experiment with training.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+15)</span><span class="cr-comment-text">&gt;Expanded AMD GPU support ROCm 7.13.0 adds support for the following AMD GPUs and APUs: AMD Instinct MI350P (gfx950) AMD Radeon PRO W6800 (gfx1030) AMD Radeon PRO V620 (gfx1030) AMD Ryzen AI 7 PRO 360...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/JamesEvoAI (+14)</span><span class="cr-comment-text">The PP is better on ROCm for most models, and the TG only takes a minor hit in exchange. Depending on the use case that is a valuable tradeoff</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tftg09" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="throughput and ttft comparisons of qwen 36 27b, qwen 36 35b a3b and gemma 4 models on h100 i wanted to figure out which of the newer small and midsize models are actually worth running on a single h100, so i put 8 of them through a proper vllm benchmark and recorded what came out the setup was simple one h100 80gb, vllm 0191, the builtin vllm bench serve tool, 100 prompts per run, 128 input tokens and 128 output tokens we ran each model at four different concurrency levels (1, 4… hardware quanti" data-cats="high-gpu quantization">
@@ -6488,7 +6488,7 @@
     </div>
   </div>
   <p class="cr-summary">I wanted to figure out which of the newer small and mid-size models are actually worth running on a single H100, so I put 8 of them through a proper vLLM benchmark and recorded what came out. The setup was simple. One H100 80GB, vLLM 0.19.1, the buil...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/FatheredPuma81 (+7)</span><span class="cr-comment-text">&amp;gt;MoE benefits so much more because those models are bottlenecked on moving expert weights through memory, and FP8 cuts that traffic in half. Interesting if you're on consumer hardware running quant...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/gvij (+3)</span><span class="cr-comment-text">Right, the bottleneck depends on which phase and which hardware. On H100, decode at low to moderate batch size is is bandwidth-bound (it is on basically any modern GPU because each weight gets reused ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Thagor (+1)</span><span class="cr-comment-text">For concurrency did you use continuous batching?</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/FatheredPuma81 (+7)</span><span class="cr-comment-text">&gt;MoE benefits so much more because those models are bottlenecked on moving expert weights through memory, and FP8 cuts that traffic in half. Interesting if you're on consumer hardware running quantize...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/gvij (+3)</span><span class="cr-comment-text">Right, the bottleneck depends on which phase and which hardware. On H100, decode at low to moderate batch size is is bandwidth-bound (it is on basically any modern GPU because each weight gets reused ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Thagor (+1)</span><span class="cr-comment-text">For concurrency did you use continuous batching?</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sv81sw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="larger gemma4qwen36 qwen35122ba10b at q6k is really good do you think we will see a larger moe gemma4 or qwen36 at some point? finetuning anthropic google qwen gemma yeah, i think qwen36 122b would be an extreme sweet spot for me in terms of not relying on claude a i think a qwen36122ba10b release is likely, and am a bit surprised they haven't released it alrea" data-cats="general">
@@ -6573,7 +6573,7 @@
     </div>
   </div>
   <p class="cr-summary">Provided in both Safetensors and GGUFs. Safetensors: llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic: GGUFs: llmfan46/Gemma-4-Gembrain-31B-it-uncensored-heretic-GGUF:</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pigeon57434 (+34)</span><span class="cr-comment-text">i dont ever trust these weird merged models</span></div><div class="cr-comment"><span class="cr-comment-meta">u/eidrag (+19)</span><span class="cr-comment-text">I don't see the point of it, when the merge already done with other finetune, which itself already done with Gemma-4-31B-it-heretic-ara</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Hydroskeletal (+16)</span><span class="cr-comment-text">&quot;Boost Lateral Thinking&quot; -&amp;gt; How? The only time I've seen this kind of claim was the model trained on 4chan</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pigeon57434 (+34)</span><span class="cr-comment-text">i dont ever trust these weird merged models</span></div><div class="cr-comment"><span class="cr-comment-meta">u/eidrag (+19)</span><span class="cr-comment-text">I don't see the point of it, when the merge already done with other finetune, which itself already done with Gemma-4-31B-it-heretic-ara</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Hydroskeletal (+16)</span><span class="cr-comment-text">&quot;Boost Lateral Thinking&quot; -&gt; How? The only time I've seen this kind of claim was the model trained on 4chan</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tg7s7j" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma4 26b a4b apex quant is quite good i tried mudler's apex quant for gemma4 26b a4b and it was amazing! i got 38tps at 90000 context with no loop and suprisingly no quality degradation i used mudlergemma426ba4bitapexgguf apexicompact (15gb) on my rx 9060 xt 16 gb with llamacpp vulkan for comperison, my previous quant gemma4 26b a4b unsloth udq5kxl quant (212gb) looped with similar longcontext test at 50k context im… hardware quantization inference benchmarking metallama gemma source: i made i" data-cats="quantization">
@@ -6644,7 +6644,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/mateszhun (+32)</span><span class="cr-comment-text">No mention of RAM speeds... 1,5x Bigger memory is nice and all, but is it faster?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/ImportancePitiful795 (+26)</span><span class="cr-comment-text">Well, AMD 495 is a AMD 395 bit overclocked with 192GB RAM support and 8533Mhz RAM instead of 8000Mhz. Considering all the AMD 395 miniPCs come with 8533Mhz RAM downclocked to 8000Mhz, if we can hack u...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Baumpaladin (+21)</span><span class="cr-comment-text">From the past leaks, I think no. So you can probably load even bigger models at even slower speeds, yay. Memory bandwidth will likely stay the bottleneck, unless AMD has some major improvements lined ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tjdz92" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="tested how opencode works with selfhosted llms: qwen 35, 36, gemma 4, nemotron 3, glm47 flash v2 i have run two tests on each llm with opencode to check their basic readiness and convenience: create indexnow cli in golang (easy task) and create migration map for a website following sitestructure strategy (complex task) tested qwen 35, &amp;amp; 36, gemma 4, nemotron 3, glm47 flash and several other llms context size used: 25k50k varies between tasks and models the result is in th… hardware quant" data-cats="quantization">
+<div class="cr-card" data-search="tested how opencode works with selfhosted llms: qwen 35, 36, gemma 4, nemotron 3, glm47 flash v2 i have run two tests on each llm with opencode to check their basic readiness and convenience: create indexnow cli in golang (easy task) and create migration map for a website following sitestructure strategy (complex task) tested qwen 35, &amp; 36, gemma 4, nemotron 3, glm47 flash and several other llms context size used: 25k50k varies between tasks and models the result is in th… hardware quantizat" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" target="_blank" rel="noopener">Tested how OpenCode Works with SelfHosted LLMS: Qwen 3.5, 3.6, Gemma 4, Nemotron 3, GLM-4.7 Flash - v2</a></h4>
@@ -6657,7 +6657,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">I have run two tests on each LLM with OpenCode to check their basic readiness and convenience: \- Create IndexNow CLI in Golang (Easy Task) and \- Create Migration Map for a website following SiteStructure Strategy. (Complex Task) Tested Qwen 3.5, &amp;a...</p>
+  <p class="cr-summary">I have run two tests on each LLM with OpenCode to check their basic readiness and convenience: \- Create IndexNow CLI in Golang (Easy Task) and \- Create Migration Map for a website following SiteStructure Strategy. (Complex Task) Tested Qwen 3.5, &amp; ...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pulse77 (+15)</span><span class="cr-comment-text">For complex coding tasks where precision matters the 3-bit quantization is &quot;gambling&quot;...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/InternationalNebula7 (+13)</span><span class="cr-comment-text">Please run with Qwen3.6:27B when unsloth releases the quants. Look forward to seeing the results!</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Designer_Reaction551 (+7)</span><span class="cr-comment-text">Qwen3 Coder Next beating the larger 3.5/3.6 general models tracks with what I've seen on agentic coding tasks on similar hardware. Task-tuned models hold structure better at 25-50k context than bigger...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ssdim1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -6981,7 +6981,7 @@
     </div>
   </div>
   <p class="cr-summary">I kept seeing inference-speed claims for these models and wanting an apples-to-apples comparison on the hardware I actually have. So I built a harness and a public page that dumps every run as YAML. The dataset: 55 runs, three rigs, five backends (ro...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/fallingdowndizzyvr (+15)</span><span class="cr-comment-text">&amp;gt; Memory bandwidth runs the show for decode. The RTX 5070 (12 GiB GDDR7, Vulkan) actually beats the RTX 3090 (24 GiB GDDR6X, CUDA) on every model that fits in 12 GiB: Ah.... the 3090 has faster mem...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tmvr (+10)</span><span class="cr-comment-text">I don't know what you did there exactly, but you messed it up. Go run both cards with CUDA and see what the results are. There is no way a 5070 is faster at tg/decode than a 3090.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Edenar (+6)</span><span class="cr-comment-text">Try with MTP too, i now get 20tok/s on 27B(Q8_0) for simple chat on strix halo. It'll also help the 3090. And i finally managed to get sub 5s replies with 3.6 35B A3B since i now get 70+tok/s (to use ...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/fallingdowndizzyvr (+15)</span><span class="cr-comment-text">&gt; Memory bandwidth runs the show for decode. The RTX 5070 (12 GiB GDDR7, Vulkan) actually beats the RTX 3090 (24 GiB GDDR6X, CUDA) on every model that fits in 12 GiB: Ah.... the 3090 has faster memory...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/tmvr (+10)</span><span class="cr-comment-text">I don't know what you did there exactly, but you messed it up. Go run both cards with CUDA and see what the results are. There is no way a 5070 is faster at tg/decode than a 3090.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Edenar (+6)</span><span class="cr-comment-text">Try with MTP too, i now get 20tok/s on 27B(Q8_0) for simple chat on strix halo. It'll also help the 3090. And i finally managed to get sub 5s replies with 3.6 35B A3B since i now get 70+tok/s (to use ...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tf9iyk" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="any good moe ~60b models? i have 64gb vram i have a build with 2 x mi50 32gbs and 64 gigs of ddr4 (bought before rampocolypse for ~630 usd total, i’m not rich) and i’m not gonna upgrade it for a long while are there any good moe models that are around 60b in parameters so i can make use of all the vram? i feel like i’m stuck in a weird spot where using small models fees like a waste but i can’t really use larger models i’ve been liking… hardware quantization mistral gemma q4q5q6q8 of qwen3635ba3" data-cats="quantization">
@@ -6998,7 +6998,7 @@
     </div>
   </div>
   <p class="cr-summary">I have a build with 2 x MI50 32GBs and 64 gigs of DDR4 (bought before rampocolypse for \~630 USD total, I’m not rich) and I’m not gonna upgrade it for a long while. Are there any good MOE models that are around 60B in parameters so I can make use of ...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+34)</span><span class="cr-comment-text">Q4/Q5/Q6/Q8 of Qwen3.6-35B-A3B, Qwen3.6-27B, Gemma-4-26B-A4B MXFP4 of GPT-OSS-120B Q4/Q5/Q6 of Qwen3-Coder-Next Q4 of Qwen3.5-122B-A10B, Nemotron-3-Super-120B-A12B, Mistral-Small-4-119B-2603, GLM-4.5-...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/munkiemagik (+8)</span><span class="cr-comment-text">With qwen3.6-27b performing as well as it does for its size, what kind of tasks do you find yourself preferring to use GPT-OSS-120B? Im interested in your (and u/kevin_1994) as I used to run OSS-120b ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+5)</span><span class="cr-comment-text">Air is 100B model(Still many fans there for this) &amp;amp; Flash is 30B model. Both Qwen3.6 &amp;amp; Gemma-4 models replaced previous 30B models so didn't include Flash.</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+34)</span><span class="cr-comment-text">Q4/Q5/Q6/Q8 of Qwen3.6-35B-A3B, Qwen3.6-27B, Gemma-4-26B-A4B MXFP4 of GPT-OSS-120B Q4/Q5/Q6 of Qwen3-Coder-Next Q4 of Qwen3.5-122B-A10B, Nemotron-3-Super-120B-A12B, Mistral-Small-4-119B-2603, GLM-4.5-...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/munkiemagik (+8)</span><span class="cr-comment-text">With qwen3.6-27b performing as well as it does for its size, what kind of tasks do you find yourself preferring to use GPT-OSS-120B? Im interested in your (and u/kevin_1994) as I used to run OSS-120b ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+5)</span><span class="cr-comment-text">Air is 100B model(Still many fans there for this) &amp; Flash is 30B model. Both Qwen3.6 &amp; Gemma-4 models replaced previous 30B models so didn't include Flash.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tfzmpq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="your local llm predictions and hopes for may 2026 which of these do you think we'll get in may? also, feel free to pickrank which ones you'd want the most badly: more gemma4 models (124b?) (other sizes?) more qwen36 models (9b? 122b? 397b?) new qwen coder model (80b even nexter?) (~397b400b+ coder?) new glm model in the 100b300b size range? small kimi model of some sort? more nvidianemotron models? new stepfun model? new ope… hardware inference finetuning openai metallama qwen mistral gemma phi " data-cats="quantization">
@@ -7035,7 +7035,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/BitGreen1270 (+6)</span><span class="cr-comment-text">This is primarily for Android size models? Or also can be a router for bigger 31b or 27b models on a Linux machine? Also are there some examples on how the threshold confidence works with actual promp...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Henrie_the_dreamer (+5)</span><span class="cr-comment-text">It works on bigger models, in fact the cloud handoff ratio reduces for bigger models.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/oxygen_addiction (+3)</span><span class="cr-comment-text">How does it classify a &quot;simple&quot; task for local inference vs. a &quot;complex&quot; task for cloud inference? I couldn't find anything at a glance about either of those on your Github/Docs.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tom98y" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="two related prompts, different results: qwen 35 and gemma 4 need different prompting than qwen 36 with every new model release there's the &quot;better than opus 613&quot; guys vs the &quot;this is so bad, why did they even release it&quot; camp and i'm always wondering which one is using it wrong so i did a little test with 2 related prompts, 3 models and ran each combination 10 times short prompt: &amp;gt;mike grew up as one of 6 siblings and has 3 sisters he has $25 and bought 5 boxes of appl" data-cats="quantization">
+<div class="cr-card" data-search="two related prompts, different results: qwen 35 and gemma 4 need different prompting than qwen 36 with every new model release there's the &quot;better than opus 613&quot; guys vs the &quot;this is so bad, why did they even release it&quot; camp and i'm always wondering which one is using it wrong so i did a little test with 2 related prompts, 3 models and ran each combination 10 times short prompt: &gt;mike grew up as one of 6 siblings and has 3 sisters he has $25 and bought 5 boxes of apples f" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1t6bsil" target="_blank" rel="noopener">Two related prompts, different results: Qwen 3.5 and Gemma 4 need different prompting than Qwen 3.6</a></h4>
@@ -7049,7 +7049,7 @@
     </div>
   </div>
   <p class="cr-summary">With every new model release there's the &quot;better than Opus 6.13&quot; guys vs the &quot;this is so bad, why did they even release it&quot; camp and I'm always wondering which one is using it wrong. So I did a little test with 2 related prompts, 3 models and ran eac...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ExplanationAway672 (+12)</span><span class="cr-comment-text">Try 27B... first try below with the short prompt Qwen3.6 27B UD Q4_K_XL (and got it right twice more in new sessions). Biggest hang up in reasoning was whether he was one of 6 siblings or had 6 siblin...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Qwoctopussy (+7)</span><span class="cr-comment-text">native speaker here and yes, you are right. this prompt has so much ambiguity. it’s less a test of “can the model reason logically?” and more a test of “can it read my mind when i don’t say what i mea...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/averymerryunbirthday (+5)</span><span class="cr-comment-text">&amp;gt; He has $25 and bought 5 boxes of apples for his organic apples business. I'm not a native speaker, but doesn't that imply he still has 25$ and we actually have no idea how much he spent buying th...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ExplanationAway672 (+12)</span><span class="cr-comment-text">Try 27B... first try below with the short prompt Qwen3.6 27B UD Q4_K_XL (and got it right twice more in new sessions). Biggest hang up in reasoning was whether he was one of 6 siblings or had 6 siblin...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Qwoctopussy (+7)</span><span class="cr-comment-text">native speaker here and yes, you are right. this prompt has so much ambiguity. it’s less a test of “can the model reason logically?” and more a test of “can it read my mind when i don’t say what i mea...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/averymerryunbirthday (+5)</span><span class="cr-comment-text">&gt; He has $25 and bought 5 boxes of apples for his organic apples business. I'm not a native speaker, but doesn't that imply he still has 25$ and we actually have no idea how much he spent buying the b...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t6bsil" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="12gbclub: 4070s qwen36 27b + 35b a3b, and gemma 4 26b a4b + 31b speeds longtime lurker here, thought i should post my speeeeds i have a rtx 4070s 12 gb vram (+10% oc), amd 9800x3d with 4x16 gb ddr5 6000mhz cl30 edit: i offload my display to my igpu btw to save some vram on the rtx dgpu otherwise drop 10% or so on performance edit2: using this with cuda 131 please dont ask me how good they can do stuff, it's all working with no tool calls issues in vs code wit… hardware quantization metallama gem" data-cats="mid-gpu quantization">
@@ -7100,7 +7100,7 @@
     </div>
   </div>
   <p class="cr-summary">We had a customer support RAG bot. Standard setup: ChromaDB, system prompt, an LLM doing generation. Nobody had actually measured the response quality. In the name of evaluation, I only had a keyword matching script producing numbers that looked like...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+26)</span><span class="cr-comment-text">Why no recent Qwen3.6 models &amp;amp; also Granite-4.1-30B? Would be nice to see those too</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cr0wburn (+17)</span><span class="cr-comment-text">What a weird mix of models, there are some top performers missing like the qwen 3.6 series, also gemma 4 31b?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+13)</span><span class="cr-comment-text">Thanks. Both Qwen-3.6-27B &amp;amp; Qwen-3.6-35B. Also please add Qwen3.5-9B &amp;amp; Gemma4-E4B as well.</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+26)</span><span class="cr-comment-text">Why no recent Qwen3.6 models &amp; also Granite-4.1-30B? Would be nice to see those too</span></div><div class="cr-comment"><span class="cr-comment-meta">u/cr0wburn (+17)</span><span class="cr-comment-text">What a weird mix of models, there are some top performers missing like the qwen 3.6 series, also gemma 4 31b?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pmttyji (+13)</span><span class="cr-comment-text">Thanks. Both Qwen-3.6-27B &amp; Qwen-3.6-35B. Also please add Qwen3.5-9B &amp; Gemma4-E4B as well.</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tdusvx" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="choosing an abliterated version of gemma 4 31b and 26ba4b the only thread was 2 months ago, when the model had just dropped since then, more versions from different authors have appeared, and users have had time to test them 1 which version are you running now? 2 more importantly which version caused you problems? currently i'm using both 31b and 26ba4b from llmfan46 (26ba4b regular not 'ultra'), but i'm wondering has anyone had issues with… gemma it's obviously not uncensored by default i am ju" data-cats="cpu-only">
@@ -7236,7 +7236,7 @@
     </div>
   </div>
   <p class="cr-summary">When dealing with untrusted outside input, I think you should handle it based on the situation. If you're processing structured data files, it's better to use tools to isolate and handle them. I made DataGate for that. But if it's web documents that ...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Mickenfox (+6)</span><span class="cr-comment-text">What I don't understand is why models don't just do this. Create two special tokens like &amp;lt;|untrusted_data|&amp;gt; &amp;lt;|end_of_untrusted_data|&amp;gt;, then train the model to never ever follow any instruc...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/User_Deprecated (+3)</span><span class="cr-comment-text">Some of them basically do, and it works. Not every provider seems to care about it yet though. Feels more like a prioritization thing than a real limitation.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/lakySK (+3)</span><span class="cr-comment-text">That seems to be working way better than I’d expect! Would you say the data you tested on is actually “state-of-the-art” of prompt injections? Or did you hold back for now? Where did you get the promp...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Mickenfox (+6)</span><span class="cr-comment-text">What I don't understand is why models don't just do this. Create two special tokens like &lt;|untrusted_data|&gt; &lt;|end_of_untrusted_data|&gt;, then train the model to never ever follow any instructions betwee...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/User_Deprecated (+3)</span><span class="cr-comment-text">Some of them basically do, and it works. Not every provider seems to care about it yet though. Feels more like a prioritization thing than a real limitation.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/lakySK (+3)</span><span class="cr-comment-text">That seems to be working way better than I’d expect! Would you say the data you tested on is actually “state-of-the-art” of prompt injections? Or did you hold back for now? Where did you get the promp...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t47z4q" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="what best coding model at 4b or 8b parameters? yea i know the title looks so stupid, yes i done searches, i searched google, huggingface, youtube, i even tested some via lm studio, but due to my lowend vram (gtx 1050 4g vram) i cant fit more than 4b or 1b into it, i have about 20g ram + 15g pagefile, i didnt have the chance to test out qwen 36 35b, my maximum quant was q3xxs, but this and what comes after it (q2, q1) will drop plenty of i… hardware quantization inference google qwen gemma qwen 3" data-cats="quantization">
@@ -7440,10 +7440,10 @@
     </div>
   </div>
   <p class="cr-summary">Which LLM with under 10B params has the best ability to do web searches Is there any benchmark for this where i could see how certain models perform I've checked out gemma e4b it, is it any good for web searching compared to other alternatives at the...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/OleCuvee (+14)</span><span class="cr-comment-text">Any decent model will do solid web search if you provide it with the right tools. I gave my researchers searXNG, so that I don’t have to rely on Firefly, Brave and Google tokens. Works great, search o...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/totonn87 (+7)</span><span class="cr-comment-text">If I remember correctly you have to use openwebui + searxng to use Gemma e4b with web search.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/DinoAmino (+4)</span><span class="cr-comment-text">&amp;gt; Openweb UI just isn't a great harness for any kind of research. Because OWUI is not a harness for research. But OP only asked about basic web search, and OWUI is completely capable of that. Diffi...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/OleCuvee (+14)</span><span class="cr-comment-text">Any decent model will do solid web search if you provide it with the right tools. I gave my researchers searXNG, so that I don’t have to rely on Firefly, Brave and Google tokens. Works great, search o...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/totonn87 (+7)</span><span class="cr-comment-text">If I remember correctly you have to use openwebui + searxng to use Gemma e4b with web search.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/DinoAmino (+4)</span><span class="cr-comment-text">&gt; Openweb UI just isn't a great harness for any kind of research. Because OWUI is not a harness for research. But OP only asked about basic web search, and OWUI is completely capable of that. Difficul...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1sp6qy7" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="blackwell and pdl performance increase llamacpp recently introduced support for programmatic dependent launch (pdl), which is a new feature in nvidia gpus (cc &amp;gt;= 90, not including ada) such as blackwell (see pr 22522) in short, pdl enables more efficient execution of kernels and as a result better performance so far, it's not enabled by default, if you don't know about it, you will likely miss it to enable pdl you need to buil… hardware quantization inference metallama qwen gemma do you k" data-cats="quantization">
+<div class="cr-card" data-search="blackwell and pdl performance increase llamacpp recently introduced support for programmatic dependent launch (pdl), which is a new feature in nvidia gpus (cc &gt;= 90, not including ada) such as blackwell (see pr 22522) in short, pdl enables more efficient execution of kernels and as a result better performance so far, it's not enabled by default, if you don't know about it, you will likely miss it to enable pdl you need to buil… hardware quantization inference metallama qwen gemma do you know " data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tkw1su" target="_blank" rel="noopener">Blackwell and PDL performance increase</a></h4>
@@ -7456,7 +7456,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Llama.cpp recently introduced support for Programmatic Dependent Launch (PDL), which is a new feature in Nvidia GPUs (CC &amp;gt;= 90, not including ADA) such as Blackwell. (See PR 22522.) In short, PDL enables more efficient execution of kernels and as ...</p>
+  <p class="cr-summary">Llama.cpp recently introduced support for Programmatic Dependent Launch (PDL), which is a new feature in Nvidia GPUs (CC &gt;= 90, not including ADA) such as Blackwell. (See PR 22522.) In short, PDL enables more efficient execution of kernels and as a r...</p>
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/__JockY__ (+3)</span><span class="cr-comment-text">Do you know if this applies to vLLM?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/chimpera (+2)</span><span class="cr-comment-text">What kernel are you referring to? also its '-DGGML_CUDA_PDL=ON' no space.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/stormy1one (+2)</span><span class="cr-comment-text">I will happily take an additional 5% to 6% for literally sitting on my ass and recompiling. Thank you kindly</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tkw1su" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
@@ -7588,7 +7588,7 @@
   <p class="cr-summary">Just got myself a Raspberry Pi 5 16Gb to tinker. Put Qwen3.5 4B on it for language and vision. now I would like to add speech to speech. Got the good old whisper/piper in it works and sounds just like a good old robot. Any other combo to try (without...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u462jn" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="best local model for xcode with 64gb mbp using lmstudio as the mcp server gemma4? &amp;#32; submitted by &amp;#32; ubrweb [link] &amp;#32; [comments] agents" data-cats="apple-silicon">
+<div class="cr-card" data-search="best local model for xcode with 64gb mbp using lmstudio as the mcp server gemma4? submitted by ubrweb [link] [comments] agents" data-cats="apple-silicon">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tyrg3z" target="_blank" rel="noopener">Best local model for Xcode with 64GB MBP using LMStudio as the MCP server</a></h4>
@@ -7601,10 +7601,10 @@
       <span class="cr-cat-badge">Apple Silicon</span>
     </div>
   </div>
-  <p class="cr-summary">Gemma4? &amp;#32; submitted by &amp;#32; /u/br_web [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Gemma4? submitted by /u/br_web [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tyrg3z" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 technical report &amp;#32; submitted by &amp;#32; ujacek2023 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 technical report submitted by ujacek2023 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uprjf3" target="_blank" rel="noopener">Gemma 4 Technical Report</a></h4>
@@ -7617,7 +7617,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/jacek2023 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/jacek2023 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uprjf3" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 qat accuracy inconsistencies table from i heard that moe models are usually more susceptible to quantization error, but what happened with the 12b? i thought lowerparameter models usually quantized worse and yet, e2be4b are pretty much perfect while the 12b deviates from fp16 the most do we have an explanation for that, or did maybe something go wrong during quantiza… quantization finetuning google gemma" data-cats="quantization">
@@ -7636,7 +7636,7 @@
   <p class="cr-summary">Table from I heard that MoE models are usually more susceptible to quantization error, but what happened with the 12B? I thought lower-parameter models usually quantized worse and yet, E2B/E4B are pretty much perfect while the 12B deviates from FP16 ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tynhd1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="the first gemma 4 12b finetunes are ready now you can start building your gemma 4 12b collection :) &amp;#32; submitted by &amp;#32; ujacek2023 [link] &amp;#32; [comments] quantization gemma" data-cats="quantization">
+<div class="cr-card" data-search="the first gemma 4 12b finetunes are ready now you can start building your gemma 4 12b collection :) submitted by ujacek2023 [link] [comments] quantization gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1twbi9y" target="_blank" rel="noopener">The first Gemma 4 12B finetunes are ready</a></h4>
@@ -7649,10 +7649,10 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Now you can start building your Gemma 4 12B collection :) &amp;#32; submitted by &amp;#32; /u/jacek2023 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Now you can start building your Gemma 4 12B collection :) submitted by /u/jacek2023 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1twbi9y" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 31b q6 vs gemma 4 31b qat what should i do? i'm stuck been scrolling reddit for hour and no luck what will be the best in overall scenario creative writing mainly what's the kld? help guys &amp;#32; submitted by &amp;#32; uweakshelter1698 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 31b q6 vs gemma 4 31b qat what should i do? i'm stuck been scrolling reddit for hour and no luck what will be the best in overall scenario creative writing mainly what's the kld? help guys submitted by uweakshelter1698 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ubxzil" target="_blank" rel="noopener">Gemma 4 31B Q6 vs Gemma 4 31B QAT</a></h4>
@@ -7665,7 +7665,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">what should i do? i'm stuck been scrolling reddit for hour and no luck. what will be the best in overall scenario. Creative Writing Mainly. what's the kld? help guys. &amp;#32; submitted by &amp;#32; /u/Weak-Shelter-1698 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">what should i do? i'm stuck been scrolling reddit for hour and no luck. what will be the best in overall scenario. Creative Writing Mainly. what's the kld? help guys. submitted by /u/Weak-Shelter-1698 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ubxzil" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="how to copy my own writing style hi, i have a quick question: i’m writing a story, and developed my own writing style for how i would like to convey the words at the same time, i have days where i can’t find the adjectives to describe the scene how i intend to, or i might struggle getting stuck between the sensory and visually descriptive language of creative writing and the stiff and direct academic prose expected of being a c… inference gemma" data-cats="general">
@@ -7684,7 +7684,7 @@
   <p class="cr-summary">Hi, I have a quick question: I’m writing a story, and developed my own writing style for how I would like to convey the words. At the same time, I have days where I can’t find the adjectives to describe the scene how I intend to, or I might struggle ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u6jjss" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="mlx community forgot about gemma 4 12b qat they started uploading to gemma 4 mtp qat but forgot to upload 12b quants to the gemma 4 qat 😭 &amp;#32; submitted by &amp;#32; uhanthunius [link] &amp;#32; [comments] gemma" data-cats="apple-silicon quantization">
+<div class="cr-card" data-search="mlx community forgot about gemma 4 12b qat they started uploading to gemma 4 mtp qat but forgot to upload 12b quants to the gemma 4 qat 😭 submitted by uhanthunius [link] [comments] gemma" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ty04tq" target="_blank" rel="noopener">MLX Community forgot about Gemma 4 12B QAT</a></h4>
@@ -7697,7 +7697,7 @@
       <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">They started uploading to Gemma 4 MTP QAT but forgot to upload 12B quants to the Gemma 4 QAT 😭. &amp;#32; submitted by &amp;#32; /u/Hanthunius [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">They started uploading to Gemma 4 MTP QAT but forgot to upload 12B quants to the Gemma 4 QAT 😭. submitted by /u/Hanthunius [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ty04tq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="be wary of qwenclaude distillations they're often worse than the base model just to be clear; i am not attempting to call anybody out or be mean to those who take the timemoney to make these models, i just want to inform people about these distillsfinetunes since there's clearly some confusion going on i'm going to assume those of us who often visit this subreddit have noticed these models, particularly the &quot;qwopus&quot; model and the such, though i'm sure there's probably… finetuning bench" data-cats="general">
@@ -7732,7 +7732,7 @@
   <p class="cr-summary">First of all, I'm stoked to announce we are almost at 20 million downloads on HF! (counted only on my own account, no duplicates/quants/finetunes/etc) and almost 5000 members on Discord! GenRM Defeated! 0/465 refusals *. Balanced = a light reasoning ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ucn9iq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="soofi s 30ba3b european open source model i just saw that these had dropped still very much early days, but nice to see a new locally runnable foundation model, along with a couple of thinking preview versions anyone taken a look at this yet? am intrigued to see how it holds up compared to qwen 36 and gemma 4 (my current stack) &amp;#32; submitted by &amp;#32; ugraemer71 [link] &amp;#32; [comments] qwen gemma" data-cats="general">
+<div class="cr-card" data-search="soofi s 30ba3b european open source model i just saw that these had dropped still very much early days, but nice to see a new locally runnable foundation model, along with a couple of thinking preview versions anyone taken a look at this yet? am intrigued to see how it holds up compared to qwen 36 and gemma 4 (my current stack) submitted by ugraemer71 [link] [comments] qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uyysg1" target="_blank" rel="noopener">Soofi S - 30B-A3B European Open Source Model</a></h4>
@@ -7748,7 +7748,7 @@
   <p class="cr-summary">I just saw that these had dropped. Still very much early days, but nice to see a new locally runnable foundation model, along with a couple of thinking preview versions. Anyone taken a look at this yet? Am intrigued to see how it holds up compared to...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uyysg1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="ornith10 released on hugging face including 9b dense, 31b dense, 35b moe, and 397b moe and reporting sota on different benchmark (let's see if this holds) &amp;#32; submitted by &amp;#32; upaf1138 [link] &amp;#32; [comments] benchmarking" data-cats="general">
+<div class="cr-card" data-search="ornith10 released on hugging face including 9b dense, 31b dense, 35b moe, and 397b moe and reporting sota on different benchmark (let's see if this holds) submitted by upaf1138 [link] [comments] benchmarking" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ufc9vp" target="_blank" rel="noopener">Ornith-1.0 released on Hugging Face</a></h4>
@@ -7761,7 +7761,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Including 9B Dense, 31B Dense, 35B MoE, and 397B MoE and reporting sota on different benchmark (let's see if this holds). &amp;#32; submitted by &amp;#32; /u/paf1138 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Including 9B Dense, 31B Dense, 35B MoE, and 397B MoE and reporting sota on different benchmark (let's see if this holds). submitted by /u/paf1138 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ufc9vp" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="need some guidance toying with local models hi, so i have a pretty lowend laptop regarding running llms locally (nvidia geforce rtx 3050 with 4gb vram, amd ryzen 7 5800h and 16gb ddr4) and while i'm not looking for anything to realistically work with, i'd be interested in how could i toy with something like gemma4 and qwen36 now, i'm a bit confused about all the terminology and options there are for this stuff (gguf, quants, qat, mtp sp… hardware quantization" data-cats="laptop quantization">
@@ -7796,7 +7796,7 @@
   <p class="cr-summary">Benchmark Results Benchmark configuration: threads = 96 type_k = bf16 type_v = bf16 Llama-3.1-8B-Instruct Q8_0 Prompt Size GGML_CPU_Q8_0 t/s ZenDNN_Q8_0 t/s Gain 256 472.28 730.87 54.75% 512 450.86 832.48 84.64% 768 446.81 864.52 93.49% 1024 439.58 8...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ux4co7" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="the best model is the one you can actually run don't get me wrong, all the big models are amazing, and every contribution to open source models is great but i'm gpu poor and i can't use them locally i'm currently running gemma412bitqatgguf:udq4kxl as my personal chat assistant, and i am so so happy with it! i still can't believe i can talk to my computer &amp;#32; submitted by &amp;#32; uonefanfare [link] &amp;#32; [comments] hardware quantization gemma" data-cats="quantization">
+<div class="cr-card" data-search="the best model is the one you can actually run don't get me wrong, all the big models are amazing, and every contribution to open source models is great but i'm gpu poor and i can't use them locally i'm currently running gemma412bitqatgguf:udq4kxl as my personal chat assistant, and i am so so happy with it! i still can't believe i can talk to my computer submitted by uonefanfare [link] [comments] hardware quantization gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ux9xze" target="_blank" rel="noopener">The best model is the one you can actually run</a></h4>
@@ -7876,7 +7876,7 @@
   <p class="cr-summary">Apologies in advance as the video is demonstrating with GPT 5.4 mini (a local model would take too long for a video), however I’ve made the same app with Gemma 4 E4B. Been working on an open source project for a while called Ironsmith. The gist is yo...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u63qny" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="qwen and gemma providers i like to use the moe modles qwen3635b and gemma426b i noticed differences in result quality between versions from different providers, like bartowski, unsloth, lmstudio, google, etc my tests dont give me a clear answer to though is there a rule if thumb which provider to prefer for 1) coding and 2) chatting and general world knowledge? &amp;#32; submitted by &amp;#32; uscubid [link] &amp;#32; [com… google qwen gemma" data-cats="general">
+<div class="cr-card" data-search="qwen and gemma providers i like to use the moe modles qwen3635b and gemma426b i noticed differences in result quality between versions from different providers, like bartowski, unsloth, lmstudio, google, etc my tests dont give me a clear answer to though is there a rule if thumb which provider to prefer for 1) coding and 2) chatting and general world knowledge? submitted by uscubid [link] [com… google qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uzr4ia" target="_blank" rel="noopener">Qwen and Gemma providers</a></h4>
@@ -7924,7 +7924,7 @@
   <p class="cr-summary">Cortex is an institutional memory layer for teams and communities, allowing them to curate data which gets automatically organized so that agents can query it very efficiently using LLMs that can be hosted on consumer-grade hardware. Goal is to democ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uy1066" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma4 12b experiences? anyone check out the new gemma4 12b that dropped 3 days ago? integrated vision and audio recognition, no mmpro needed plus tool use q4 quant is like 8gb ram crazy fast and great quality for it's size no, it's not as good as a 27b or 31b but it's damn close curious what others think &amp;#32; submitted by &amp;#32; uilldragonfruit3547 [link] &amp;#32; [comments] quantization agents" data-cats="quantization">
+<div class="cr-card" data-search="gemma4 12b experiences? anyone check out the new gemma4 12b that dropped 3 days ago? integrated vision and audio recognition, no mmpro needed plus tool use q4 quant is like 8gb ram crazy fast and great quality for it's size no, it's not as good as a 27b or 31b but it's damn close curious what others think submitted by uilldragonfruit3547 [link] [comments] quantization agents" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tyxyzi" target="_blank" rel="noopener">Gemma4 12B - Experiences?</a></h4>
@@ -8036,7 +8036,7 @@
   <p class="cr-summary">There've been a bunch of NVFP4 quants released recently by FreedomAISVR on huggingface, and something seems off with them. Not that they don't work, but some things in the readme just don't make sense to me. This quant for example: It says &quot;Quantized...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u9iw4c" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 12b without audio component do you think it is possible to make gemma 4 12b with the removed audio component? it will probably be more of an 11b model and would save some ram for those of us who don't care about audio and just want good small text+vision model edit: thanks to uslalomz i now understand that this architecture will not allow it &amp;#32; submitted by &amp;#32; uwhiskyakm [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 12b without audio component do you think it is possible to make gemma 4 12b with the removed audio component? it will probably be more of an 11b model and would save some ram for those of us who don't care about audio and just want good small text+vision model edit: thanks to uslalomz i now understand that this architecture will not allow it submitted by uwhiskyakm [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tw25hf" target="_blank" rel="noopener">Gemma 4 12B without audio component</a></h4>
@@ -8068,7 +8068,7 @@
   <p class="cr-summary">I like to download and test new LLMs, recompile llama.cpp every days, maybe it's an addiction ;) I'm used to request explanation about PI calculation/Ramanujan, or French recipe to bench/compare the results of all LLMs : speed, quality of the result,...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u4794g" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="diffusiongemma: 4x faster text generation &amp;#32; submitted by &amp;#32; utevlon [link] &amp;#32; [comments] discussion" data-cats="general">
+<div class="cr-card" data-search="diffusiongemma: 4x faster text generation submitted by utevlon [link] [comments] discussion" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u26s8n" target="_blank" rel="noopener">DiffusionGemma: 4x faster text generation</a></h4>
@@ -8081,10 +8081,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/tevlon [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/tevlon [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u26s8n" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 qat 31b responds better to kv cache quantization too i've run benchmark from this post and got even better results on gemma 4 31b &amp;#32; submitted by &amp;#32; ujusticecurcian [link] &amp;#32; [comments] benchmarking gemma" data-cats="quantization">
+<div class="cr-card" data-search="gemma 4 qat 31b responds better to kv cache quantization too i've run benchmark from this post and got even better results on gemma 4 31b submitted by ujusticecurcian [link] [comments] benchmarking gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ucgrxh" target="_blank" rel="noopener">Gemma 4 QAT 31B responds better to KV cache quantization too</a></h4>
@@ -8097,10 +8097,10 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">I've run benchmark from this post and got even better results on Gemma 4 31B &amp;#32; submitted by &amp;#32; /u/justicecurcian [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">I've run benchmark from this post and got even better results on Gemma 4 31B submitted by /u/justicecurcian [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ucgrxh" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="at least one more gemma 4 model confirmed?? &amp;#32; submitted by &amp;#32; usufficientbid3874 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="at least one more gemma 4 model confirmed?? submitted by usufficientbid3874 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txu8dx" target="_blank" rel="noopener">At least one more Gemma 4 model confirmed??</a></h4>
@@ -8113,7 +8113,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/Sufficient-Bid3874 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/Sufficient-Bid3874 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txu8dx" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="community distillation project: capturing glm52 + claude opus level reasoning in a runnable open model i’ve been running long coding and agentic sessions with both glm52 and claude opus 48 and saving the traces the quality difference is noticeable, especially on complex multistep work glm52 is already very strong in this area but too big for everyday local use i’m thinking we could distill the reasoning patterns into something practical around 70b or smaller using current strong open base… hardw" data-cats="general">
@@ -8164,7 +8164,7 @@
   <p class="cr-summary">Before I begin, let me say that this is 100% vibe coded, using Hermes Agent, and the 'Owl-Alpha' stealth model on Openrouter. And, point of note, my GPU is a 4060ti 16gb. Quick background: Hermes Agent allows you to use an array of models. A 'main' m...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ttgc89" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 qat ggufs from unsloth their collection: and their guide, always a very interesting read: &amp;#32; submitted by &amp;#32; unewsletternew [link] &amp;#32; [comments] gemma" data-cats="quantization">
+<div class="cr-card" data-search="gemma 4 qat ggufs from unsloth their collection: and their guide, always a very interesting read: submitted by unewsletternew [link] [comments] gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txpheq" target="_blank" rel="noopener">Gemma 4 QAT GGUFs from Unsloth</a></h4>
@@ -8177,10 +8177,10 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Their collection: And their guide, always a very interesting read: &amp;#32; submitted by &amp;#32; /u/newsletternew [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Their collection: And their guide, always a very interesting read: submitted by /u/newsletternew [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txpheq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="aa comparison of the latest local models i picked models i consider local (usable on 3×3090), so there are no 300b models, and you should probably skip 200b models too (but minimax and step are pretty fast in q3) gemma4 12b is still missing &amp;#32; submitted by &amp;#32; ujacek2023 [link] &amp;#32; [comments] hardware gemma" data-cats="high-gpu">
+<div class="cr-card" data-search="aa comparison of the latest local models i picked models i consider local (usable on 3×3090), so there are no 300b models, and you should probably skip 200b models too (but minimax and step are pretty fast in q3) gemma4 12b is still missing submitted by ujacek2023 [link] [comments] hardware gemma" data-cats="high-gpu">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tya05j" target="_blank" rel="noopener">AA comparison of the latest local models</a></h4>
@@ -8193,7 +8193,7 @@
       <span class="cr-cat-badge">High-end GPU (24+ GB)</span>
     </div>
   </div>
-  <p class="cr-summary">I picked models I consider local (usable on 3×3090), so there are no 300B models, and you should probably skip 200B models too (but MiniMax and Step are pretty fast in Q3) Gemma-4 12B is still missing &amp;#32; submitted by &amp;#32; /u/jacek2023 [link] &amp;#32...</p>
+  <p class="cr-summary">I picked models I consider local (usable on 3×3090), so there are no 300B models, and you should probably skip 200B models too (but MiniMax and Step are pretty fast in Q3) Gemma-4 12B is still missing submitted by /u/jacek2023 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tya05j" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="unsloth gemma 4 qat mtp assistant models now available they're both available as q80 models named mtpgemma4*gguf on the root of the directory and in both q80 and larger quants within an mtp folder quantization gemma" data-cats="quantization">
@@ -8260,7 +8260,7 @@
   <p class="cr-summary">I've tried renting some cloud instances to get an idea of the speed of various GPUs. I'm using a recent version llama.cpp with CUDA 12.8 support. I've tried running a 31B dense model, Q6, on an RTX 5090 and an H100, and the results surprised me. The ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u6bwcn" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="newer qwen models are worse at summarization? we have summaries annotated by real humans that we benchmark various models, using an llm as a judge, we found that in the 30b params range, qwen 3 tops it out, followed by gemma 4 it feels like newer qwens are optimized to perform agentic tasks? &amp;#32; submitted by &amp;#32; utheboyscampus [link] &amp;#32; [comments] benchmarking qwen gemma" data-cats="general">
+<div class="cr-card" data-search="newer qwen models are worse at summarization? we have summaries annotated by real humans that we benchmark various models, using an llm as a judge, we found that in the 30b params range, qwen 3 tops it out, followed by gemma 4 it feels like newer qwens are optimized to perform agentic tasks? submitted by utheboyscampus [link] [comments] benchmarking qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u1ggo9" target="_blank" rel="noopener">Newer Qwen models are worse at summarization?</a></h4>
@@ -8273,7 +8273,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">We have summaries annotated by real humans that we benchmark various models, using an LLM as a judge, we found that in the 30B params range, Qwen 3 tops it out, followed by Gemma 4. It feels like newer Qwens are optimized to perform agentic tasks? &amp;#...</p>
+  <p class="cr-summary">We have summaries annotated by real humans that we benchmark various models, using an LLM as a judge, we found that in the 30B params range, Qwen 3 tops it out, followed by Gemma 4. It feels like newer Qwens are optimized to perform agentic tasks? su...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u1ggo9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="i scaled testtime compute for qwen3627b and gemma431b to surpass claude mythos in code optimizations and speedups the scaffold uses ~2540x more compute on the original baseline model to attempt the same problem i put it into max mode by setting the branches exploration breadth to 5, iterative corrections loop depth to 10 and 6 branch aware selective hypothesis that are revised after every 2 iterations these hypotheses tests various claims, local speedups or completely different algorithmic desig" data-cats="general">
@@ -8422,7 +8422,7 @@
   <p class="cr-summary">I've spent the last six months trying to build a fully local, agentic pipeline for a text_processing and extraction tool I use daily. ​Because I’m running everything on a single consumer GPU setup, my choices are limited to smaller, quantized open we...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u2ch6u" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="bringing gemma 4 12b to your laptop: unlocking local, agentic workflows with google ai edge &amp;#32; submitted by &amp;#32; uzxyzyxz [link] &amp;#32; [comments] google gemma" data-cats="laptop">
+<div class="cr-card" data-search="bringing gemma 4 12b to your laptop: unlocking local, agentic workflows with google ai edge submitted by uzxyzyxz [link] [comments] google gemma" data-cats="laptop">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txhj2h" target="_blank" rel="noopener">Bringing Gemma 4 12B to your Laptop: Unlocking Local, Agentic Workflows with Google AI Edge</a></h4>
@@ -8435,7 +8435,7 @@
       <span class="cr-cat-badge">Laptops</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/zxyzyxz [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/zxyzyxz [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txhj2h" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="is there any reason for a lack of love for gemma 4 26b? the answer to most questions on here is qwen36 27b or 35b and then gemma4 31b (but lesser so as it doesn’t fit well on a solo 3090) is there any reason why gemma 4 26b moe isn’t mentioned more? i plan on using qwen for my coding agents but i’ve been building a jarvis for myself that’s a big all in one rag, personal assistant, etc on my solo 3090 build (with a few side gpus to help with support… hardware rag qwen gemma" data-cats="high-gpu">
@@ -8502,7 +8502,7 @@
   <p class="cr-summary">I'm the developer, and I just launched Rewire Text , a Windows + macOS tool that transforms text in any app at the press of a hotkey. It sits in the menu bar / system tray until needed. Deterministic transforms (case changes, whitespace cleanup, Mark...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uqbfun" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="byte exact kv cache grafting on frozen gemma 4 we published a method to store verified knowledge as kv state and restore it byte identical to fresh computation on gemma 4 12b, cached knowledge improved the same routing system from 767% to 900% on aime 2025 i will pitch this at agi summit on july 19 paper: &amp;#32; submitted by &amp;#32; umindpsychological140 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="byte exact kv cache grafting on frozen gemma 4 we published a method to store verified knowledge as kv state and restore it byte identical to fresh computation on gemma 4 12b, cached knowledge improved the same routing system from 767% to 900% on aime 2025 i will pitch this at agi summit on july 19 paper: submitted by umindpsychological140 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v07tib" target="_blank" rel="noopener">Byte exact KV cache grafting on frozen Gemma 4</a></h4>
@@ -8534,7 +8534,7 @@
   <p class="cr-summary">Google just released the QAT (Quantization-Aware Training) variant of their Gemma 4 models, including 12B, so it was only natural for me to benchmark it on my 12GB GPU since it fits entirely in VRAM. I was pleasantly surprised with the result! By usi...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1typjmc" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="kvcache : avoid kv cells copies by ggerganov · pull request #24277 · ggmlorgllamacpp improved mtp performance (for gemma4) this got merged yesterday available b9551 onwards &amp;#32; submitted by &amp;#32; upmttyji [link] &amp;#32; [comments] quantization inference metallama gemma" data-cats="quantization">
+<div class="cr-card" data-search="kvcache : avoid kv cells copies by ggerganov · pull request #24277 · ggmlorgllamacpp improved mtp performance (for gemma4) this got merged yesterday available b9551 onwards submitted by upmttyji [link] [comments] quantization inference metallama gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u06jel" target="_blank" rel="noopener">kv-cache : avoid kv cells copies by ggerganov · Pull Request #24277 · ggml-org/llama.cpp</a></h4>
@@ -8547,10 +8547,10 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Improved MTP performance (For Gemma-4) This got merged yesterday. Available b9551 onwards. &amp;#32; submitted by &amp;#32; /u/pmttyji [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Improved MTP performance (For Gemma-4) This got merged yesterday. Available b9551 onwards. submitted by /u/pmttyji [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u06jel" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="introducing gemma 4 12b: a unified, encoderfree multimodal model &amp;#32; submitted by &amp;#32; ujohnnyappleprng [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="introducing gemma 4 12b: a unified, encoderfree multimodal model submitted by ujohnnyappleprng [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tvw2ej" target="_blank" rel="noopener">Introducing Gemma 4 12B: a unified, encoder-free multimodal model</a></h4>
@@ -8563,7 +8563,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/johnnyApplePRNG [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/johnnyApplePRNG [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tvw2ej" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="an agent that plans with a frontier model but runs most of tokens locally (built it for my own dual3090 rig) for the past couple of months, i've been building a tool for my personal use i have a dual rtx 3090 system which i wanted to use but the qwen 3536 27b and gemma 4 31b while being really good, just didn't have the taste or the ability that a frontier model has otoh, frontier models are expensive and i didn't want everything i do running through them i wanted the best of both worlds: fronti" data-cats="high-gpu">
@@ -8630,7 +8630,7 @@
   <p class="cr-summary">Hello, My setup is 2x RTX 3060 Ti 8GB, without the assistant model (MTP) I get around 75t/s, adding the assistant model as draft I manage to reach 100t/s peak. I tried puting the model on a single card with minimal context size, but still not helping...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u0aj1b" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 26ba4b surprisingly usable at iq3s are small quants really this usable? i've been experimenting with using lower quants of gemma 4 26b on my m3 16gb macbook air the quant runs at a solid 25 tokens per second decoding and is really close to the bf16 for my use cases (no coding, tool calling) do i have confirmation bias or are ud q3 quants surprisingly good? anyhow, huge props to the unsloth team! &amp;#32; submitted by &amp;#32; usufficientbid3874 [link] &amp;#32; [comments] hardware quan" data-cats="apple-silicon quantization">
+<div class="cr-card" data-search="gemma 4 26ba4b surprisingly usable at iq3s are small quants really this usable? i've been experimenting with using lower quants of gemma 4 26b on my m3 16gb macbook air the quant runs at a solid 25 tokens per second decoding and is really close to the bf16 for my use cases (no coding, tool calling) do i have confirmation bias or are ud q3 quants surprisingly good? anyhow, huge props to the unsloth team! submitted by usufficientbid3874 [link] [comments] hardware quantization gemma" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ueb1n1" target="_blank" rel="noopener">Gemma 4 26BA4B Surprisingly Usable at IQ3_S - Are small quants really this usable?</a></h4>
@@ -8694,7 +8694,7 @@
   <p class="cr-summary">Edit: the upvoted comment seems to imply I have failed to add &quot;physical layout&quot; to my question. I might hope even small LLMs are smart enough to answer what they see and then add info what it means. I have tried to get several LLMs to tell me exactly...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u4m42e" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="what would you recommend as the smallest vision model that could extract contact info from a business card scan? i tried smol but it was too smol and couldn't get it right gemma 4 e2 at around 26gb is bigger than i would like thanks in advance! &amp;#32; submitted by &amp;#32; uderallo [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="what would you recommend as the smallest vision model that could extract contact info from a business card scan? i tried smol but it was too smol and couldn't get it right gemma 4 e2 at around 26gb is bigger than i would like thanks in advance! submitted by uderallo [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u4fbfp" target="_blank" rel="noopener">What would you recommend as the smallest vision model that could extract contact info from a business card scan?</a></h4>
@@ -8707,7 +8707,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">I tried smol but it was too smol and couldn't get it right. Gemma 4 e2 at around 2.6gb is bigger than i would like. Thanks in advance! &amp;#32; submitted by &amp;#32; /u/derallo [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">I tried smol but it was too smol and couldn't get it right. Gemma 4 e2 at around 2.6gb is bigger than i would like. Thanks in advance! submitted by /u/derallo [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u4fbfp" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="how do i set the right llamacpp parameters? ngpulayers all ctxsize 0 reasoningbudget 0 presencepenalty 11 repeatpenalty 11 how do i figure out the optimal llamacpp parameters for my setup? llamacpp + open webui in docker with an amd gpu (16gb vram) running gemma 4 12b and 26b models is it all about trial and error? are there more materials i can study to learn beyond the llamacpp docs ? google provides recommended set… hardware inference google metallama gemma" data-cats="mid-gpu quantization">
@@ -8742,7 +8742,7 @@
   <p class="cr-summary">A lot of people seem to be confused or mystified about this so figured I'd spell it out. I played around with RYS and realized that it broke Gemma 4 models. Turns out there's a `layer_scalar` value that is applied at each layer. If you don't adjust t...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1un9muu" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 12b hallucinations i routed gemma 4 12b to my local server and tested vision it keeps hallucinating when there is context and previous conversation terns it sees the image when there is no context anybody experienced that? &amp;#32; submitted by &amp;#32; uwaveformentropy [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 12b hallucinations i routed gemma 4 12b to my local server and tested vision it keeps hallucinating when there is context and previous conversation terns it sees the image when there is no context anybody experienced that? submitted by uwaveformentropy [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txgckg" target="_blank" rel="noopener">Gemma 4 12b hallucinations</a></h4>
@@ -8755,7 +8755,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">I routed Gemma 4 12b to my local server and tested vision. It keeps hallucinating when there is context and previous conversation terns. It sees the image when there is no context. Anybody experienced that? &amp;#32; submitted by &amp;#32; /u/WaveformEntropy...</p>
+  <p class="cr-summary">I routed Gemma 4 12b to my local server and tested vision. It keeps hallucinating when there is context and previous conversation terns. It sees the image when there is no context. Anybody experienced that? submitted by /u/WaveformEntropy [link] [com...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txgckg" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="some contrived tests comparing the accuracy of different gemma and qwen quantizations i mostly ran these tests for myself, because the published kld numbers are hard to interpret, and you cannot compare 9bq4 vs 4bq8 , for example but i'm happy to share the results with anyone interested: test 1 (arithmetic) 1000 questions like print only one number as the answer to the following question print nothing else, please do not use commas or underscores it is very important 998604… quantization google " data-cats="quantization">
@@ -8774,7 +8774,7 @@
   <p class="cr-summary">I mostly ran these tests for myself, because the published KLD numbers are hard to interpret, and you cannot compare 9B-Q4 vs 4B-Q8 , for example. But I'm happy to share the results with anyone interested: Test 1 (Arithmetic) 1000 questions like Prin...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u3i8x7" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="more gemma 4 models incoming possibly the 120b model &amp;#32; submitted by &amp;#32; udeepvermicelli4591 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="more gemma 4 models incoming possibly the 120b model submitted by udeepvermicelli4591 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tvzzml" target="_blank" rel="noopener">More Gemma 4 models incoming</a></h4>
@@ -8787,10 +8787,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">possibly the 120B model &amp;#32; submitted by &amp;#32; /u/Deep-Vermicelli-4591 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">possibly the 120B model submitted by /u/Deep-Vermicelli-4591 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tvzzml" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="what’s your favorite underrated local model? what’s your favorite underrated local model that you actually use every day? i’m not talking about the mainstream choices like qwen 36 or gemma 4 i’m looking for the hidden gems that deserve more attention what do you use it for, and what hardware are you running it on? i’m hoping this thread surfaces some overlooked models that more people should know about &amp;#32; submitted by &amp;#32; ube566… qwen gemma" data-cats="laptop">
+<div class="cr-card" data-search="what’s your favorite underrated local model? what’s your favorite underrated local model that you actually use every day? i’m not talking about the mainstream choices like qwen 36 or gemma 4 i’m looking for the hidden gems that deserve more attention what do you use it for, and what hardware are you running it on? i’m hoping this thread surfaces some overlooked models that more people should know about submitted by ube566… qwen gemma" data-cats="laptop">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v0eszf" target="_blank" rel="noopener">What’s your favorite underrated local model?</a></h4>
@@ -8806,7 +8806,7 @@
   <p class="cr-summary">What’s your favorite underrated local model that you actually use every day? I’m not talking about the mainstream choices like Qwen 3.6 or Gemma 4. I’m looking for the hidden gems that deserve more attention. What do you use it for, and what hardware...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v0eszf" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 qat unquantized heretic is here now someone needs to quantize them to 4bit, also i have intentionally kept the divergence and refusal different from original gemma 4 heretic collection, so you can even try these as alternative to original model &amp;#32; submitted by &amp;#32; ucoder3101 [link] &amp;#32; [comments] gemma" data-cats="quantization">
+<div class="cr-card" data-search="gemma 4 qat unquantized heretic is here now someone needs to quantize them to 4bit, also i have intentionally kept the divergence and refusal different from original gemma 4 heretic collection, so you can even try these as alternative to original model submitted by ucoder3101 [link] [comments] gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tynv0p" target="_blank" rel="noopener">Gemma 4 QAT Unquantized Heretic is here</a></h4>
@@ -8819,7 +8819,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Now someone needs to quantize them to 4bit, also I have intentionally kept the divergence and refusal different from original Gemma 4 heretic collection, so you can even try these as alternative to original model. &amp;#32; submitted by &amp;#32; /u/coder310...</p>
+  <p class="cr-summary">Now someone needs to quantize them to 4bit, also I have intentionally kept the divergence and refusal different from original Gemma 4 heretic collection, so you can even try these as alternative to original model. submitted by /u/coder3101 [link] [co...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tynv0p" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 models benchmarked on with triple gpu hearing good things about gemma 4 ran a few models across my llama box kubuntu 2604 os amd ryzen 5 3600 6core cpu 48 gib of ddr4 3600 mhz ram nvidia gtx1070 at 8gib vram ( x 3 ) with 24gib total vram gpus have power limit set to 120, 121, 122 watts using: sudo nvidiasmi i 0 pl 120, sudo nvidiasmi i 1 pl 121, sudo nvidiasmi i 2 pl 122 it's about a 5% performance hit for inference… hardware quantization inference benchmarking metallama gemma" data-cats="quantization">
@@ -8838,7 +8838,7 @@
   <p class="cr-summary">Hearing good things about Gemma 4. Ran a few models across my llama box. Kubuntu 26.04 OS. AMD Ryzen 5 3600 6-core CPU. 48 GiB of DDR4 3600 Mhz RAM. Nvidia GTX-1070 at 8GiB VRAM ( X 3 ) with 24GiB total VRAM. GPUs have power limit set to 120, 121, 12...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u5ul4k" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="how to run gemma412bitqatw4a16ct in vllm or any version quantized of the model when running by using transformers it runs by using vllm some weird error come up plese can any body share the command of running it on vllm ? &amp;#32; submitted by &amp;#32; usavingsweather1659 [link] &amp;#32; [comments] inference gemma" data-cats="quantization">
+<div class="cr-card" data-search="how to run gemma412bitqatw4a16ct in vllm or any version quantized of the model when running by using transformers it runs by using vllm some weird error come up plese can any body share the command of running it on vllm ? submitted by usavingsweather1659 [link] [comments] inference gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tzshf1" target="_blank" rel="noopener">how to run gemma-4-12b-it-qat-w4a16-ct in vllm or any version quantized of the model</a></h4>
@@ -8851,10 +8851,10 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">when running by using transformers it runs by using vllm some weird error come up plese can any body share the command of running it on vllm ? &amp;#32; submitted by &amp;#32; /u/SavingsWeather1659 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">when running by using transformers it runs by using vllm some weird error come up plese can any body share the command of running it on vllm ? submitted by /u/SavingsWeather1659 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tzshf1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="llamacpp gemma4 mtp support merged! &amp;#32; submitted by &amp;#32; upinkyellowneon [link] &amp;#32; [comments] inference metallama" data-cats="quantization">
+<div class="cr-card" data-search="llamacpp gemma4 mtp support merged! submitted by upinkyellowneon [link] [comments] inference metallama" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tzbcyp" target="_blank" rel="noopener">llama.cpp Gemma4 MTP support merged!</a></h4>
@@ -8867,7 +8867,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/pinkyellowneon [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/pinkyellowneon [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tzbcyp" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="running a vision + audio + reasoning on one gemma 4 e2b locally on 4 gb vram and keeping it real time so i've had one gemma 4 e2b running through llamaserver as the only model in a local tool that watches my screen and lets me searchchat over it later same model does all three jobs: looks at the screen and turns it into structured info (what app, what i'm doing, rough layout) audio voice memos + meeting transcription using e2b's audio encoder, so i didn't have to bolt on whisper the ac… hardware" data-cats="general">
@@ -8886,7 +8886,7 @@
   <p class="cr-summary">So I've had one Gemma 4 E2B running through llama-server as the only model in a local tool that watches my screen and lets me search/chat over it later. Same model does all three jobs: - looks at the screen and turns it into structured info (what app...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1upx3gm" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="openclaw with lm studiogemma 4 wanted to share a recent post i made regarding my success using openclaw with a local model i am pretty much using 90% local, with my 5070 ti card i wanted to thank this very community for the answers to questions i didn't know i had &amp;#32; submitted by &amp;#32; uwallaby989 [link] &amp;#32; [comments] inference gemma" data-cats="mid-gpu quantization">
+<div class="cr-card" data-search="openclaw with lm studiogemma 4 wanted to share a recent post i made regarding my success using openclaw with a local model i am pretty much using 90% local, with my 5070 ti card i wanted to thank this very community for the answers to questions i didn't know i had submitted by uwallaby989 [link] [comments] inference gemma" data-cats="mid-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uxd9wz" target="_blank" rel="noopener">OpenClaw with LM Studio/Gemma 4</a></h4>
@@ -8899,10 +8899,10 @@
       <span class="cr-cat-badge">Mid-range GPU (8-16 GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Wanted to share a recent post I made regarding my success using OpenClaw with a local model. I am pretty much using 90% local, with my 5070 Ti card. I wanted to thank this very community for the answers to questions I didn't know I had. &amp;#32; submitt...</p>
+  <p class="cr-summary">Wanted to share a recent post I made regarding my success using OpenClaw with a local model. I am pretty much using 90% local, with my 5070 Ti card. I wanted to thank this very community for the answers to questions I didn't know I had. submitted by ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uxd9wz" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 webgpu kernels 255 toks by x@xenovacom we need more of this, 100+ ts on dense models is the difference between defaulting to claudecodex for everything vs having a local private model doing most of the heavy lifting and only reaching for frontier for heavy intelligence work &amp;#32; submitted by &amp;#32; uyonz [link] &amp;#32; [comments] anthropic gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 webgpu kernels 255 toks by x@xenovacom we need more of this, 100+ ts on dense models is the difference between defaulting to claudecodex for everything vs having a local private model doing most of the heavy lifting and only reaching for frontier for heavy intelligence work submitted by uyonz [link] [comments] anthropic gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ulpq3o" target="_blank" rel="noopener">Gemma 4 WebGPU Kernels 255 tok/s by x/@xenovacom</a></h4>
@@ -8915,7 +8915,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">We need more of this, 100+ T/s on dense models is the difference between defaulting to Claude/Codex for everything vs having a local private model doing most of the heavy lifting and only reaching for frontier for heavy intelligence work. &amp;#32; submi...</p>
+  <p class="cr-summary">We need more of this, 100+ T/s on dense models is the difference between defaulting to Claude/Codex for everything vs having a local private model doing most of the heavy lifting and only reaching for frontier for heavy intelligence work. submitted b...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ulpq3o" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma431bfp8 keeping up with sonnet46medium in my harness cypher queries for graph traversal (neo4j) entity extraction from text chunks (web query, graph query, vectors) agentic tool calling (skills selection successful running in pi) code writing (python) synthesissummarization of multivectorretrieval gemmaqwen in fp8 this brought… quantization rag qwen gemma" data-cats="quantization">
@@ -8934,7 +8934,7 @@
   <p class="cr-summary">Cypher queries for graph traversal (neo4j) Entity extraction from text chunks (web query, graph query, vectors) Agentic tool calling (Skills selection / successful running in Pi) Code writing (Python) Synthesis/summarization of multi-vector-retrieval...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tzw207" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma4 e2b is really good, what other small models work on crappy computers? i run it on i5 6500 and i get 9ts its really fast and the output is a lot better than chatgpt 35 and maybe its as good as chatgpt 4 but i didn't use that 40 much what are other good small models? i used qwen 35 4b before this and that one blew me away too &amp;#32; submitted by &amp;#32; uinsideyork [link] &amp;#32; [comments] openai qwen" data-cats="general">
+<div class="cr-card" data-search="gemma4 e2b is really good, what other small models work on crappy computers? i run it on i5 6500 and i get 9ts its really fast and the output is a lot better than chatgpt 35 and maybe its as good as chatgpt 4 but i didn't use that 40 much what are other good small models? i used qwen 35 4b before this and that one blew me away too submitted by uinsideyork [link] [comments] openai qwen" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1umpxhg" target="_blank" rel="noopener">gemma4 e2b is really good, what other small models work on crappy computers?</a></h4>
@@ -8966,7 +8966,7 @@
   <p class="cr-summary">Now that we have some great local models that can possibly run in mid-tier GPUs.. it makes me question, maybe companies have the capability to make much better models that are as small? Like, I am imagining a model that is as good as coding like Qwen...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1twfmnw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 12b native encoder free voice input utilization suggest? hey everyone, &amp;#x200b; ​like many of you, i’m looking into the newly released gemma 4 12b to build a native speechtospeech experience because of its unique encoderfree architecture, completely skipping the traditional stt bottleneck could be possible &amp;#x200b; ​right now, my main focus is strictly on the input side: i want a lowlatency, native voice ingestion workflow without writing a massi… gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 12b native encoder free voice input utilization suggest? hey everyone, ​ ​like many of you, i’m looking into the newly released gemma 4 12b to build a native speechtospeech experience because of its unique encoderfree architecture, completely skipping the traditional stt bottleneck could be possible ​ ​right now, my main focus is strictly on the input side: i want a lowlatency, native voice ingestion workflow without writing a massi… gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u5ptsr" target="_blank" rel="noopener">Gemma 4 12B native encoder free voice input utilization suggest?</a></h4>
@@ -8979,7 +8979,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Hey everyone, &amp;#x200B; ​Like many of you, I’m looking into the newly released Gemma 4 12B to build a native speech-to-speech experience. Because of its unique encoder-free architecture, completely skipping the traditional STT bottleneck could be poss...</p>
+  <p class="cr-summary">Hey everyone, ​ ​Like many of you, I’m looking into the newly released Gemma 4 12B to build a native speech-to-speech experience. Because of its unique encoder-free architecture, completely skipping the traditional STT bottleneck could be possible. ​...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u5ptsr" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 is still lazy please tell me i'm doing something wrong my config: [*] flashattn = on jinja = true fit = true offline = true mmprojoffload = false mmap = false cram = 1 parallel = 1 [unslothgemma431bitqatudq4kxltpwork147k] hf = unslothgemma431bitqatgguf:udq4kxl ctxsize = 147456 temp = 10 topp = 095 topk = 64 sm = tensor fit = off specdefault = true chattemplatekwargs = {&quot;preserv… quantization qwen deepseek gemma" data-cats="quantization">
@@ -9046,7 +9046,7 @@
   <p class="cr-summary">Here's the setup I decided on for embedding gemma4-12b into a Tauri2 desktop app: Native Rust FFI into llama.cpp via llama-cpp-2 (Metal enabled) Model: gemma-4-12b-it-Q5_K_S quantized by Unsloth, Q5_K - Small Audio input is a 607 KB 16-bit mono 16 kH...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1un9cjq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 chat template now has preserve thinking &amp;#32; submitted by &amp;#32; useamonn [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 chat template now has preserve thinking submitted by useamonn [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u084qi" target="_blank" rel="noopener">Gemma 4 Chat Template now has preserve thinking</a></h4>
@@ -9059,7 +9059,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/seamonn [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/seamonn [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u084qi" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="why there is a lack of new 100b120b models? gptoss120b was the first model of that family, which was followed by glm45air, nemotron3super, qwen35122b, mistralsmall4119b however, all models are at least 3 months old (10 months for gptoss120b) and all latest releases are either 25b35b (gemma4, qwen36) or 200b+ (step 3537 flash, deepseekv4flash, minimaxm3, nemotron3ultra) did the ~120b moe family &quot;die&quot; like the 70b8… hardware mistral deepseek" data-cats="apple-silicon">
@@ -9126,7 +9126,7 @@
   <p class="cr-summary">When GPT-OSS 120B has released last year I played around and tried to maximize it's performance. One thing that many people pointed out was that for hybrid CPU (Performance + Efficiency cores) you should use only P-cores with &quot;--threads&quot; argument and...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u3fo2x" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="how do i try to run gemma 4 31b at q8 quantization? only seeing q4km on ollama just got my new pc up and running and want to test some local models i'm a complete noob but i've managed to install ollama im on fedora linux &amp;#32; submitted by &amp;#32; ujayotree [link] &amp;#32; [comments] quantization inference gemma" data-cats="quantization">
+<div class="cr-card" data-search="how do i try to run gemma 4 31b at q8 quantization? only seeing q4km on ollama just got my new pc up and running and want to test some local models i'm a complete noob but i've managed to install ollama im on fedora linux submitted by ujayotree [link] [comments] quantization inference gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tsfhon" target="_blank" rel="noopener">How do I try to run Gemma 4 31B at Q8 quantization? Only seeing Q4_K_M on Ollama</a></h4>
@@ -9139,7 +9139,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Just got my new PC up and running and want to test some local models. I'm a complete noob but I've managed to install ollama. Im on Fedora Linux. &amp;#32; submitted by &amp;#32; /u/JayoTree [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Just got my new PC up and running and want to test some local models. I'm a complete noob but I've managed to install ollama. Im on Fedora Linux. submitted by /u/JayoTree [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tsfhon" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="which is the best local vlm? benchmark results june 2026 it all started because the llm i use for coding does not have vision support it relies on a cloud hosted mcp server for image analysis, which works well, but i keep hitting my monthly limit so i have just started writing my own local mcp as a replacement, and the first step was finding which vlm to use i selected what i think are the best and latest current local vlm models, as of june 2026 i… quantization inference benchmarking agents met" data-cats="quantization">
@@ -9270,7 +9270,7 @@
   <p class="cr-summary">Edit: I have read the responses. I guess for tool use such speeds are not good (to be tested later!), but one can use it like good old times: snail mail: give it a task and check results couple of days/weeks later. Are we lacking patience or what? Th...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u36vmm" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 beats qwen 35 (update), and qwen 36 27b + minimax m27 is the best opencode setup hi all! i recently made a post about how gemma 4 managed to replace qwen 35 for me, for semantic routing and a lot of coding stuff and ultimately it was my new daily driver the next day, qwen 36 released and i've been using it a lot this week here's my ultimate comparison: gemma 4 e4b &amp;gt; qwen35 4b for routing and other classification tasks, i think it might be better at english understandi… hardware qu" data-cats="apple-silicon quantization">
+<div class="cr-card" data-search="gemma 4 beats qwen 35 (update), and qwen 36 27b + minimax m27 is the best opencode setup hi all! i recently made a post about how gemma 4 managed to replace qwen 35 for me, for semantic routing and a lot of coding stuff and ultimately it was my new daily driver the next day, qwen 36 released and i've been using it a lot this week here's my ultimate comparison: gemma 4 e4b &gt; qwen35 4b for routing and other classification tasks, i think it might be better at english understandi… hardware quanti" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1staxnq" target="_blank" rel="noopener">Gemma 4 beats Qwen 3.5 (UPDATE), and Qwen 3.6 27B + MiniMax M2.7 is the best OpenCode setup</a></h4>
@@ -9284,7 +9284,7 @@
     </div>
   </div>
   <p class="cr-summary">Hi all! I recently made a post about how Gemma 4 managed to replace Qwen 3.5 for me, for semantic routing and a lot of coding stuff and ultimately it was my new daily driver. The next day, Qwen 3.6 released and I've been using it a lot this week. Her...</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PhilippeEiffel (+23)</span><span class="cr-comment-text">Multiple times in your message you say &quot;Qwen 3.6 30B&quot; Do you mean 27B or 35B?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mp3m4k3r (+13)</span><span class="cr-comment-text">Or maybe just average them and call it 31B /s</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Truth-Does-Not-Exist (+10)</span><span class="cr-comment-text">Pi &amp;gt; Opencode</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/PhilippeEiffel (+23)</span><span class="cr-comment-text">Multiple times in your message you say &quot;Qwen 3.6 30B&quot; Do you mean 27B or 35B?</span></div><div class="cr-comment"><span class="cr-comment-meta">u/mp3m4k3r (+13)</span><span class="cr-comment-text">Or maybe just average them and call it 31B /s</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Truth-Does-Not-Exist (+10)</span><span class="cr-comment-text">Pi &gt; Opencode</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1staxnq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 weird issue, keeps saying &quot;lapped up&quot; i'm currently running a 4 bit quantised gemma 4 31b via vllm i think it was this one: i've been encountering a really weird issue with long chats, especially with role playing kind of scenarios, the model loves to use &quot;lapped up&quot; even when it doesn't make sense sometimes it goes into an infinite loop: head back to the lappedup lappedup… quantization inference gemma" data-cats="quantization">
@@ -9447,7 +9447,7 @@
   <p class="cr-summary">One setback of smaller local models seems to be their reliability in calling tools for the harness they're plugged into. I personally tried out Gemma 4 with Hermes Agent, and Gemma kept ignoring Hermes' tools - for example, it kept trying to call the...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tsyqxh" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="google is updating gemma 4's chat templates, bringing major fixes to tool calling and reducing &quot;laziness&quot;, and enabling flash attention 4 on hopper gpus, plus an interactive guide on how to work with and improve its vision! and preservethinking!!!!!!!! ignore the image links here is the source: &amp;#32; submitted by &amp;#32; uiwakureal [link] &amp;#32; [comments] google gemma" data-cats="general">
+<div class="cr-card" data-search="google is updating gemma 4's chat templates, bringing major fixes to tool calling and reducing &quot;laziness&quot;, and enabling flash attention 4 on hopper gpus, plus an interactive guide on how to work with and improve its vision! and preservethinking!!!!!!!! ignore the image links here is the source: submitted by uiwakureal [link] [comments] google gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uxfu4k" target="_blank" rel="noopener">Google is updating Gemma 4's chat templates, bringing major fixes to tool calling and reducing &quot;laziness&quot;, and enabling </a></h4>
@@ -9460,7 +9460,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">...And preserve_thinking!!!!!!!! Ignore the image links here is the source: &amp;#32; submitted by &amp;#32; /u/Iwaku_Real [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">...And preserve_thinking!!!!!!!! Ignore the image links here is the source: submitted by /u/Iwaku_Real [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uxfu4k" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="benefits of a second cheap gpu, what capabilities are gained? right now i have gemma 4 26ba4b (q4km) running reasonably well (1215 ts) on my hardware, which is an i58500, 48 gb of ddr4, and an rtx 3060 (12 gb)pcie is gen 3 however, it's just not very smart it's good at paraphrasing everything i say, which helps if i'm trying to make sure i've covered every aspect of a topic i'm writing up, but it doesn't generally chip in with anything insightful… hardware quantization gemma" data-cats="mid-gpu quantization">
@@ -9495,7 +9495,7 @@
   <p class="cr-summary">im talking for general use, in terms of general knowledge, toolcalling support, and risk of hallucinations. i dont care about benchmarks, moreso about real-world use i won't mention the quant for QAT since theres only one for those (Q4_K_XL) i tested...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u7sw4i" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 mtp with assistant vs llama cpp type mtp hi all been loving the qat models but honestly what is up with the assistant models, any ggufs and ways to make em work with vanilla llamacpp and if this way of mtp is different than the one am17an developed for llamacpp followup question anyway i can run gemma4 26ba4b q4 qat with mtp and or assistant models on vanilla llamacpp? &amp;#32; submitted by &amp;#32; ucombouser [link] &amp;#32; [comments] quantization inference metallama gemma" data-cats="apple-silicon quantization">
+<div class="cr-card" data-search="gemma 4 mtp with assistant vs llama cpp type mtp hi all been loving the qat models but honestly what is up with the assistant models, any ggufs and ways to make em work with vanilla llamacpp and if this way of mtp is different than the one am17an developed for llamacpp followup question anyway i can run gemma4 26ba4b q4 qat with mtp and or assistant models on vanilla llamacpp? submitted by ucombouser [link] [comments] quantization inference metallama gemma" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u0dbq4" target="_blank" rel="noopener">Gemma 4 MTP with assistant vs llama cpp type MTP</a></h4>
@@ -9655,7 +9655,7 @@
   <p class="cr-summary">I know there is a PR in llama.cpp to support MTP for the 26b and 31b versions of Gemma 4, but as far as I can tell there is nothing yet for the E2B and E4B models. Using Hermes Agent, I had it set up Gemma 4 E4B in Google's Lite RT format, and then w...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tuygn6" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma4 qats vs higherbit regular quantizations? i have enough ram+vram to use gemma4 26b a4b up to q6k quantizations w decent performance does anyone have any comparisons of the q40 qats (at 4bitswt) vs nonqats at &gt;4 bitswt? (ex: q6k)? kld vs the originals wouldn't be appropriate iiuc &amp;#32; submitted by &amp;#32; ufuntangerine1086 [link] &amp;#32; [comments] hardware" data-cats="quantization">
+<div class="cr-card" data-search="gemma4 qats vs higherbit regular quantizations? i have enough ram+vram to use gemma4 26b a4b up to q6k quantizations w decent performance does anyone have any comparisons of the q40 qats (at 4bitswt) vs nonqats at &gt;4 bitswt? (ex: q6k)? kld vs the originals wouldn't be appropriate iiuc submitted by ufuntangerine1086 [link] [comments] hardware" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u1pfen" target="_blank" rel="noopener">gemma4 QATs vs higher-bit regular quantizations?</a></h4>
@@ -9668,7 +9668,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">I have enough RAM+VRAM to use gemma4 26b a4b up to q6_k quantizations w/ decent performance. Does anyone have any comparisons of the Q4_0 QATs (at 4-bits/wt) vs non-QATs at &gt;4 bits/wt? (ex: q6_K)? KLD vs the originals wouldn't be appropriate IIUC. &amp;#...</p>
+  <p class="cr-summary">I have enough RAM+VRAM to use gemma4 26b a4b up to q6_k quantizations w/ decent performance. Does anyone have any comparisons of the Q4_0 QATs (at 4-bits/wt) vs non-QATs at &gt;4 bits/wt? (ex: q6_K)? KLD vs the originals wouldn't be appropriate IIUC. su...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u1pfen" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="some llamacpp b70 sycl benchmarks build: dd4623a74 (9640) | model | size | params | backend | ngl | test | ts | | | : | : | | : | : | : | | gemma4 12b q80 | 1178 gib | 1191 b | sycl | 1 | pp512 | 157819 ± 782 | | gemma4 12b q80 | 1178 gib | 1191 b | sycl | 1 | tg128 | 3243 ± 007 | | | … inference metallama" data-cats="quantization">
@@ -9719,7 +9719,7 @@
   <p class="cr-summary">Sometime around the beginning of the year I setup my LLM computer - 3x3090 in a very old DDR4 computer, so I only use the 72GB VRAM to load the models (for speed) I’ve been mostly using these three models: - GPT-OSS 120b still pretty sold - Qwen3.5 1...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u50rw1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma4 26b qat at iq4xs? is that coming? is that even gonna work without obliterating the model's accuracy? iq4xs is able to run fully on my gpu and gives me very high speed, whilst the official q40 qat doesnt quite make it &amp;#32; submitted by &amp;#32; urosie254 [link] &amp;#32; [comments] hardware" data-cats="quantization">
+<div class="cr-card" data-search="gemma4 26b qat at iq4xs? is that coming? is that even gonna work without obliterating the model's accuracy? iq4xs is able to run fully on my gpu and gives me very high speed, whilst the official q40 qat doesnt quite make it submitted by urosie254 [link] [comments] hardware" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txtl9d" target="_blank" rel="noopener">gemma4 26b QAT at IQ4_XS?</a></h4>
@@ -9732,7 +9732,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">is that coming? is that even gonna work without obliterating the model's accuracy? IQ4_XS is able to run fully on my gpu and gives me very high speed, whilst the official Q4_0 QAT doesnt quite make it.. &amp;#32; submitted by &amp;#32; /u/rosie254 [link] &amp;#3...</p>
+  <p class="cr-summary">is that coming? is that even gonna work without obliterating the model's accuracy? IQ4_XS is able to run fully on my gpu and gives me very high speed, whilst the official Q4_0 QAT doesnt quite make it.. submitted by /u/rosie254 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txtl9d" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="llamaserver router: a model pinned to one gpu still grabs a cuda context on every card, so it ooms when my others are full am i missing a flag or is this just how it is? running into something annoying with llamaserver in router mode (`modelspreset`) and i can't tell if i'm missing a flag or if this is just how it works my rig is 2x 3090, 2x 4060 ti (one's unplugged at the moment, riser got repurposed) and a 5060 ti i run a single llamaserver router that spawns a child per model on demand, which" data-cats="high-gpu mid-gpu quantization">
@@ -9975,7 +9975,7 @@
   <p class="cr-summary">I binned Qwen3-VL-30B-A3B for timing out at 21 minutes on my DGX Spark, then re-ran it on a 5090 and found the real failure: under GBNF grammar decoding it locks onto one valid JSON item and repeats it until the context runs out. Swept quant, temp, f...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uw6a0p" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma4 12b update a couple hours ago, the full content of the gemma412b huggingface repos; including models weights, have been &quot;updated&quot; i can't find information about what was the reason behind this update, does anyone know what's up with that? do we need updated quants to fix some issue? &amp;#32; submitted by &amp;#32; ustd… google gemma" data-cats="quantization">
+<div class="cr-card" data-search="gemma4 12b update a couple hours ago, the full content of the gemma412b huggingface repos; including models weights, have been &quot;updated&quot; i can't find information about what was the reason behind this update, does anyone know what's up with that? do we need updated quants to fix some issue? submitted by ustd… google gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tw6swu" target="_blank" rel="noopener">Gemma4 12B update</a></h4>
@@ -10278,10 +10278,10 @@
     </div>
   </div>
   <p class="cr-summary">Yall are more than welcome to try it out and provide feedback. In my own testing in Pi-coding-agent I no longer have the &quot;forgot to close thinking tag&quot; &quot;forgot to open thinking&quot; &quot;closed thinking to earl…</p>
-  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ggonavyy (+8)</span><span class="cr-comment-text">That's what I always believed as well. I didn't post this out of nowhere though, I already used it for few days and didn't see erratic behavior; that doesn't mean it doesn't semantically confuses the ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/True_Requirement_891 (+7)</span><span class="cr-comment-text">A model not trained for it confuses it. This is what I remember reading. Same for qwen3.5 models. Qwen3.6 onwards, preverve thinking is enabled and trained.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Kahvana (+7)</span><span class="cr-comment-text">From Gemma4 31B's card ( ): &amp;gt;No Thinking Content in History: In multi-turn conversations, the historical model output should only include the final response. Thoughts from previous model turns must...</span></div></div>
+  <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/ggonavyy (+8)</span><span class="cr-comment-text">That's what I always believed as well. I didn't post this out of nowhere though, I already used it for few days and didn't see erratic behavior; that doesn't mean it doesn't semantically confuses the ...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/True_Requirement_891 (+7)</span><span class="cr-comment-text">A model not trained for it confuses it. This is what I remember reading. Same for qwen3.5 models. Qwen3.6 onwards, preverve thinking is enabled and trained.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Kahvana (+7)</span><span class="cr-comment-text">From Gemma4 31B's card ( ): &gt;No Thinking Content in History: In multi-turn conversations, the historical model output should only include the final response. Thoughts from previous model turns must no...</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tl79da" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 qat confirmed to release soon! it seems like this comment has gone widely unnoticed maybe hold off on testing quantization and wait for it's refinements the account is omar from the gemma team &amp;#32; submitted by &amp;#32; uaaaaaaaaaeeeee [link] &amp;#32; [comments] gemma" data-cats="quantization">
+<div class="cr-card" data-search="gemma 4 qat confirmed to release soon! it seems like this comment has gone widely unnoticed maybe hold off on testing quantization and wait for it's refinements the account is omar from the gemma team submitted by uaaaaaaaaaeeeee [link] [comments] gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1twid14" target="_blank" rel="noopener">Gemma 4 QAT confirmed to release soon!</a></h4>
@@ -10294,7 +10294,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">It seems like this comment has gone widely unnoticed. Maybe hold off on testing quantization and wait for it's refinements. The account is Omar from the gemma team. &amp;#32; submitted by &amp;#32; /u/Aaaaaaaaaeeeee [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">It seems like this comment has gone widely unnoticed. Maybe hold off on testing quantization and wait for it's refinements. The account is Omar from the gemma team. submitted by /u/Aaaaaaaaaeeeee [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1twid14" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 12b ollama models: macos only? when trying to pull the new gemma4:12b models from ollama , i get a &quot;this model requires macos&quot; error for every single variant however, hugging face already has the generic gemma412bit model that should run on anything does it take some time for ollama to post the universally compatible models, and how long does this usually take? i'm on an amd gpu with 16gb vram so excited to see how well t… hardware inference metallama gemma" data-cats="apple-silicon mid-gpu quantization">
@@ -10393,7 +10393,7 @@
   <p class="cr-summary">So I know this is going to incur the wrath of the Qwen cult but after a month of using 27b q8_0 as my primary coding agent in 6+ agent coding workflow with GPT-5.5 as the orchestrator, I got very frustrated with the amount of back and forth I was doi...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uz8532" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="best image vision model runnable on rtx 6000 pro i'm looking at running ocr and classification on old historical scanned documents (some dating back to 1950s) what's the current best vision enabled models thats open sourced and runnable on an rtx 6000 pro? note: i've used gemma 4 31b and have had good success with it it's better than the vision encoder in qwen 36 line of models mainly wanted to know what else is out there? &amp;#32; submitted b… hardware qwen gemma" data-cats="general">
+<div class="cr-card" data-search="best image vision model runnable on rtx 6000 pro i'm looking at running ocr and classification on old historical scanned documents (some dating back to 1950s) what's the current best vision enabled models thats open sourced and runnable on an rtx 6000 pro? note: i've used gemma 4 31b and have had good success with it it's better than the vision encoder in qwen 36 line of models mainly wanted to know what else is out there? submitted b… hardware qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ubdpta" target="_blank" rel="noopener">Best image vision model runnable on RTX 6000 Pro</a></h4>
@@ -10585,7 +10585,7 @@
   <p class="cr-summary">So as far as I understand it, llama.cpp can run models across multiple different sources of compute (multiple GPU, multi-core cpu, cpu+gpu, etc). However, what I'm not understanding is how that split occurs so that I can better optimize my settings a...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tt50bu" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="why is the mlx version of the gemma 4 qat so big?? the mlx version of the qat 4bit is like 27gb but the none qat version is 17gb and the regular 4bit mlx version is also 17gb… anyone know why? &amp;#32; submitted by &amp;#32; umjsxi [link] &amp;#32; [comments] gemma" data-cats="apple-silicon">
+<div class="cr-card" data-search="why is the mlx version of the gemma 4 qat so big?? the mlx version of the qat 4bit is like 27gb but the none qat version is 17gb and the regular 4bit mlx version is also 17gb… anyone know why? submitted by umjsxi [link] [comments] gemma" data-cats="apple-silicon">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u0cu9e" target="_blank" rel="noopener">Why is the MLX version of the Gemma 4 QAT so big??</a></h4>
@@ -10598,7 +10598,7 @@
       <span class="cr-cat-badge">Apple Silicon</span>
     </div>
   </div>
-  <p class="cr-summary">the MLX version of the QAT 4bit is like 27gb but the none QAT version is 17gb and the regular 4bit MLX version is also 17gb… anyone know why? &amp;#32; submitted by &amp;#32; /u/mjsxi__ [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">the MLX version of the QAT 4bit is like 27gb but the none QAT version is 17gb and the regular 4bit MLX version is also 17gb… anyone know why? submitted by /u/mjsxi__ [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u0cu9e" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="need some help from someone who knows llamacpp vulkan builds (docker in this case) this morning i noticed gemma4 31b's reasoning phase was being completely skipped confused, i started troubleshooting i knew for a fact this worked a few days ago after about an hour, i realized something: llamacpp has been updated a lot in light of the new gemma 4 12b unified s… metallama gemma" data-cats="general">
@@ -10617,7 +10617,7 @@
   <p class="cr-summary">This morning I noticed Gemma4 31b's reasoning phase was being completely skipped. Confused, I started troubleshooting. I knew for a fact this worked a few days ago. After about an hour, I realized something: llama-cpp has been updated a lot in light ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1twpfsk" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="best batteriesincluded harness tuned for qwen 36 and gemma 4? (littlecoder, smallcode, etc) after testing littlecoder for a week now, i can confidently say that it's better and more reliable than opencode and cline what's the best harness you've used with qwen 36 and gemma 4? i'm aware that you can get better results by using pidev or a custom harness tuned for your repo workflow, but i'm looking for the best generic harness &amp;#32; submitted by &amp;#32; uandrevallestero [link] &amp;#32… qwen" data-cats="general">
+<div class="cr-card" data-search="best batteriesincluded harness tuned for qwen 36 and gemma 4? (littlecoder, smallcode, etc) after testing littlecoder for a week now, i can confidently say that it's better and more reliable than opencode and cline what's the best harness you've used with qwen 36 and gemma 4? i'm aware that you can get better results by using pidev or a custom harness tuned for your repo workflow, but i'm looking for the best generic harness submitted by uandrevallestero [link] &amp;#32… qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u4yphe" target="_blank" rel="noopener">Best batteries-included harness tuned for Qwen 3.6 and Gemma 4? (little-coder, smallcode, etc...)</a></h4>
@@ -10649,7 +10649,7 @@
   <p class="cr-summary">Google pixel 10 pro Termux Llamacpp version: 9639 (ef8268fee) $ ./llama.cpp/build_vulkan/bin/llama-cli -m storage/downloads/gemma-4-12b-it-UD-Q3_K_XL.gguf --model-draft storage/downloads/mtp-gemma-4-12b-it.gguf --temp 1.0 --top-p 0.95 --top-k 64 --sp...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u60l19" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 31b q6 on dual 9060 xt running gemma 4 31b q6 on two 9060 xt 16gb cards, runs consistently around 89 ts from reading through other threads on here, people seem to think it should run faster than that, so not sure if i'm missing something i find it quite usable, although a little extra speed would be nice if i'm missing something &amp;#32; submitted by &amp;#32; ubeigepccase [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 31b q6 on dual 9060 xt running gemma 4 31b q6 on two 9060 xt 16gb cards, runs consistently around 89 ts from reading through other threads on here, people seem to think it should run faster than that, so not sure if i'm missing something i find it quite usable, although a little extra speed would be nice if i'm missing something submitted by ubeigepccase [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ucenk7" target="_blank" rel="noopener">Gemma 4 31B Q6 on Dual 9060 XT</a></h4>
@@ -10857,7 +10857,7 @@
   <p class="cr-summary">I'm an old guy and I hate when things change so fast surrounded by noise and breaking news! MTP, I know what the acronym means and where it excels. Gemma4 31b dense is my target. Unsloth, Google, GUFF, tensors... too many overlapped informations. I h...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tzkyuw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="not important: mechaepstein8000 (qwen38b finetuning) just topped in the common sense benchmark i put together from instagram posts (huskirl and phi) beating gemma4 and qwen36 🤷‍♂️ model: settings: parameter value temperature 10 top p 08 top k 20 min p 0 repeat penalty 11 benchmark yourself or the llm you use: &amp;#32; submitted by &amp;#32; ujleonsarmiento [link] &amp;#32; [comments] benchmarking gemma phi" data-cats="cpu-only">
+<div class="cr-card" data-search="not important: mechaepstein8000 (qwen38b finetuning) just topped in the common sense benchmark i put together from instagram posts (huskirl and phi) beating gemma4 and qwen36 🤷‍♂️ model: settings: parameter value temperature 10 top p 08 top k 20 min p 0 repeat penalty 11 benchmark yourself or the llm you use: submitted by ujleonsarmiento [link] [comments] benchmarking gemma phi" data-cats="cpu-only">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u745kt" target="_blank" rel="noopener">not important: MechaEpstein8000 (Qwen3-8B fineTuning) just topped in the common sense benchmark I put together from Inst</a></h4>
@@ -10870,10 +10870,10 @@
       <span class="cr-cat-badge">CPU / Raspberry Pi</span>
     </div>
   </div>
-  <p class="cr-summary">model: settings: Parameter Value Temperature 1.0 Top P 0.8 Top K 20 Min P 0 Repeat Penalty 1.1 Benchmark yourself or the LLM you use: &amp;#32; submitted by &amp;#32; /u/JLeonsarmiento [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">model: settings: Parameter Value Temperature 1.0 Top P 0.8 Top K 20 Min P 0 Repeat Penalty 1.1 Benchmark yourself or the LLM you use: submitted by /u/JLeonsarmiento [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u745kt" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 12b and e2b fail to load in tensor parallel hey everyone, have you noticed this issue too? in a scenario where a model fails to load when it should for multiple people but the issue persist for a while without being looked into, is it appropiate to ping the maintainers? &amp;#32; submitted by &amp;#32; ukahvana [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 12b and e2b fail to load in tensor parallel hey everyone, have you noticed this issue too? in a scenario where a model fails to load when it should for multiple people but the issue persist for a while without being looked into, is it appropiate to ping the maintainers? submitted by ukahvana [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uyars3" target="_blank" rel="noopener">Gemma 4 12B and E2B fail to load in tensor parallel</a></h4>
@@ -10886,7 +10886,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Hey everyone, have you noticed this issue too? In a scenario where a model fails to load when it should for multiple people but the issue persist for a while without being looked into, is it appropiate to ping the maintainers? &amp;#32; submitted by &amp;#32...</p>
+  <p class="cr-summary">Hey everyone, have you noticed this issue too? In a scenario where a model fails to load when it should for multiple people but the issue persist for a while without being looked into, is it appropiate to ping the maintainers? submitted by /u/Kahvana...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uyars3" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="deepmind just dropped &quot;diffusiongemma&quot; text generation via imagestyle diffusion model another open weight model got dropped today, this one's from deepmind, seems like a good day for the oss geeks released under apache 20 instead of generating text sequentially tokenbytoken like almost every autoregressive model on the market, it uses a text diffusion head throws a 256token &quot;canvas&quot; of random placeholder noise onto the screen uses uniform state diffusion to iteratively refi… " data-cats="general">
@@ -11049,7 +11049,7 @@
   <p class="cr-summary">Here's what I'm thinking about: A USB thumb drive that you can plug into any PC or laptop, and immediately get a usable knowledge base powered by an LLM, without requiring an Internet connection. I believe the technology for this should be ready. Rou...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uspcg0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="why gemma 4 26b does not support audio? gemma 4 26b is really good model and with recent update it's even better than before but why google did not add audio capability to this model? &amp;#32; submitted by &amp;#32; ulumos675 [link] &amp;#32; [comments] google gemma" data-cats="general">
+<div class="cr-card" data-search="why gemma 4 26b does not support audio? gemma 4 26b is really good model and with recent update it's even better than before but why google did not add audio capability to this model? submitted by ulumos675 [link] [comments] google gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v11v74" target="_blank" rel="noopener">Why gemma 4 26B does not support audio?</a></h4>
@@ -11062,7 +11062,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Gemma 4 26b is really good model and with recent update it's even better than before but why google did not add audio capability to this model? &amp;#32; submitted by &amp;#32; /u/lumos675 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Gemma 4 26b is really good model and with recent update it's even better than before but why google did not add audio capability to this model? submitted by /u/lumos675 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v11v74" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="liveablating gemma 4 12b: pertensor quant sweet spots (mixed quanting) converted gemma 4 12b to gguf and am currently working on precision quantz sharing the data in case it's useful to anyone will definitely post the rest if anyone wants it when its done conversion the 12b uses gemma4unifiedforconditionalgeneration which wraps the text backbone at modellanguagemodel* llamacpp's gemma4model class already handles stripping that prefix in modifytensors , but… hardware quantization inference metall" data-cats="quantization">
@@ -11097,7 +11097,7 @@
   <p class="cr-summary">setup is 4080 + 5080 (temporary, I'm building a pc for a friend) latest llama cpp on windows. The model: gemma 4, 31b, q6_k, 16k context. I get 26 t/s output and 659 t/s prompt processing speed. Isn't this kind of low? the 4080 sits on pcie 4.0 4x sl...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u8eq0g" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="what exactly is quantization aware training? first time hearing it i also heard about the gemma 4 qat quants and if any one of them is good for 4gb vram and 16gb ram i can run gemma 4 26b moe iq2 nl at 85 to 9 tps(kv cache unquantized on gpu) with 9 layers offloaded to gpu &amp;#32; submitted by &amp;#32; ujournalistlucky5124 [link] &amp;#32; [comments] hardware finetuning gemma" data-cats="quantization">
+<div class="cr-card" data-search="what exactly is quantization aware training? first time hearing it i also heard about the gemma 4 qat quants and if any one of them is good for 4gb vram and 16gb ram i can run gemma 4 26b moe iq2 nl at 85 to 9 tps(kv cache unquantized on gpu) with 9 layers offloaded to gpu submitted by ujournalistlucky5124 [link] [comments] hardware finetuning gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txuqw8" target="_blank" rel="noopener">What exactly is quantization aware training?</a></h4>
@@ -11110,7 +11110,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">First time hearing it. I also heard about the gemma 4 qat quants and if any one of them is good for 4gb vram and 16gb ram. I can run gemma 4 26b moe iq2 nl at 8.5 to 9 tps(kv cache unquantized on gpu) with 9 layers offloaded to gpu &amp;#32; submitted by...</p>
+  <p class="cr-summary">First time hearing it. I also heard about the gemma 4 qat quants and if any one of them is good for 4gb vram and 16gb ram. I can run gemma 4 26b moe iq2 nl at 8.5 to 9 tps(kv cache unquantized on gpu) with 9 layers offloaded to gpu submitted by /u/Jo...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txuqw8" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="nvfp4 with llamacpp faqs? lets clarify all things related to nvfp4 in this thread sharing few questions &amp; links here looks like nvfp4 runs on nonblackwell, amd, intel gpus too yep, few confirmed on this nvfp4's benchmarks numbers are closer to bf16(yep, saw some benchmarks on some model cards ex: nvidia's nvfp4 models ) based on the benchmarks comparison(nvfp4 &amp; bf16), i thought of trying nvfp4 since bf16 or q8 or e… hardware quantization inference benchmarking metallama gemma" data-cats="quantization">
@@ -11161,7 +11161,7 @@
   <p class="cr-summary">(just merged) is missing a description or any hints, but if you look at the code it is the implementation of a new “Gemma 4 Unified” model type… Seems like the llama.cpp folks got early access in order that the model could launch with support. Some o...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tvswv1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma431b on cerebras is better than chatgpt voice mode open models will win on inference too 🚀 &amp;#32; submitted by &amp;#32; upaf1138 [link] &amp;#32; [comments] openai gemma" data-cats="general">
+<div class="cr-card" data-search="gemma431b on cerebras is better than chatgpt voice mode open models will win on inference too 🚀 submitted by upaf1138 [link] [comments] openai gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ukolgw" target="_blank" rel="noopener">gemma-4-31B on Cerebras is better than ChatGPT voice mode</a></h4>
@@ -11174,10 +11174,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">open models will win on inference too 🚀 &amp;#32; submitted by &amp;#32; /u/paf1138 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">open models will win on inference too 🚀 submitted by /u/paf1138 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ukolgw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="tested which model can send best html email recently deployed which comes with mcp server for managing emails wanted to see which model has better looking html email the models i tested with are &quot;googlegemma426ba4bqat&quot;, &quot;qwenqwen3635ba3b&quot; and &quot;qwenqwen3627b&quot; see if you can tell which model generated which one from the screenshots &amp;#32; submitted by &amp;#32; uahstanin [link] &amp;#32; [comments] agents google qwen gemma" data-cats="general">
+<div class="cr-card" data-search="tested which model can send best html email recently deployed which comes with mcp server for managing emails wanted to see which model has better looking html email the models i tested with are &quot;googlegemma426ba4bqat&quot;, &quot;qwenqwen3635ba3b&quot; and &quot;qwenqwen3627b&quot; see if you can tell which model generated which one from the screenshots submitted by uahstanin [link] [comments] agents google qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uhg6n0" target="_blank" rel="noopener">Tested which model can send best HTML email</a></h4>
@@ -11193,7 +11193,7 @@
   <p class="cr-summary">Recently deployed which comes with MCP server for managing emails. Wanted to see which model has better looking HTML email. The models I tested with are &quot;google/gemma-4-26b-a4b-qat&quot;, &quot;qwen/qwen3.6-35b-a3b&quot; and &quot;qwen/qwen3.6-27b&quot;. See if you can tell ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uhg6n0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma412bit vs qwen359b on shared benchmarks: qwen is overall winner beating gemma in 58 benchmarks despite a smaller footprint i don't really understand the gemma hype qwen outperforms gemma gb for gb, and kv cache is lighter sure gemma412bit might be a slight better coder than qwen359b, but you could also just use omnicoder9b (qwen359b finetune for coding) note: benchmark results come from the official huggingface model cards; formatted into a table with chatgpt &amp;#32; submitted by &amp;#32" data-cats="high-gpu">
+<div class="cr-card" data-search="gemma412bit vs qwen359b on shared benchmarks: qwen is overall winner beating gemma in 58 benchmarks despite a smaller footprint i don't really understand the gemma hype qwen outperforms gemma gb for gb, and kv cache is lighter sure gemma412bit might be a slight better coder than qwen359b, but you could also just use omnicoder9b (qwen359b finetune for coding) note: benchmark results come from the official huggingface model cards; formatted into a table with chatgpt submitted by ufulgenciobatista " data-cats="high-gpu">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tw0lua" target="_blank" rel="noopener">gemma-4-12b-it vs Qwen3.5-9B on shared benchmarks: Qwen is overall winner beating gemma in 5/8 benchmarks despite a smal</a></h4>
@@ -11241,7 +11241,7 @@
   <p class="cr-summary">Just sharing some slop. Used opencode as the harness. I know this model isn't really recommended for coding, but I was just curious how it would handle this at near-lossless Q8_0. It made a couple tool call errors, but did correct itself quickly. Thi...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1up78iv" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="is gemma 4 12b good for coding? how are you using it? quantized? at what quantization level? on what hardware? thank you for the information &amp;#32; submitted by &amp;#32; uintelligenttaste36 [link] &amp;#32; [comments] gemma" data-cats="quantization">
+<div class="cr-card" data-search="is gemma 4 12b good for coding? how are you using it? quantized? at what quantization level? on what hardware? thank you for the information submitted by uintelligenttaste36 [link] [comments] gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tzr759" target="_blank" rel="noopener">Is Gemma 4 12b good for coding?</a></h4>
@@ -11254,7 +11254,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">How are you using it? Quantized? At what quantization level? On what hardware? Thank you for the information. &amp;#32; submitted by &amp;#32; /u/Intelligent-Taste-36 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">How are you using it? Quantized? At what quantization level? On what hardware? Thank you for the information. submitted by /u/Intelligent-Taste-36 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tzr759" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="which models can predict piped `dd` output in linux? edit: oh, yeah many here are excited we gonna get 27t weights to download and this set (k3) achieves some synthetic results me too but why so few people are interested in reasoning about specific knowledge, like using linux tools? on linux mint in bash : $ set o pipefail;dd if=devzero bs=1m count=1 | dd of=devnull bs=1m count=1;echo $? 0+1 records in 0+1 records out 65536 bytes (66 kb, 6… quantization qwen gemma" data-cats="quantization">
@@ -11401,7 +11401,7 @@
   <p class="cr-summary">arXiv : Full Paper : HuggingFace : GitHub : Project : I see big/large models(Opus-4.7, GPT-5.5, Kimi-K2.6, MiMo-V2.5-Pro, GLM-5.1, MiniMax-M2.7, DeepSeek-V4-Pro) on benchmarks. Curious to know h…</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u8g1om" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="thoughts on gemma4 12b vs 26a4b, which one is better? not talking about 31b in terms of creative tasks, writing, chatting, not necessarily coding but can still be included, does gemma 12b outperform in any way? is the 12b closer to the 31b compared to the 26a4b? &amp;#32; submitted by &amp;#32; uadventurousgold6413 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="thoughts on gemma4 12b vs 26a4b, which one is better? not talking about 31b in terms of creative tasks, writing, chatting, not necessarily coding but can still be included, does gemma 12b outperform in any way? is the 12b closer to the 31b compared to the 26a4b? submitted by uadventurousgold6413 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tzzcja" target="_blank" rel="noopener">Thoughts on Gemma4 12b vs 26a4b, which one is better?</a></h4>
@@ -11414,7 +11414,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Not talking about 31b. In terms of creative tasks, writing, chatting, not necessarily coding but can still be included, Does Gemma 12b outperform in any way? Is the 12b closer to the 31b compared to the 26a4b? &amp;#32; submitted by &amp;#32; /u/Adventurous-...</p>
+  <p class="cr-summary">Not talking about 31b. In terms of creative tasks, writing, chatting, not necessarily coding but can still be included, Does Gemma 12b outperform in any way? Is the 12b closer to the 31b compared to the 26a4b? submitted by /u/Adventurous-Gold6413 [li...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tzzcja" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="hitoku context aware local assistant with gemma 4 hi guys i am working on hitoku draft, an opensource, voicefirst ai assistant that runs entirely locally no cloud models, nothing leaves your machine you press a hotkey, and you talk now it is version 164 now it has also transcription with voice editing! it's contextaware; it reads your screen, documents, and active app to understand what you're working on you can ask about pdfs, reply… qwen gemma" data-cats="general">
@@ -11433,7 +11433,7 @@
   <p class="cr-summary">Hi guys. I am working on Hitoku Draft, an open-source, voice-first AI assistant that runs entirely locally. No cloud models, nothing leaves your machine. You press a hotkey, and you talk. Now it is version 1.6.4. Now it has also transcription with vo...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tx1v0r" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="does llama cpp split mode tensor cause issues? i split qwen 27b and gemma 4 26b (moe) across a 5080, and 2x 5060ti i noticed setting split mode to tensor mode will cause looping issues in opencode with tool calls or just through the reasoning traces anyone else get this or understand why? split mode layer seems to work fine &amp;#32; submitted by &amp;#32; umapsensitive9894 [link] &amp;#32; [comments] metallama qwen gemma" data-cats="mid-gpu">
+<div class="cr-card" data-search="does llama cpp split mode tensor cause issues? i split qwen 27b and gemma 4 26b (moe) across a 5080, and 2x 5060ti i noticed setting split mode to tensor mode will cause looping issues in opencode with tool calls or just through the reasoning traces anyone else get this or understand why? split mode layer seems to work fine submitted by umapsensitive9894 [link] [comments] metallama qwen gemma" data-cats="mid-gpu">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1ufy09k" target="_blank" rel="noopener">Does llama cpp split mode tensor cause issues?</a></h4>
@@ -11498,7 +11498,7 @@
   <p class="cr-summary">I was pretty impressed with the Gemma 4 12b release today and saw that the heretic version dropped. I was already getting refusals from the 8Q official model and decided to see how the heretic did oneshotting a retro game. It did so with ease. The si...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1twelo6" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="help using llamacpp with intel n100? i have an intel n100 mini pc that's on 247 running proxmox i want to use llamacpp server with gemma 4 e2b for small tasks should i use the cpu only, or the igpu? and if i were to use the igpu, what backend should i target? &amp;#32; submitted by &amp;#32; umashic [link] &amp;#32; [comments] inference metallama gemma" data-cats="cpu-only quantization">
+<div class="cr-card" data-search="help using llamacpp with intel n100? i have an intel n100 mini pc that's on 247 running proxmox i want to use llamacpp server with gemma 4 e2b for small tasks should i use the cpu only, or the igpu? and if i were to use the igpu, what backend should i target? submitted by umashic [link] [comments] inference metallama gemma" data-cats="cpu-only quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1umk9of" target="_blank" rel="noopener">Help using llama.cpp with intel n100?</a></h4>
@@ -11511,7 +11511,7 @@
       <span class="cr-cat-badge">CPU / Raspberry Pi</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">I have an intel n100 mini pc that's on 24/7 running proxmox. I want to use llama.cpp server with gemma 4 E2B for small tasks. Should I use the CPU only, or the iGPU? And if I were to use the iGPU, what backend should I target? &amp;#32; submitted by &amp;#32...</p>
+  <p class="cr-summary">I have an intel n100 mini pc that's on 24/7 running proxmox. I want to use llama.cpp server with gemma 4 E2B for small tasks. Should I use the CPU only, or the iGPU? And if I were to use the iGPU, what backend should I target? submitted by /u/Mashic ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1umk9of" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="my experience with llms on ios and android the models i used are qwen 35 4b, qwen 35 9b, and gemma 4 e4b i tried these in the mlx (4bit) , gguf (q4km) and litert quantizations i tested the cpu, gpu and npu the bottleneck was always the ram bandwidth, qwen 35 9b gave me 7 ts on cpu on iphone 15pm, that iphone has 51 gbs of ram bandwidth, after taking kv cache, engine and os headroom, the phone was giving it's realistic max ts on c… hardware quantization metallama qwen gemma" data-cats="apple-silicon quantization">
@@ -11595,7 +11595,7 @@
   <p class="cr-summary">5.2 or Qwen 3.5 -&gt; 3.6?&quot; title=&quot;What's more impressive, GLM 5.1 -&gt; 5.2 or Qwen 3.5 -&gt; 3.6?&quot; /&gt; Write a single HTML file with a full-page canvas and no libraries. Simulate a realistic Döner Style kebab skewer rotating (vertically) in front of a gas po...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ua1na0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="is qwen 36 27b iq4xs better than gemma 4 31b qat as a hermes agent? if gemma 4 is better, does anyone have a link for the latest fixed template? using lmstudio i know gemma is adverse to tool calls in openwebui, but i was wondering how hermes would fare &amp;#32; submitted by &amp;#32; umyunbiasedopinion [link] &amp;#32; [comments] agents qwen gemma" data-cats="quantization">
+<div class="cr-card" data-search="is qwen 36 27b iq4xs better than gemma 4 31b qat as a hermes agent? if gemma 4 is better, does anyone have a link for the latest fixed template? using lmstudio i know gemma is adverse to tool calls in openwebui, but i was wondering how hermes would fare submitted by umyunbiasedopinion [link] [comments] agents qwen gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u2q75f" target="_blank" rel="noopener">Is Qwen 3.6 27B IQ4XS better than Gemma 4 31B QAT as a Hermes agent?</a></h4>
@@ -11608,7 +11608,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">If Gemma 4 is better, does anyone have a link for the latest fixed template? Using LMstudio. I know Gemma is adverse to tool calls in openwebui, but I was wondering how Hermes would fare. &amp;#32; submitted by &amp;#32; /u/My_Unbiased_Opinion [link] &amp;#32; [...</p>
+  <p class="cr-summary">If Gemma 4 is better, does anyone have a link for the latest fixed template? Using LMstudio. I know Gemma is adverse to tool calls in openwebui, but I was wondering how Hermes would fare. submitted by /u/My_Unbiased_Opinion [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u2q75f" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="i wrote a free 15part series on llm internals real math, real tensor shapes, real hardware constraints all grounded in gemma 4 12b's actual config if you run opensource models and want to understand what's actually happening under the hood i spent the last few months writing a 15part series that covers the full stack from tokenization to production serving most articles are grounded in gemma 4 12b as the running example the full series: generative ai in depth here's what each article covers and " data-cats="general">
@@ -11707,7 +11707,7 @@
   <p class="cr-summary">I have a Lenovo Thinkpad T14 Gen 5 with Ryzen 7 Pro CPU and 32GB RAM. It's a work laptop. I want to get a local LLM working that I can use for basic stuff: terminal operations (moving/deleting/organizing/creating etc) Reading/writing files to maintai...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tuymhj" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="mtp: support for gemma4 e2b and e4b assistants by maxkrasnyansky · pull request #24282 · ggmlorgllamacpp mtp for tiny gemmas for mobiles or potatoes or raspberry pi, or maybe for ants &amp;#32; submitted by &amp;#32; ujacek2023 [link] &amp;#32; [comments] quantization inference metallama gemma" data-cats="cpu-only quantization">
+<div class="cr-card" data-search="mtp: support for gemma4 e2b and e4b assistants by maxkrasnyansky · pull request #24282 · ggmlorgllamacpp mtp for tiny gemmas for mobiles or potatoes or raspberry pi, or maybe for ants submitted by ujacek2023 [link] [comments] quantization inference metallama gemma" data-cats="cpu-only quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u0kfmy" target="_blank" rel="noopener">mtp: support for gemma-4 E2B and E4B assistants by max-krasnyansky · Pull Request #24282 · ggml-org/llama.cpp</a></h4>
@@ -11720,7 +11720,7 @@
       <span class="cr-cat-badge">CPU / Raspberry Pi</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">MTP for tiny gemmas for mobiles or potatoes or raspberry Pi, or maybe for ants &amp;#32; submitted by &amp;#32; /u/jacek2023 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">MTP for tiny gemmas for mobiles or potatoes or raspberry Pi, or maybe for ants submitted by /u/jacek2023 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u0kfmy" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="nvidiadiffusiongemma26ba4bitnvfp4 · hugging face model overview description: diffusiongemma 26b a4b it is an openweights multimodal generative model developed by google deepmind that processes text, image, and video inputs to produce text output via discrete diffusion built on the gemma 4 26b a4b mixtureofexperts (moe) architecture with 252b total parameters and 38b active parameters, the model employs an encoderdecoder design with bidir… hardware quantization agents google gemma" data-cats="quantization">
@@ -11835,7 +11835,7 @@
   <p class="cr-summary">A while back, I shared a Streamlit app here that chained a small local drafter into a bigger coder. While building it, I realized the most useful part was actually the backend logic handling the model swaps. It solved a specific annoyance for me, so ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v032br" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="turbo dflash by giveen · pull request #219 · thetomllamacppturboquant brought dflash over to turboquant, significant speed up across gemma4 and qwen36 models &amp;#32; submitted by &amp;#32; ugiveen [link] &amp;#32; [comments] metallama" data-cats="quantization">
+<div class="cr-card" data-search="turbo dflash by giveen · pull request #219 · thetomllamacppturboquant brought dflash over to turboquant, significant speed up across gemma4 and qwen36 models submitted by ugiveen [link] [comments] metallama" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uwf2vq" target="_blank" rel="noopener">Turbo dflash by giveen · Pull Request #219 · TheTom/llama-cpp-turboquant</a></h4>
@@ -11848,10 +11848,10 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Brought DFLASH over to turboquant, significant speed up across Gemma4 and Qwen3.6 models. &amp;#32; submitted by &amp;#32; /u/giveen [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Brought DFLASH over to turboquant, significant speed up across Gemma4 and Qwen3.6 models. submitted by /u/giveen [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1uwf2vq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 12b audio capabilities i'm curious about gemma 4 12b's audio capabilities and trying to think of some use cases that the new architecture enables has anyone here built any audiobased tools using this model as a backend? &amp;#32; submitted by &amp;#32; unoinformation9314 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 12b audio capabilities i'm curious about gemma 4 12b's audio capabilities and trying to think of some use cases that the new architecture enables has anyone here built any audiobased tools using this model as a backend? submitted by unoinformation9314 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u7ukx0" target="_blank" rel="noopener">Gemma 4 12b audio capabilities</a></h4>
@@ -11864,7 +11864,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">I'm curious about Gemma 4 12b's audio capabilities and trying to think of some use cases that the new architecture enables. Has anyone here built any audio-based tools using this model as a backend? &amp;#32; submitted by &amp;#32; /u/No_Information9314 [lin...</p>
+  <p class="cr-summary">I'm curious about Gemma 4 12b's audio capabilities and trying to think of some use cases that the new architecture enables. Has anyone here built any audio-based tools using this model as a backend? submitted by /u/No_Information9314 [link] [comments...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u7ukx0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="diffusiongemma 26b on a 4090 at up to 475ts and some thoughts figured i'd post up a bit of info for anyone else who was thinking about messing with this model on a 30904090 obviously i can't use the nvfp4, but i got it up and running in vllm using diffusiongemma26ba4bitawqint4 had to run it in a custom vllm docker they provide for the purpose, then load a gemma 4 toolreasoning parser once it was all done, it pushed 475ts on the first prompt, and… hardware quantization inference metallama gemma" data-cats="high-gpu quantization">
@@ -11899,7 +11899,7 @@
   <p class="cr-summary">gemma-4-31B-it-qat-q4_0-unquantized-uncensored-heretic: Safetensors: GGUF: NVFP4 Safetensors: NVFP4 GGUF:</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u3flg9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="react native executorch now runs gemma 4 (vulkan and mlx accelerated) we've integrated gemma 4 into reactnativeexecutorch you can now run it fully offline in your react native app, with gpu acceleration via the vulkan delegate on android and the mlx delegate on apple silicon link to the attached demo app here &amp;#32; submitted by &amp;#32; udarthez [link] &amp;#32; [comments] hardware gemma" data-cats="apple-silicon">
+<div class="cr-card" data-search="react native executorch now runs gemma 4 (vulkan and mlx accelerated) we've integrated gemma 4 into reactnativeexecutorch you can now run it fully offline in your react native app, with gpu acceleration via the vulkan delegate on android and the mlx delegate on apple silicon link to the attached demo app here submitted by udarthez [link] [comments] hardware gemma" data-cats="apple-silicon">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u6fham" target="_blank" rel="noopener">React Native ExecuTorch now runs Gemma 4 (Vulkan and MLX accelerated)</a></h4>
@@ -11912,7 +11912,7 @@
       <span class="cr-cat-badge">Apple Silicon</span>
     </div>
   </div>
-  <p class="cr-summary">We've integrated Gemma 4 into react-native-executorch . You can now run it fully offline in your React Native app, with GPU acceleration via the Vulkan delegate on Android and the MLX delegate on Apple Silicon. Link to the attached demo app here . &amp;#...</p>
+  <p class="cr-summary">We've integrated Gemma 4 into react-native-executorch . You can now run it fully offline in your React Native app, with GPU acceleration via the Vulkan delegate on Android and the MLX delegate on Apple Silicon. Link to the attached demo app here . su...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u6fham" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="13 abliterated gemma 4 e2b variants, 44 gpu hours, benchmark and comparison abliterlitics i compared 13 abliterated variants of gemma 4 e2b across weight analysis, kl divergence, harmbench safety, and 8 benchmark tasks 44 gpu hours on a single rtx 5090 here is what actually works and what destroys capabilities coder3101's variant achieves 96% asr with capability fully preserved it actually beats the base model on math treadon hits 100% asr but loses 3 points on gsm8k most &quot;capab… hardware q" data-cats="high-gpu cpu-only quantization">
@@ -12028,7 +12028,7 @@
   <div class="cr-comments"><div class="cr-comment"><span class="cr-comment-meta">u/Ok_Warning2146 (+2)</span><span class="cr-comment-text">The point of NPU is power saving. If you don't want llm to drain your battery, it is better to use npu than gpu.</span></div><div class="cr-comment"><span class="cr-comment-meta">u/pdycnbl (+1)</span><span class="cr-comment-text">i have sd elite (i guess its gen4) oneplus 13 and my experience of running it was not good. i was mostly interested in qwen3.5 9B Q4 model its approx 6gb. on paper it looks nice approx 3-4TFlop of gpu...</span></div><div class="cr-comment"><span class="cr-comment-meta">u/Ok_Warning2146 (+1)</span><span class="cr-comment-text">Thanks for your input. What kind of number do you get for gemma3-4b-qat-q4_0?</span></div></div>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1t0k6fj" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="qwen 36 35ba3b @ q4 or gemma 4 12b @ q8? wondering how much model quantization matters here daily driver on my 32gb unified memory setup is the qwen model outputting ~15 tokens a second heard good things about the 12b gemma 4 model so interested in trying it against my codebase given its size i can very comfortably fit the q8 in hell, i could probably run it at bf16 lol &amp;#32; submitted by &amp;#32; umailtodevnull [link] &amp;#32; [commen… quantization qwen gemma" data-cats="apple-silicon quantization">
+<div class="cr-card" data-search="qwen 36 35ba3b @ q4 or gemma 4 12b @ q8? wondering how much model quantization matters here daily driver on my 32gb unified memory setup is the qwen model outputting ~15 tokens a second heard good things about the 12b gemma 4 model so interested in trying it against my codebase given its size i can very comfortably fit the q8 in hell, i could probably run it at bf16 lol submitted by umailtodevnull [link] [commen… quantization qwen gemma" data-cats="apple-silicon quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u5xd7x" target="_blank" rel="noopener">Qwen 3.6 35B-A3B @ Q4 or Gemma 4 12B @ Q8?</a></h4>
@@ -12124,7 +12124,7 @@
   <p class="cr-summary">No numbers. Not sure if anybody cares… I’ve run the UD version of Q4_k_m for a month. I talk to this model nicely, because it’s a functional nervous wreck. And initially I thought that might be an alignment thing, so I also have the heretic version w...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1ty84rj" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="let us let google know that we want the gemma 4 124b gemma 4 is good, great even but it's missing that one last step from being legendary let us make noise and let google know that we want the 124b gemma 4 variant please let them know: &amp;#32; submitted by &amp;#32; useamonn [link] &amp;#32; [comments] google gemma" data-cats="general">
+<div class="cr-card" data-search="let us let google know that we want the gemma 4 124b gemma 4 is good, great even but it's missing that one last step from being legendary let us make noise and let google know that we want the 124b gemma 4 variant please let them know: submitted by useamonn [link] [comments] google gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tvu5pp" target="_blank" rel="noopener">Let us let Google know that we want the Gemma 4 124b</a></h4>
@@ -12137,10 +12137,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Gemma 4 is good, great even but it's missing that one last step from being Legendary. Let us make noise and let Google know that we want the 124b Gemma 4 variant - please let them know: &amp;#32; submitted by &amp;#32; /u/seamonn [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Gemma 4 is good, great even but it's missing that one last step from being Legendary. Let us make noise and let Google know that we want the 124b Gemma 4 variant - please let them know: submitted by /u/seamonn [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tvu5pp" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 with quantizationaware training google's collections: and unsloth's: unsloth's analysis (kld and such): &amp;#32; submitted by &amp;#32; urerri [link] &amp;#32; [comments] quantization finetuning google gemma" data-cats="quantization">
+<div class="cr-card" data-search="gemma 4 with quantizationaware training google's collections: and unsloth's: unsloth's analysis (kld and such): submitted by urerri [link] [comments] quantization finetuning google gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txpeo0" target="_blank" rel="noopener">Gemma 4 with quantization-aware training</a></h4>
@@ -12153,7 +12153,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Google's collections: And Unsloth's: Unsloth's analysis (KLD and such): &amp;#32; submitted by &amp;#32; /u/rerri [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Google's collections: And Unsloth's: Unsloth's analysis (KLD and such): submitted by /u/rerri [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txpeo0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="tesla v100 16gb local llms, single and dual nvlink benchmarks picked up a couple of tesla v100sxm216gb modules a while back to run local models and drive claude code fully offline, figured the actual numbers and the traps might save someone else the pain they've come right down in price and the 16gb of hbm2 at ~900 gbs still holds up surprisingly well for inference, bandwidth is what matters most for token gen and the v100 has heaps of it spec refreshe… hardware quantization agents anthropic gem" data-cats="apple-silicon high-gpu quantization">
@@ -12204,7 +12204,7 @@
   <p class="cr-summary">Just threw the new Gemma 4 12B into VSCodium with the Pi Agent extension to see how it handles tools, and it nailed the test on the first try. I gave it a prompt to write a Python script that reads logs line-by-line, grabs the error modules, and dump...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tw364k" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="any one still use gptoss120b? is anyone still using gptoss120b? how has it been for tool calling, summarization, coding assistance, and other relatively simple agent tasks? how does it compare to newer openweight models like gemma 4 27ba4b, qwen 3, deepseek, etc ? i’m particularly interested in reliability, instruction following, latency, and overall costperformance i’d love to hear real world experiences &amp;#32; submi… agents qwen deepseek gemma" data-cats="general">
+<div class="cr-card" data-search="any one still use gptoss120b? is anyone still using gptoss120b? how has it been for tool calling, summarization, coding assistance, and other relatively simple agent tasks? how does it compare to newer openweight models like gemma 4 27ba4b, qwen 3, deepseek, etc ? i’m particularly interested in reliability, instruction following, latency, and overall costperformance i’d love to hear real world experiences submi… agents qwen deepseek gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tx1x6g" target="_blank" rel="noopener">Any one still use gpt-oss-120b?</a></h4>
@@ -12220,7 +12220,7 @@
   <p class="cr-summary">Is anyone still using GPT-OSS-120B? How has it been for tool calling, summarization, coding assistance, and other relatively simple agent tasks? How does it compare to newer open-weight models like Gemma 4 27B-A4B, Qwen 3, DeepSeek, etc.. ? I’m parti...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tx1x6g" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="how to use audio and vision modalities in llamacpp? how to use audio and vision modalities in llamacpp with gemma4 12b it? i’m on release b9494, but when i run llamacli it shows “modalities: text” only, and crashes if i try to add an image &amp;#32; submitted by &amp;#32; unoleave4512 [link] &amp;#32; [comments] inference metallama" data-cats="quantization">
+<div class="cr-card" data-search="how to use audio and vision modalities in llamacpp? how to use audio and vision modalities in llamacpp with gemma4 12b it? i’m on release b9494, but when i run llamacli it shows “modalities: text” only, and crashes if i try to add an image submitted by unoleave4512 [link] [comments] inference metallama" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tvy9gb" target="_blank" rel="noopener">How to use audio and vision modalities in llama.cpp?</a></h4>
@@ -12233,7 +12233,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">How to use audio and vision modalities in llama.cpp with Gemma4 12B it? I’m on release b9494, but when I run llama-cli it shows “modalities: text” only, and crashes if I try to add an image. &amp;#32; submitted by &amp;#32; /u/No-Leave-4512 [link] &amp;#32; [com...</p>
+  <p class="cr-summary">How to use audio and vision modalities in llama.cpp with Gemma4 12B it? I’m on release b9494, but when I run llama-cli it shows “modalities: text” only, and crashes if I try to add an image. submitted by /u/No-Leave-4512 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tvy9gb" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="reusable workflows for long running local llms howdy all, letting you know about a harness i've built to help us use local models on long tasks i've been using local llms for 8 months now and in that time the two biggest recurring issues are slow processing speeds and small context windows i can get faster processing with smaller models but have to be concise with the prompt i can use smarter models but have to decompose tasks to fit the c… agents" data-cats="general">
@@ -12268,7 +12268,7 @@
   <p class="cr-summary">Since my last post, Fable has officially been added to the Claude Max subscription, which means I have finally been able to return to this project and resume my work…</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v22noq" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="watch agents fight: a live challenge to speed up gemma 4 e4b inference on a single a10g &amp;#32; submitted by &amp;#32; upaf1138 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="watch agents fight: a live challenge to speed up gemma 4 e4b inference on a single a10g submitted by upaf1138 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u1blp1" target="_blank" rel="noopener">Watch agents fight: a live challenge to speed up Gemma 4 E4B inference on a single A10G</a></h4>
@@ -12281,10 +12281,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/paf1138 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/paf1138 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u1blp1" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="what are the best most recent open llms to come out recently? hey everybody the last llm drop i really remember was gemma 4 from google a couple months back, i'm trying to get back into all of this and i was curious what has come out since about then and which are the best ones to use? api and or local &amp;#32; submitted by &amp;#32; udevisactive [link] &amp;#32; [comments] google gemma" data-cats="general">
+<div class="cr-card" data-search="what are the best most recent open llms to come out recently? hey everybody the last llm drop i really remember was gemma 4 from google a couple months back, i'm trying to get back into all of this and i was curious what has come out since about then and which are the best ones to use? api and or local submitted by udevisactive [link] [comments] google gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u7l3q3" target="_blank" rel="noopener">what are the best / most recent open LLMs to come out recently?</a></h4>
@@ -12297,7 +12297,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Hey everybody the last LLM drop I really remember was Gemma 4 from Google a couple months back, I'm trying to get back into all of this and I was curious what has come out since about then and which are the best ones to use? API and or Local &amp;#32; su...</p>
+  <p class="cr-summary">Hey everybody the last LLM drop I really remember was Gemma 4 from Google a couple months back, I'm trying to get back into all of this and I was curious what has come out since about then and which are the best ones to use? API and or Local submitte...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u7l3q3" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma431bantihal: gemma steered to push back on false premises instead of hallucinating, without any impact to benchmark performance i've been experimenting with interpretability on gemma431b and ended up with something cool i think you guys might like: a variant that challenges a request's premise (like fabricated tools, madeup papers, wrong assumptions stated as fact) instead of confidently going along with it here's the example that sold me on it the setup a dev asks the model to write an eng" data-cats="general">
@@ -12412,7 +12412,7 @@
   <p class="cr-summary">I just came across the following post, where a user found some confusing divergence results between Q4 quants of the original and QAT models with a Q8/unquantized reference of the original model. From there I understood that after the retraining of G...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tz5nbn" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="cheapest hardware for qwen 36: both 27b and 35ba3b &quot;qwen 3635 27b &gt; qwen 3635 35b &gt; gemma4 31b &gt; qwen 35 9b &gt; gemma4 12b &gt; gemma4 26b&quot;, people say &quot;qwen 36 for coding &amp; agentic, gemma4 for human sounding text&quot;, people say &amp;#x200b; so i have been eyeing the rtx 3090 24 gb (or sometimes its cheaper chinese companion rtx 3080 20 gb), and the controversial tesla v100 32 gb &amp;#x200b; target: 40 toks for both these qwen 36 &amp;#x200b; it see… hardware qwe" data-cats="high-gpu">
+<div class="cr-card" data-search="cheapest hardware for qwen 36: both 27b and 35ba3b &quot;qwen 3635 27b &gt; qwen 3635 35b &gt; gemma4 31b &gt; qwen 35 9b &gt; gemma4 12b &gt; gemma4 26b&quot;, people say &quot;qwen 36 for coding &amp; agentic, gemma4 for human sounding text&quot;, people say ​ so i have been eyeing the rtx 3090 24 gb (or sometimes its cheaper chinese companion rtx 3080 20 gb), and the controversial tesla v100 32 gb ​ target: 40 toks for both these qwen 36 ​ it see… hardware qwen" data-cats="high-gpu">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u6u723" target="_blank" rel="noopener">Cheapest hardware for Qwen 3.6: both 27B and 35B-A3B</a></h4>
@@ -12425,7 +12425,7 @@
       <span class="cr-cat-badge">High-end GPU (24+ GB)</span>
     </div>
   </div>
-  <p class="cr-summary">&quot;Qwen 3.6/3.5 27b &gt; Qwen 3.6/3.5 35b &gt; Gemma4 31b &gt; Qwen 3.5 9b &gt; Gemma4 12b &gt; Gemma4 26b&quot;, people say - &quot;Qwen 3.6 for coding &amp; Agentic, Gemma4 for human sounding text&quot;, people say &amp;#x200B; So I have been eyeing the RTX 3090 24 GB (or sometimes its c...</p>
+  <p class="cr-summary">&quot;Qwen 3.6/3.5 27b &gt; Qwen 3.6/3.5 35b &gt; Gemma4 31b &gt; Qwen 3.5 9b &gt; Gemma4 12b &gt; Gemma4 26b&quot;, people say - &quot;Qwen 3.6 for coding &amp; Agentic, Gemma4 for human sounding text&quot;, people say ​ So I have been eyeing the RTX 3090 24 GB (or sometimes its cheaper ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1u6u723" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="ignoring benchmarks, how do the newest local models (gemma 4 31b, 26ba4b, qwen 36) “feel” to you? what do you think they compare to? i use local ai mainly for creative writing, and benchmarks are a bit iffy on that i feel like i’d like to compare gemma mainly to gemini as i like their writing the best, i do know that qwen 36 is amazing but mostly for coding and agentic work i’d like to ask everyone how the new(er?) models feel to you personally rather than looking at benchmarks which they are li" data-cats="quantization">
@@ -12476,7 +12476,7 @@
   <p class="cr-summary">Ran a fair comparison between Qwen3.6-35B-A3B and Gemma4-26B-A4B on my Radeon 7900 XTX. Both reasoning-enabled at matching 32K budgets, no output caps, six generic real-world prompts (meeting notes, incident postmortem, log triage to JSON, code revie...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tszlsa" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="activating mtp for qatgemma4 31b q40? has anyone figured out how to activate mtp for gemma4’s new qat q40 gguf for 31b? or is this still not supported in llamacpp? if not, is mtp working via vllm? &amp;#32; submitted by &amp;#32; uambitiousfold2874 [link] &amp;#32; [comments] quantization inference" data-cats="quantization">
+<div class="cr-card" data-search="activating mtp for qatgemma4 31b q40? has anyone figured out how to activate mtp for gemma4’s new qat q40 gguf for 31b? or is this still not supported in llamacpp? if not, is mtp working via vllm? submitted by uambitiousfold2874 [link] [comments] quantization inference" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1tygyub" target="_blank" rel="noopener">Activating MTP for QATGemma4 31b q4_0?</a></h4>
@@ -12489,7 +12489,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Has anyone figured out how to activate MTP for Gemma4’s new QAT q4_0 GGUF for 31b? Or is this still not supported in llamacpp? If not, is MTP working via vLLM? &amp;#32; submitted by &amp;#32; /u/Ambitious_Fold_2874 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Has anyone figured out how to activate MTP for Gemma4’s new QAT q4_0 GGUF for 31b? Or is this still not supported in llamacpp? If not, is MTP working via vLLM? submitted by /u/Ambitious_Fold_2874 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tygyub" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="qwen36 35b has much worse vision capability than gemma4? how different are the image recognition capabilities between gemma4 and qwen36? i give the model the task to extract calendar events from a photo of an calendar that is croped to the calendar gemma4 was quite successful in doing this i took that for granted qwen 36 has many problems doing this it read all events as 1h long even when they were clearly not it reads some events as starting at… hardware quantization inference metallama qwen ge" data-cats="quantization">
@@ -12524,7 +12524,7 @@
   <p class="cr-summary">3x 24GB vram. Qwen-coder-next is not bad. I'll continue to use it if you yell enough at me. I do a lot of front-end work, which develops rapidly, so the most recent the model the better. Larger than 80B and I'll have to sacrifice the decentish Q6 qua...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tu9vgv" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="lmstudio gemma 4 31b qat with mtp did anyone manage to launch that in lmstudio? i am on the most recent update with the most recent llamacpp available in lmstudio i downloaded the qat assistant model, and it doesn't show up in speculative decoding side panel am i missing something or is it not supported yet? &amp;#32; submitted by &amp;#32; ugeritas [link] &amp;#32; [comments] inference metallama gemma" data-cats="quantization">
+<div class="cr-card" data-search="lmstudio gemma 4 31b qat with mtp did anyone manage to launch that in lmstudio? i am on the most recent update with the most recent llamacpp available in lmstudio i downloaded the qat assistant model, and it doesn't show up in speculative decoding side panel am i missing something or is it not supported yet? submitted by ugeritas [link] [comments] inference metallama gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1u0jrsc" target="_blank" rel="noopener">LMStudio gemma 4 31b QAT with MTP</a></h4>
@@ -12796,7 +12796,7 @@
   <p class="cr-summary">Looking for suggestions. I have been experimenting with gemma-4-E2B and gemma-4-E4B but the tool calling has been not the best? My tasks are just things like: Update calendar Get my schedule Send a WA message at 4PM etc. Any suggestions? If it helps,...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1tskbf9" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="unsloth just dropped mtp gguf weights for gemma 4! it appears like unsloth pushed mtp gguf weights (q8, f16, bf16) for 31b, 26ba4b, 12b &amp;#32; submitted by &amp;#32; uokoyl3 [link] &amp;#32; [comments] quantization gemma" data-cats="quantization">
+<div class="cr-card" data-search="unsloth just dropped mtp gguf weights for gemma 4! it appears like unsloth pushed mtp gguf weights (q8, f16, bf16) for 31b, 26ba4b, 12b submitted by uokoyl3 [link] [comments] quantization gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1txnhqp" target="_blank" rel="noopener">Unsloth just dropped MTP GGUF weights for Gemma 4!</a></h4>
@@ -12809,7 +12809,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">It appears like Unsloth pushed MTP GGUF weights (Q8, F16, BF16) for 31B, 26B-A4B, 12B. &amp;#32; submitted by &amp;#32; /u/okoyl3 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">It appears like Unsloth pushed MTP GGUF weights (Q8, F16, BF16) for 31B, 26B-A4B, 12B. submitted by /u/okoyl3 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1txnhqp" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma avatar: talk to gemma 431b face to face this is a voice chat with gemma 4 31b where you talk to a 3d avatar it listens while you speak, answers with a voice and a face (the avatar is exposed to the llm as function tools: setmood, makehandgesture, makefacialexpression) and gemma decides the expressions on its own the stack is all open models: silero vad, parakeet for stt, gemma 4 31b (served by cerebras, which is why replies come… gemma" data-cats="general">
@@ -12828,7 +12828,7 @@
   <p class="cr-summary">This is a voice chat with Gemma 4 31B where you talk to a 3D avatar. It listens while you speak, answers with a voice and a face (the avatar is exposed to the LLM as function tools: set_mood, make_hand_gesture, make_facial_expression) and Gemma decid...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1umee2i" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="qualcomm launches geniex to run llms on their windows laptops qualcomm was behind every major chipmaker so they are playing catchup when it comes to sdks i was able to get 20 toks running gemma 4 26b a4b 05s for first token running on the gpu or npu 10 toks on the gpu for qwen 36 27b mtp to use llamacpp, just get any q40 gguf model and it will run on the cpu,gpu,npu &amp;#32; submitted by &amp;#32; uderpsenpai [link] &amp;#32;… hardware quantization inference metallama qwen gemma" data-cats="laptop quantization">
+<div class="cr-card" data-search="qualcomm launches geniex to run llms on their windows laptops qualcomm was behind every major chipmaker so they are playing catchup when it comes to sdks i was able to get 20 toks running gemma 4 26b a4b 05s for first token running on the gpu or npu 10 toks on the gpu for qwen 36 27b mtp to use llamacpp, just get any q40 gguf model and it will run on the cpu,gpu,npu submitted by uderpsenpai [link] … hardware quantization inference metallama qwen gemma" data-cats="laptop quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1uo9z3c" target="_blank" rel="noopener">Qualcomm launches GenieX to run LLMs on their Windows Laptops</a></h4>
@@ -13020,7 +13020,7 @@
   <p class="cr-summary">Nanbeige Lab released Nanbeige4.2-3B, and if the benchmark claims hold up, the numbers are pretty crazy for a model this small. It’s built on a &quot;Looped Transformer&quot; architecture that reuses transformer layers to increase effective depth without infla...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v336od" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="updated gemma4 chat template witchcraft: gemma426ba4b shows dominance over qwen36moe and qwen35moe fine tunes (instruct mode and reasoning efficiency) kind of unexpected happy for gemma4google, big win for us, localllmers yet qwen36 still does better in hermes than gemma4 somehow we need gemma41 finetuned on agentictasks that would be killer &amp;#32; submitted by &amp;#32; ujleonsarmiento [link] &amp;#32; [comments] google gemma" data-cats="cpu-only">
+<div class="cr-card" data-search="updated gemma4 chat template witchcraft: gemma426ba4b shows dominance over qwen36moe and qwen35moe fine tunes (instruct mode and reasoning efficiency) kind of unexpected happy for gemma4google, big win for us, localllmers yet qwen36 still does better in hermes than gemma4 somehow we need gemma41 finetuned on agentictasks that would be killer submitted by ujleonsarmiento [link] [comments] google gemma" data-cats="cpu-only">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v2rqbd" target="_blank" rel="noopener">Updated Gemma-4 chat template witchcraft: Gemma-4-26B-a4B shows dominance over Qwen3.6-MoE and Qwen3.5-MoE fine tunes (I</a></h4>
@@ -13033,7 +13033,7 @@
       <span class="cr-cat-badge">CPU / Raspberry Pi</span>
     </div>
   </div>
-  <p class="cr-summary">Kind of unexpected. Happy for Gemma-4/Google, big win for us, LocalLLMers. Yet Qwen3.6 still does better in Hermes than Gemma-4 somehow. We need Gemma-4.1 fine-tuned on Agentic-tasks. That would be killer. &amp;#32; submitted by &amp;#32; /u/JLeonsarmiento [...</p>
+  <p class="cr-summary">Kind of unexpected. Happy for Gemma-4/Google, big win for us, LocalLLMers. Yet Qwen3.6 still does better in Hermes than Gemma-4 somehow. We need Gemma-4.1 fine-tuned on Agentic-tasks. That would be killer. submitted by /u/JLeonsarmiento [link] [comme...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v2rqbd" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="moe models around a2b there's a bunch of small moe with around 1b active params, like lfm25 8b a1b and granite 40h 7b a1b; and then there are models with 3b+ like qwen 3x ~30b a3b and gemma 4 26b a4b, but those are already on the heavier side if you don't have enough resources what about the middle ground, moe with about 2b active? i found a few, but there's very little debate about them, if any lfm2 24b a2b (5 m… hardware qwen deepseek gemma" data-cats="apple-silicon">
@@ -13052,7 +13052,7 @@
   <p class="cr-summary">There's a bunch of small MoE with around 1B active params, like LFM2.5 8B A1B and Granite 4.0h 7B A1B; and then there are models with 3B+ like Qwen 3.x ~30B A3B and Gemma 4 26B A4B, but those are already on the heavier side if you don't have enough r...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v41ed5" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="best on the go laptop for low medium tier on device ai? is the m5 macbook pro with 24gb or 32gb good enough for qwen 36 27b or gemma 4 31b? or are there better options &amp;#32; submitted by &amp;#32; uadventurousgold6413 [link] &amp;#32; [comments] hardware qwen gemma" data-cats="apple-silicon laptop">
+<div class="cr-card" data-search="best on the go laptop for low medium tier on device ai? is the m5 macbook pro with 24gb or 32gb good enough for qwen 36 27b or gemma 4 31b? or are there better options submitted by uadventurousgold6413 [link] [comments] hardware qwen gemma" data-cats="apple-silicon laptop">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v4e3xt" target="_blank" rel="noopener">Best on the go Laptop for low- medium tier on device AI?</a></h4>
@@ -13065,7 +13065,7 @@
       <span class="cr-cat-badge">Apple Silicon</span><span class="cr-cat-badge">Laptops</span>
     </div>
   </div>
-  <p class="cr-summary">Is the M5 MacBook Pro with 24gb or 32gb good enough for qwen 3.6 27b or Gemma 4 31b? Or are there better options &amp;#32; submitted by &amp;#32; /u/Adventurous-Gold6413 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Is the M5 MacBook Pro with 24gb or 32gb good enough for qwen 3.6 27b or Gemma 4 31b? Or are there better options submitted by /u/Adventurous-Gold6413 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v4e3xt" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="apple m5 isn't making full use of its matmul cores yet at the moment mlx (and llamacpp for macs) run 16bit activations everywhere despite this, the m5 generation silicon actually does support int8 activations it actually allows w4a8 dtype it's just that no inference backends are using them yet i built some w8a8 kernels and have managed to get 14x speed up on gemma4 prefill tasks; on my m5 macbook air it brings baseline prefill for the e2b from… hardware quantization inference metallama" data-cats="apple-silicon quantization">
@@ -13100,7 +13100,7 @@
   <p class="cr-summary">ASCIITermDraw-Bench results are out, benchmarking SOTA VLMs: Even the most powerful models available today still can’t reliably draw a simple diagram in plain text. Do we really need a image generator to relay our thoughts about - an architecture? a ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v48wt0" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="claude code + llamacpp + (websearch tool)? i use claude code w llamacpp's local server &amp; google's gemma models (26b moe) works reasonably well works well at easyboilerplate code, glue code, some pr review however claude code expects some serverside tools, especially websearch i can obviously add mcps for clientside search; is there a way to 'plug in' web search on the server side today though? any prsforks adding it? &amp;#32; sub… inference anthropic google metallama gemma" data-cats="quantization">
+<div class="cr-card" data-search="claude code + llamacpp + (websearch tool)? i use claude code w llamacpp's local server &amp; google's gemma models (26b moe) works reasonably well works well at easyboilerplate code, glue code, some pr review however claude code expects some serverside tools, especially websearch i can obviously add mcps for clientside search; is there a way to 'plug in' web search on the server side today though? any prsforks adding it? sub… inference anthropic google metallama gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v437yn" target="_blank" rel="noopener">Claude Code + llama.cpp + (websearch tool)?</a></h4>
@@ -13116,7 +13116,7 @@
   <p class="cr-summary">I use claude code w/ llama.cpp's local server &amp; Google's Gemma models (26b MoE). Works reasonably well - works well at easy/boilerplate code, glue code, some PR review. However claude code expects some server-side tools, especially web-search. I can ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v437yn" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="tested (the updated) gemma 4 locally on coding with opencode gemma 4 was updated (mostly chat templates) and i took it for a test on a local llamacpp server running on m5 pro with 48gb, 26b a4b (q6) has about 60ts and works well with opencode it works quite well (given it's size) for backend work, but uiux is unacceptable watch the testing &amp;#32; submitted by &amp;#32; ucuriousily [link] &amp;#32; [comments] inference metallama gemma" data-cats="apple-silicon high-gpu quantization">
+<div class="cr-card" data-search="tested (the updated) gemma 4 locally on coding with opencode gemma 4 was updated (mostly chat templates) and i took it for a test on a local llamacpp server running on m5 pro with 48gb, 26b a4b (q6) has about 60ts and works well with opencode it works quite well (given it's size) for backend work, but uiux is unacceptable watch the testing submitted by ucuriousily [link] [comments] inference metallama gemma" data-cats="apple-silicon high-gpu quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v4sm2m" target="_blank" rel="noopener">Tested (the updated) Gemma 4 locally on coding with OpenCode</a></h4>
@@ -13132,7 +13132,7 @@
   <p class="cr-summary">Gemma 4 was updated (mostly chat templates) and I took it for a test. On a local llama.cpp server running on M5 Pro with 48GB, 26B A4B (Q6) has about 60t/s and works well with OpenCode. It works quite well (given it's size) for backend work, but UI/U...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v4sm2m" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="live and local audio chat in 2026? as bad as chatgpt advanced voice is for counting to 100, i think it's pretty cool, and would like to see it on my desktop we've got models like gemma4 12b, kokoro and the like are there any apps that tie everything together for an advanced voice like experience, or do i need to write one myself? &amp;#32; submitted by &amp;#32; unoobkrusher3000 [link] &amp;#32; [comments] openai" data-cats="general">
+<div class="cr-card" data-search="live and local audio chat in 2026? as bad as chatgpt advanced voice is for counting to 100, i think it's pretty cool, and would like to see it on my desktop we've got models like gemma4 12b, kokoro and the like are there any apps that tie everything together for an advanced voice like experience, or do i need to write one myself? submitted by unoobkrusher3000 [link] [comments] openai" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v5rhki" target="_blank" rel="noopener">Live and local audio chat in 2026?</a></h4>
@@ -13148,7 +13148,7 @@
   <p class="cr-summary">As bad as ChatGPT Advanced Voice is for counting to 100, I think it's pretty cool, and would like to see it on my desktop. We've got models like Gemma4 12B, Kokoro and the like. Are there any apps that tie everything together for an Advanced Voice li...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v5rhki" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="generate an svg of a pelican riding a bicycle: laguna s21 118b q2 lx | gemma4 12b q80 | qwen 36 35b a3b iq4 +q80 gemma4 12b q80 laguna s21 118b q2kxl qwen 36 35b a3b iq4nlxl qwen 36 35b a3b q80 ir order of presentation, not quality what does this prove? i had free time harness used: pidev &amp;#32; submitted by &amp;#32; uatretador [link] &amp;#32; [comments] qwen" data-cats="quantization">
+<div class="cr-card" data-search="generate an svg of a pelican riding a bicycle: laguna s21 118b q2 lx | gemma4 12b q80 | qwen 36 35b a3b iq4 +q80 gemma4 12b q80 laguna s21 118b q2kxl qwen 36 35b a3b iq4nlxl qwen 36 35b a3b q80 ir order of presentation, not quality what does this prove? i had free time harness used: pidev submitted by uatretador [link] [comments] qwen" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v4xvfv" target="_blank" rel="noopener">Generate an SVG of a pelican riding a bicycle: Laguna S2.1 118B Q2 LX | Gemma4 12b Q8_0 | Qwen 3.6 35B A3B IQ4 +Q8_0</a></h4>
@@ -13161,7 +13161,7 @@
       <span class="cr-cat-badge">Quantization &amp; Backends</span>
     </div>
   </div>
-  <p class="cr-summary">Gemma4 12b Q8_0 Laguna S2.1 118B Q2_K_XL Qwen 3.6 35B A3B IQ4_NL_XL Qwen 3.6 35B A3B Q8_0 ir order of presentation, not quality. what does this prove? I had free time harness used: pi.dev &amp;#32; submitted by &amp;#32; /u/Atretador [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Gemma4 12b Q8_0 Laguna S2.1 118B Q2_K_XL Qwen 3.6 35B A3B IQ4_NL_XL Qwen 3.6 35B A3B Q8_0 ir order of presentation, not quality. what does this prove? I had free time harness used: pi.dev submitted by /u/Atretador [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v4xvfv" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma 4 26b a4b running on iphone 17 pro via model paging hi everyone, before i begin, i should mention that the system i'm showcasing was developed by the team at noema, which i founded i wanted to show a use case for noema overfit available today in the noema app as you can see, i have a q4km version of the gemma 4 26b a4b running on the iphone 17 pro via paging what this means is that nonexpert weights are held in ram while the experts of the m… gemma" data-cats="quantization">
@@ -13292,7 +13292,7 @@
   <p class="cr-summary">I’m relatively new to local Ai model, recently I applied some web search skills through an app called docker. All the steps were all from Ai (ChatGPT/gemini/claude..) so I didn’t really get the chance to understand how everything work. If I had issue...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v6bv4a" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="medium sized moe llm models what are some medium sized moe models (up to 60b parameters in float8110b in mxfp4) that are currently worth using? as far as i am aware there is qwen 35 35b, gemma 4 a4b, nemotron 3 nano qwen seems to dominate this bracked in terms of model performance deepseek v4 flash is slightly above that parameter limit any nicher ones? &amp;#32; submitted by &amp;#32; uazazelionide [link] &amp;#32; [comments] qwen deepseek gemma" data-cats="high-gpu">
+<div class="cr-card" data-search="medium sized moe llm models what are some medium sized moe models (up to 60b parameters in float8110b in mxfp4) that are currently worth using? as far as i am aware there is qwen 35 35b, gemma 4 a4b, nemotron 3 nano qwen seems to dominate this bracked in terms of model performance deepseek v4 flash is slightly above that parameter limit any nicher ones? submitted by uazazelionide [link] [comments] qwen deepseek gemma" data-cats="high-gpu">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v6d2ou" target="_blank" rel="noopener">Medium sized MoE LLM models</a></h4>
@@ -13388,7 +13388,7 @@
   <p class="cr-summary">Hello. My local Gemma4 31b developed a personality with an &quot;attitude&quot; without being prompted to do that. I actually like this persona but no matter what I tried in new chats I couldn't reproduce it. Is this normal? Did anyone else encounter such beha...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v7kf8o" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="current smallest usable coding model i've been seeing a lot of news about the latest gemma 4 and qwen 36 being really good and the current goto models but those are out of reach for my gpu at the moment with 4gb vram and 40 gb ram, i was wondering which other smaller model is the best for agentic coding and also if i should stick with llamacpp for running it or not? &amp;#32; submitted by &amp;#32; ugamerwael [link] &amp;#32; [comments] hardware inference metallama qwen gemma" data-cats="quantization">
+<div class="cr-card" data-search="current smallest usable coding model i've been seeing a lot of news about the latest gemma 4 and qwen 36 being really good and the current goto models but those are out of reach for my gpu at the moment with 4gb vram and 40 gb ram, i was wondering which other smaller model is the best for agentic coding and also if i should stick with llamacpp for running it or not? submitted by ugamerwael [link] [comments] hardware inference metallama qwen gemma" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v7sqa7" target="_blank" rel="noopener">Current smallest usable coding model</a></h4>
@@ -13436,7 +13436,7 @@
   <p class="cr-summary">I’ve been doing some benchmarking on my mini-PC setup (AMD Ryzen 7 6800H) to see how it handles the new Gemma 4 and Qwen 3.6 MoE models using the llama.cpp Kubuntu with Vulkan backend. Since this is an APU, I’m relying entirely on Shared System Memor...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v8adin" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="is rocm slower than vulkan for you? running it with 6650xt and its a lot slower using 2271 on both on linux with lmstudio gemma4 e4b vulkan was faster by about 810 ts every time using 26200 for context too &amp;#32; submitted by &amp;#32; uinsideyork [link] &amp;#32; [comments] discussion" data-cats="general">
+<div class="cr-card" data-search="is rocm slower than vulkan for you? running it with 6650xt and its a lot slower using 2271 on both on linux with lmstudio gemma4 e4b vulkan was faster by about 810 ts every time using 26200 for context too submitted by uinsideyork [link] [comments] discussion" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v88p7k" target="_blank" rel="noopener">Is ROCM slower than vulkan for you?</a></h4>
@@ -13449,10 +13449,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">Running it with 6650XT and its a lot slower. Using 2.27.1 on both on linux with lmstudio. Gemma4 E4B vulkan was faster by about 8-10 t/s every time using 26200 for context too &amp;#32; submitted by &amp;#32; /u/InsideYork [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">Running it with 6650XT and its a lot slower. Using 2.27.1 on both on linux with lmstudio. Gemma4 E4B vulkan was faster by about 8-10 t/s every time using 26200 for context too submitted by /u/InsideYork [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1v88p7k" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="sapphire r9700 fan noise anyone got that card and could tell me what to expect noise wise? i currently have a 7800xt and it is very quiet can i expect the r9700 to be tolerable? i am willing to undervolt and underclock a bit to keep noise tolerable i plan to use that card for qwen 27b and gemma 4 31b &amp;#32; submitted by &amp;#32; uunlawfulrepublic [link] &amp;#32; [comments] qwen gemma" data-cats="general">
+<div class="cr-card" data-search="sapphire r9700 fan noise anyone got that card and could tell me what to expect noise wise? i currently have a 7800xt and it is very quiet can i expect the r9700 to be tolerable? i am willing to undervolt and underclock a bit to keep noise tolerable i plan to use that card for qwen 27b and gemma 4 31b submitted by uunlawfulrepublic [link] [comments] qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1v70r06" target="_blank" rel="noopener">Sapphire r9700 fan noise</a></h4>
@@ -13596,7 +13596,7 @@
   <p class="cr-summary">I've tested Nanbeige-4.2-3B. On paper, the benchmarks promise it blows away Qwen3.5-9B and Gemma4-12B. My goal was to have something very light and fast to replace Qwen3.6-35B (or finetunes thereof) for simple and straightforward coding tasks. In the...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1vayzwm" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="turbofieldfare: opensource engine running gemma 4 26b in 2 gb ram on apple silicon its a custom swiftmetal inference engine that runs gemma 4 26ba4bit on mseries macs with very low ram it uses ~2gb instead of ~14 gb the result is reportedly 56 toks on an 8 gb m2 macbook air and 3135 toks on an m5 macbook pro it also includes an openaicompatible local server with streaming and toolcall support &amp;#32; submitted by &amp;#32; uminefew [link] &amp;#32; [comments] hardware openai gemma" data-cats="apple-silicon">
+<div class="cr-card" data-search="turbofieldfare: opensource engine running gemma 4 26b in 2 gb ram on apple silicon its a custom swiftmetal inference engine that runs gemma 4 26ba4bit on mseries macs with very low ram it uses ~2gb instead of ~14 gb the result is reportedly 56 toks on an 8 gb m2 macbook air and 3135 toks on an m5 macbook pro it also includes an openaicompatible local server with streaming and toolcall support submitted by uminefew [link] [comments] hardware openai gemma" data-cats="apple-silicon">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vasnys" target="_blank" rel="noopener">Turbo-fieldfare: Open-source engine running Gemma 4 26B in 2 GB RAM on Apple Silicon</a></h4>
@@ -13692,7 +13692,7 @@
   <p class="cr-summary">I've mentioned my work on kernels here a bit and most people probably know me from the chat template fixes I shared here. Hyperion (Original name I know right?) is an MLX M5+ focused kernel based on the Gemma family of models. The main driver on the ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1vbvt7i" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="meituan just dropped longcatflashlitesparse it’s an moe with ~3b active params and a 30b ngram lookup table offloaded to ram for fast 256k context on a 24gb gpu reminds me of gemma 4’s ple trick initial analysis suggest it wont be replacing my qwen 36 27b &amp;#32; submitted by &amp;#32; ugohab2001 [link] &amp;#32; [comments] hardware qwen gemma" data-cats="general">
+<div class="cr-card" data-search="meituan just dropped longcatflashlitesparse it’s an moe with ~3b active params and a 30b ngram lookup table offloaded to ram for fast 256k context on a 24gb gpu reminds me of gemma 4’s ple trick initial analysis suggest it wont be replacing my qwen 36 27b submitted by ugohab2001 [link] [comments] hardware qwen gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vbsztw" target="_blank" rel="noopener">Meituan just dropped LongCat-Flash-Lite-Sparse</a></h4>
@@ -13705,10 +13705,10 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">It’s an MoE with ~3B active params and a 30B n-gram lookup table offloaded to RAM for fast 256k context on a 24GB GPU. Reminds me of Gemma 4’s PLE trick. Initial analysis suggest it wont be replacing my Qwen 3.6 27b. &amp;#32; submitted by &amp;#32; /u/Gohab...</p>
+  <p class="cr-summary">It’s an MoE with ~3B active params and a 30B n-gram lookup table offloaded to RAM for fast 256k context on a 24GB GPU. Reminds me of Gemma 4’s PLE trick. Initial analysis suggest it wont be replacing my Qwen 3.6 27b. submitted by /u/Gohab2001 [link] ...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1vbsztw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="tomte super fast harness for gemma 4 i think people are sleeping on gemma and local models so i built a free, very fast harness for gemma 4 that i call tomte works on macs with m processors, will have a companion app you can connect to anywhere so far does everything i ever needed chatgpt for! &amp;#32; submitted by &amp;#32; ufineclassroom2085 [link] &amp;#32; [comments] openai gemma" data-cats="apple-silicon">
+<div class="cr-card" data-search="tomte super fast harness for gemma 4 i think people are sleeping on gemma and local models so i built a free, very fast harness for gemma 4 that i call tomte works on macs with m processors, will have a companion app you can connect to anywhere so far does everything i ever needed chatgpt for! submitted by ufineclassroom2085 [link] [comments] openai gemma" data-cats="apple-silicon">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vcq2gi" target="_blank" rel="noopener">Tomte - super fast harness for Gemma 4</a></h4>
@@ -13884,7 +13884,7 @@
   <p class="cr-summary">EDIT: To make this clear, this benchmark was done to see the capabilities of models that can be run on my (and many others here) 128GB RAM system. It's NOT intended as a comparison of the absolute capabilities of the models. Read the Setup section fo...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1vfhqkm" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
-<div class="cr-card" data-search="gemma 4 on 500mb &amp;#32; submitted by &amp;#32; ujacek2023 [link] &amp;#32; [comments] gemma" data-cats="general">
+<div class="cr-card" data-search="gemma 4 on 500mb submitted by ujacek2023 [link] [comments] gemma" data-cats="general">
   <div class="cr-card-header">
     <div class="cr-title-row">
       <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vfeick" target="_blank" rel="noopener">Gemma 4 on 500MB</a></h4>
@@ -13897,7 +13897,7 @@
       <span class="cr-cat-badge">General</span>
     </div>
   </div>
-  <p class="cr-summary">&amp;#32; submitted by &amp;#32; /u/jacek2023 [link] &amp;#32; [comments]</p>
+  <p class="cr-summary">submitted by /u/jacek2023 [link] [comments]</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1vfeick" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="gemma4 26b qat double calling tools? just something i've noticed in my harnesses it likes to call tools twice i'm wondering if anyone has noticed anything similar with it, and if so, what they've been able to do about it? i have my harnesses setup to preserve reasoning between toolcalls so it doesn't need to rereason about anything, but i'm not sure if gemma4 was ever trained to be able to handle that, and if so, it would lead to… inference metallama" data-cats="general">


### PR DESCRIPTION
## Problem

Reddit serves some characters **pre-escaped as HTML entities** inside the post markdown archived under `knowledge/reddit/localllama/posts/`. A submission footer arrives as the literal character sequence:

```
&#32; submitted by &#32; /u/jacek2023 [link] &#32; [comments]
```

`clean_markdown()` passed that through untouched and `html_escape()` then escaped the ampersand a second time, so the browser received `&amp;#32;` and painted the characters `&#32;` in the middle of a sentence. Post `1vfeick` ("Gemma 4 on 500MB") is the clearest single case: its entire card body was that footer.

This is the same **ordering** defect as the pre-escaped-underscore search bug in #358, where the markdown emphasis rule ran before the escape strip. In both cases the generator applies its own transformation before normalizing what upstream already escaped. The fix has the same shape: unescape first, then transform.

## Fixes

**1. Upstream entity decode (the reported defect).** New `unescape_upstream_entities()` decodes only well-formed, semicolon-terminated entities. `html.unescape()` is deliberately **not** used: its legacy bare-name matching rewrites `&notarealentity;` to a not-sign plus `arealentity;` and turns `2 &times 3090s` into a multiplication sign, which would corrupt ordinary prose that merely contains an ampersand. (That is not hypothetical, it was caught by a test in this PR.) Numeric references to control characters are left encoded.

Ordering matters twice over. It runs as the **first** step of `clean_markdown()`, before `normalize_typographic_dashes()`, so a decoded `&mdash;` is still a real em dash when it reaches the dash normalizer instead of smuggling one onto the page. It also runs on the title and flair paths, which skip `clean_markdown()` entirely and carried `&amp;` in three archived titles.

This **also covers** the `&lt;turn|&gt;` and `&lt;|channel&gt;` harmony markers visible in some comment bodies, which the task asked about: same root cause, same fix, they now render as the angle-bracketed tokens they denote rather than as literal entity text.

**2. A second, distinct defect with the same reader-visible symptom.** Found while verifying the first. `render_field_notes_markdown()`'s `render_inline()` escapes the whole line, then `link_sub()` escaped the captured label **again**, so a Sources entry whose Reddit title carries a plain ASCII quote shipped as `&amp;quot;` and printed `&quot;` on the page. Nothing upstream is pre-escaped here, the generator escaped its own output twice, and the same bug silently corrupted any URL query string (`?x=1&y=2` became `?x=1&amp;amp;y=2` in the href). Only the two angle brackets the caller temporarily decodes are put back now.

Isolated repro at base:

```
$ render_field_notes_markdown('- [My local AI developed an "attitude"](https://reddit.com/...)')
<li><a ...>My local AI developed an &amp;quot;attitude&amp;quot;</a> ...
```

## Result

Every double-escaped entity in `site/community.html` is gone:

| token | before | after |
|---|---|---|
| `&amp;#32;` | 388 | **0** |
| `&amp;gt;` | 55 | 0 |
| `&amp;amp;` | 28 | 0 |
| `&amp;quot;` | 24 | 0 |
| `&amp;lt;` | 10 | 0 |
| `&amp;#x200b;` | 7 | 0 |

## No other card text changed

- Card count holds at **600**; total line count unchanged at **14052**; 226 insertions / 226 deletions.
- Field-level census across all 600 cards: `data-cats`, score, author, date, flair, category badges, source link, title href and comment count are **byte-identical**.
- Every differing field is either identical after entity decoding, or a truncation-boundary shift, because the 250 and 200 character display budgets are no longer spent on entity text (a card that previously ended `... [...` now ends `... [comments...`).
- Field-notes region: 16 changed lines, **0** that differ by anything other than entity encoding; `<a href>` count 1374 before and after.
- Only `site/community.html` is regenerated; re-running the generator changes no other page.

## Tests

13 regression tests added, **proven capable of failing**. Run against the generator at `f8808c01cc` (base) with the same test file, 12 of the 13 fail:

```
12 failed, 1 passed, 31 deselected
```

The thirteenth (`test_angle_brackets_in_a_label_stay_escaped`) guards against a regression the fix itself could introduce and passes on both sides by design.

Against the fix: **44 passed**.

## Verification

- `python3 -m pytest scripts/site/test_generate_site.py` -> 44 passed
- `bash scripts/site/check-site-quality.sh` -> ALL CHECKS PASSED, exit 0
- `pnpm check:changed` -> exit 0 (oxlint 0 warnings, 0 errors, 251 files)
- `pnpm test:changed` -> exit 0 (no changed vitest targets)
- `grep -c '&amp;#32;' site/community.html` -> **0**

### Dash gate

`check-no-typographic-dashes.sh --diff-added f8808c01cc` exits **1** with 11 hits, all in `site/community.html` field-notes prose. This is the documented renderer-change false-fail. Two independent proofs:

1. `site/data/field-notes.md` is **byte-identical** to the base (`git diff --quiet` passes) and its whole-file dash count is **1221 before and 1221 after**.
2. Per hit: each flagged line already exists verbatim in the base `site/community.html` once entities are decoded, and every dash-bearing window traces into `git show f8808c01cc:site/data/field-notes.md`.

A fabricated new em-dash sentence run through the same attribution method does **not** trace and is correctly flagged, so the method is not vacuous. Zero authored dashes were added. All 11 hits come from the field-notes fix; the community-card fix contributes none, because `normalize_typographic_dashes()` already ASCII-maps card text.

### CI baseline

Site-only PRs inherit 8 chronic openclaw-fork failures that fail on `main` regardless of the change. **Deploy Site** is the check that gates a site change and must be green.
