### PR TITLE
site: Gemma4 research findings update (2026-08-14)

### DIFF
--- a/site/community.html
+++ b/site/community.html
@@ -1845,7 +1845,42 @@
     <section id="community-page">
       <h2>Community & Hardware Reports</h2>
       <p>Real-world experiences running Gemma models, curated from the community. Browse hardware reports, read the weekly field notes, or search for your setup.</p>
-      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes - 2026-08-13</h2>
+      <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes - 2026-08-14</h2>
+<p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (5 new Gemma 4 posts from the August 14, 2026 ingest, 644 community index entries total) and their threads. Confidence is <strong>moderate</strong> for quantization tuning potential but <strong>low</strong> for generalized agentic performance on Gemma 4 31B. This five-post cycle highlights task-aware quantization gains and struggles with multi-turn autonomous coding. On the quantization front, one user reported that reallocating a fixed bit budget at the tensor level above the quantization cliff recovered 8.55 percent relative coding performance on a custom Gemma 4 12B Q3 imatrix, though at the expected cost of degradation in other categories. Meanwhile, Gemma 4 31B QAT remains a strong daily driver for natural language tasks, with one user preferring it over Muse Glimmer 30B. However, for autonomous agentic coding, a user with a triple-RTX 5060 Ti setup running Gemma 4 31B reported that the model fails to understand the agent framework, contrasting with other models that panic or loop. <strong>No hardware tier recommendations change on measured grounds this cycle.</strong></p>
+<p><em>August 14 sweep, 2026-08-14 00:00 UTC:</em> a <strong>five-post cycle focusing on task-aware quantization and multi-GPU agent setups</strong>. The ingest surfaced <strong>five Gemma-mentioning entries dated August 13</strong>, taking the community index from <strong>639 to 644</strong>. The categoriser places four posts in <strong>Quantization &amp; Backends</strong> (one of which also falls under <strong>High-end GPU (24+ GB)</strong> and <strong>Mid-range GPU (8-16 GB)</strong>), and one in <strong>Mid-range GPU (8-16 GB)</strong>. The cycle documents a proof-of-concept for tensor-level quantization allocation on Gemma 4 12B Q3 yielding an 8.55 percent coding score uplift on a hand-tuned imatrix, and hardware reports covering single RTX 5090, dual RTX 5060 Ti, and triple RTX 5060 Ti setups. The triple 5060 Ti rig self-reports 70 to 110 tok/s (the author notes this is unconfirmed and read off the pi agent web UI while running several models), yet that same report still describes friction running Gemma 4 31B under a multi-turn autonomous coding framework. <strong>No Apple Silicon, laptop, integrated-graphics, single-GPU, CPU-only, Raspberry-Pi-class, or enterprise and cloud tier guidance changes.</strong> All five entries are <strong>single-author, placeholder-score (20) and zero-comment</strong>, and <strong>carry archived body text</strong>.</p>
+<h3>Best current setup (this cycle's additions)</h3>
+<ul class="setup-list">
+<li><strong>No tier recommendation changes on measured grounds.</strong> The hardware posts in this cycle are configuration questions and anecdotal agentic reports, so core hardware picks remain based on earlier sweeps.</li>
+</ul>
+<h3>What works</h3>
+<ul class="setup-list">
+<li><strong>Tensor-level precision reallocation above the quantization cliff can recover task-specific performance.</strong> Shifting bits to the most damaged tensors under a fixed budget improved a Gemma 4 12B Q3 coding score by 8.55 percent (45.974 to 49.905) without a meaningful size increase (+0.119 percent) (<a href="https://reddit.com/r/localllama/comments/1vnltec" target="_blank" rel="noopener">1vnltec</a>).</li>
+<li><strong>Gemma 4 31B QAT remains a preferred daily driver for natural language.</strong> A user comparing it against Muse Glimmer 30B reported keeping Gemma 4 31B QAT as the go-to model for day-to-day tasks like websearch, QA, summarization, and translation (<a href="https://reddit.com/r/localllama/comments/1vn20yw" target="_blank" rel="noopener">1vn20yw</a>).</li>
+<li><strong>Dual RTX 5060 Ti 16GB setups can fit 128k context windows for 30B-class models.</strong> Using BF16 with dflash-kquant allows large contexts to fit comfortably across 32 GB of distributed VRAM (<a href="https://reddit.com/r/localllama/comments/1vn20yw" target="_blank" rel="noopener">1vn20yw</a>).</li>
+<li><strong>Mini-PCs can serve 26B MoE models with large contexts.</strong> A NucBox K8 Plus home server was reported running Gemma 4 26B A4B IT QAT at Q4_K_XL with a 131k context window (<a href="https://reddit.com/r/localllama/comments/1vndaih" target="_blank" rel="noopener">1vndaih</a>).</li>
+</ul>
+<h3>Known limits</h3>
+<ul class="setup-list">
+<li><strong>Gemma 4 31B struggles with autonomous agent coding frameworks.</strong> A user running it on a triple RTX 5060 Ti setup reported that the model does not understand the agent framework during autonomous sketching, failing to build working code (<a href="https://reddit.com/r/localllama/comments/1vn5y7p" target="_blank" rel="noopener">1vn5y7p</a>).</li>
+<li><strong>Category-specialized quantization causes degradation elsewhere.</strong> Reallocating bits for coding performance damages capabilities in categories that were not selected for the imatrix tuning (<a href="https://reddit.com/r/localllama/comments/1vnltec" target="_blank" rel="noopener">1vnltec</a>).</li>
+<li><strong>All five posts in this cycle are single-author and placeholder-score (20) with zero comments.</strong> None of the reports carry community verification threads yet (<a href="https://reddit.com/r/localllama/comments/1vndaih" target="_blank" rel="noopener">1vndaih</a>, <a href="https://reddit.com/r/localllama/comments/1vnltec" target="_blank" rel="noopener">1vnltec</a>, <a href="https://reddit.com/r/localllama/comments/1vn5s3o" target="_blank" rel="noopener">1vn5s3o</a>, <a href="https://reddit.com/r/localllama/comments/1vn20yw" target="_blank" rel="noopener">1vn20yw</a>, <a href="https://reddit.com/r/localllama/comments/1vn5y7p" target="_blank" rel="noopener">1vn5y7p</a>).</li>
+</ul>
+<h3>Open questions</h3>
+<ul class="setup-list">
+<li><strong>How much performance drops in non-coding categories when tuning an imatrix specifically for code on Gemma 4 12B Q3?</strong> The degradation is expected but unmeasured in the report (<a href="https://reddit.com/r/localllama/comments/1vnltec" target="_blank" rel="noopener">1vnltec</a>).</li>
+<li><strong>Will the new ggml-cpu/ops F16 to F32 conversion vectorization improve Gemma 4 prompt processing?</strong> The PR brings 17-31 percent gains for Qwen3 4B via F16C intrinsics, but Gemma 4 models remain unmeasured (<a href="https://reddit.com/r/localllama/comments/1vn5s3o" target="_blank" rel="noopener">1vn5s3o</a>).</li>
+</ul>
+<h3>Sources</h3>
+<p>The five Gemma-mentioning posts driving this update (August 14 sweep). <strong>All five are placeholder-score (20), zero-comment and carry archived body text</strong>:</p>
+<ul class="setup-list">
+<li><a href="https://reddit.com/r/localllama/comments/1vndaih" target="_blank" rel="noopener">5090 alone or 5090 and 4070Ti Super ?</a> (Aug 13, 2026, u/Fz1zz. Hardware configuration query detailing an RTX 5090 setup for Qwen and a NucBox K8 Plus home server running Gemma 4 26B A4B IT QAT at Q4_K_XL with a 131k context window. Categorised High-end GPU (24+ GB), Mid-range GPU (8-16 GB), Quantization and Backends)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1vnltec" target="_blank" rel="noopener">Gemma 4 12B Q3: +8.55% Coding Performance From Tensor-Level Quantization Allocation</a> (Aug 13, 2026, u/devildip. A proof-of-concept report on task-aware GGUF quantization. The author generated a custom imatrix for Gemma 4 12B Q3 and reallocated the bit budget at the tensor level to recover precision for coding tasks. Claims an 8.55 percent relative coding score improvement (45.974 to 49.905) with a 0.119 percent size increase (5.528 GB to 5.535 GB). Categorised Quantization and Backends)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1vn5s3o" target="_blank" rel="noopener">ggml-cpu/ops: vectorize flash-attention V-cache F16 to F32 conversion by jinzihao · Pull Request #26947 · ggml-org/llama.cpp</a> (Aug 13, 2026, u/pmttyji. Notes a llama.cpp PR that leverages hardware F16C intrinsics for V-cache conversion, improving prompt processing by 17 to 31 percent for small Qwen models, and asks for Gemma 4 benchmarks. Categorised Quantization and Backends)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1vn20yw" target="_blank" rel="noopener">Interesting uses for Muse Glimmer 30B?</a> (Aug 13, 2026, u/Kahvana. Comparative evaluation noting that Gemma 4 31B QAT remains the author's preferred model for day-to-day natural language tasks over Muse Glimmer 30B. Mentions running 128k context BF16 with dflash-kquant on dual RTX 5060 Ti 16GB GPUs. Categorised Quantization and Backends)</li>
+<li><a href="https://reddit.com/r/localllama/comments/1vn5y7p" target="_blank" rel="noopener">Local autonomous coding agent?</a> (Aug 13, 2026, u/Ejo2001. A user running a triple RTX 5060 Ti 16GB setup reports a self-measured, unconfirmed 70 to 110 tok/s across the models tried, and says Gemma 4 31B in particular fails to understand the autonomous agent framework to write code. Categorised Mid-range GPU (8-16 GB))</li>
+</ul>
+<p><em>Last updated: 2026-08-14 (August 14 sweep). Confidence: moderate for quantization tuning potential but low for generalized agentic performance on Gemma 4 31B, on a five-post cycle documenting task-aware quantization gains, hardware setups, and friction with multi-turn autonomous coding. Key finding: reallocating a fixed bit budget toward the most damaged tensors on a custom imatrix recovered 8.55 percent relative coding performance on Gemma 4 12B Q3, with less than 0.2 percent size bloat, at the cost of expected degradation in other capabilities. Meanwhile, on a triple RTX 5060 Ti rig whose owner self-reports an unconfirmed 70 to 110 tok/s across several models, Gemma 4 31B was reported to fail at understanding autonomous agent frameworks. No Apple Silicon, laptop, integrated-graphics, single-GPU, CPU-only, Raspberry-Pi-class, or enterprise and cloud tier guidance changes. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p>
+<h2>Field Notes - 2026-08-13</h2>
 <p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma-mentioning posts (5 new Gemma 4 posts from the August 13, 2026 ingest, 639 community index entries total) and their threads. Confidence is <strong>moderate for KV cache quantization benefits on QAT models</strong>, and <strong>low to moderate for real-world hardware throughput on consumer setups</strong>. This cycle adds two concrete throughput measurements and one comprehensive KV cache quantization benchmark across Gemma 4 models. The headline finding comes from a benchmark comparing KV cache quantization on Gemma 4 31B Q4_0 QAT versus non-QAT under BeeLlama.cpp v0.4.3. The benchmark reveals that QAT models handle aggressive KV cache quantization significantly better than standard non-QAT GGUF quants: q8_0 KV quantization on QAT achieves a 0.015078 mean KL divergence (a 20.3x reduction in loss compared to 0.305575 on non-QAT) and 94.870% same-top token agreement (+9.755 percentage points over non-QAT). Even under q4_0 KV quantization, QAT maintains 86.337% same-top agreement (+14.707 percentage points over 71.630% on non-QAT), confirming that QAT fine-tuning preserves attention head structure under low-bit KV caches. On hardware, an entry-level laptop user reports running Gemma 4 e2b Q6 at ~30 tok/s with a 100k+ context window on an old system with 8 GB RAM and 4 GB VRAM, showing that lightweight Gemma 4 variants remain highly accessible on legacy hardware. Conversely, a Radeon RX 7900 XT user reports surprisingly low generation speed (~14 tok/s) when running Gemma 4 26BA4B IQ3_xxs with a 131k context window and q8_0/q5_1 KV cache quantization in LM Studio on Windows, highlighting ongoing driver and runtime bottlenecks on AMD GPU setups. Finally, an agent analysis demonstrates that Model Context Protocol (MCP) tool execution adds multi-turn token and latency overhead compared to native shell command chaining when running local agent workflows. <strong>No hardware tier recommendations change on measured grounds this cycle.</strong></p>
 <p><em>August 13 sweep, 2026-08-13 00:00 UTC:</em> a <strong>five-post cycle with two throughput measurements and one KV cache quantization benchmark</strong>. The ingest surfaced <strong>five Gemma-mentioning entries, all five dated August 12</strong>, taking the community index from <strong>634 to 639</strong>. Four of the five posts are by <strong>four different authors</strong>, while one author (u/KitchenAmoeba4438) contributed a second analysis in consecutive sweeps following their MTP benchmark in yesterday's ingest. The categoriser reaches a machine-shaped category for <strong>three of the five</strong>: <strong>two land in Quantization and Backends</strong> on the quants and runtimes they test, <strong>one lands in Laptops</strong> on the 4 GB VRAM laptop report it details, and <strong>two fall to Other</strong>, correctly, because neither names a specific hardware tier. Walking the five in order of how much a reader can act on: the <strong>first</strong> is the <strong>Gemma 4 31B QAT versus non-QAT KV cache quantization benchmark</strong>, which provides precise KL divergence metrics across six KV cache quantization levels under BeeLlama.cpp v0.4.3. The <strong>second</strong> is the <strong>low-resource laptop hands-on report</strong>, which measures Gemma 4 e2b Q6 generating ~30 tok/s with over 100k context on 4 GB VRAM and 8 GB RAM. The <strong>third</strong> is the <strong>Radeon RX 7900 XT troubleshooting report</strong>, which details slow ~14 tok/s generation on Gemma 4 26BA4B IQ3_xxs with a 131k context window under LM Studio on Windows. The <strong>fourth</strong> is the <strong>Model Context Protocol overhead analysis</strong>, which compares sequential MCP tool loops against batched shell command chaining across local models including Gemma 4. The <strong>fifth</strong> is a <strong>community discussion query on optimal models for 16 GB RAM machines</strong>, which highlights Gemma 4 e4b and e2b as top choices for resource-constrained daily drivers. That is the whole cycle: <strong>five posts, one KV cache quantization benchmark, two hardware throughput reports, one agent protocol analysis, and one machine sizing query</strong>. <strong>No Apple Silicon, laptop, integrated-graphics, mid-range GPU, single-GPU, multi-GPU, CPU-only, Raspberry-Pi-class, or enterprise and cloud tier guidance changes.</strong> All five entries are <strong>single-author, placeholder-score (20) and zero-comment</strong>, and <strong>all five carry archived body text</strong>.</p>
 <h3>Best current setup (this cycle's additions)</h3>
@@ -4627,10 +4662,10 @@
 <p>The full set of 266 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
 <p><em>Last updated: 2026-06-13 (June 13 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
       <div class="community-section" id="community">
-      <h3>Community Reports (639 from r/LocalLLaMA)</h3>
+      <h3>Community Reports (644 from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>
       <div class="search-bar"><input type="search" id="community-search" aria-label="Search community reports" placeholder="Search community reports..." autocomplete="off"></div>
-      <div class="cat-filter-bar" role="group" aria-label="Filter community reports by hardware category"><button type="button" class="cat-filter-btn active" data-cat="all" aria-pressed="true">All</button><button type="button" class="cat-filter-btn" data-cat="apple-silicon" aria-pressed="false">Apple Silicon (94)</button><button type="button" class="cat-filter-btn" data-cat="high-gpu" aria-pressed="false">High-end GPU (24+ GB) (72)</button><button type="button" class="cat-filter-btn" data-cat="mid-gpu" aria-pressed="false">Mid-range GPU (8-16 GB) (37)</button><button type="button" class="cat-filter-btn" data-cat="cpu-only" aria-pressed="false">CPU / Raspberry Pi (20)</button><button type="button" class="cat-filter-btn" data-cat="laptop" aria-pressed="false">Laptops (38)</button><button type="button" class="cat-filter-btn" data-cat="quantization" aria-pressed="false">Quantization &amp; Backends (371)</button><button type="button" class="cat-filter-btn" data-cat="general" aria-pressed="false">Other (191)</button></div>
+      <div class="cat-filter-bar" role="group" aria-label="Filter community reports by hardware category"><button type="button" class="cat-filter-btn active" data-cat="all" aria-pressed="true">All</button><button type="button" class="cat-filter-btn" data-cat="apple-silicon" aria-pressed="false">Apple Silicon (94)</button><button type="button" class="cat-filter-btn" data-cat="high-gpu" aria-pressed="false">High-end GPU (24+ GB) (73)</button><button type="button" class="cat-filter-btn" data-cat="mid-gpu" aria-pressed="false">Mid-range GPU (8-16 GB) (39)</button><button type="button" class="cat-filter-btn" data-cat="cpu-only" aria-pressed="false">CPU / Raspberry Pi (20)</button><button type="button" class="cat-filter-btn" data-cat="laptop" aria-pressed="false">Laptops (38)</button><button type="button" class="cat-filter-btn" data-cat="quantization" aria-pressed="false">Quantization &amp; Backends (375)</button><button type="button" class="cat-filter-btn" data-cat="general" aria-pressed="false">Other (191)</button></div>
 <div id="community-cards"><div class="cr-card" data-search="gemma 4 has been released [ quantization agents anthropic google gemma google is going to show what open weights is about happy easter everyone gemma4 has native thinking, tool calling and is multimodal! use temperature = 10, topp = and after a week maybe : &quot;gemma 4 26b heretic uncensored ablated claude opus 46 reasoning distlled" data-cats="quantization">
   <div class="cr-card-header">
     <div class="cr-title-row">
@@ -14967,6 +15002,86 @@
   </div>
   <p class="cr-summary">Using LM Studio on Windows with 131k context length with kv cache quantised to q8_0 and q5_1, no MTP. It should all fit into vram but the results are very weirdly slow for some reason. Does anyone have any ideas for improvements? Windows could be the...</p>
   <a href="https://reddit.com/r/LocalLLaMA/comments/1vmnj9q" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="5090 alone or 5090 and 4070ti super ? ever since i got the 5090 the 4070 ti super has been collecting dust on the shelf here’s the model + flags i’m currently running on the 5090: llamaserver model qwen3627budq5kxlgguf mmproj mmprojf16gguf ngpulayers all ctxsize 163840 parallel 1 flashattn on cachetypek q80 cachetypev q80 spectype draftmtp specdraftnmax 2 minp 0 imagemintokens 1024… hardware quantization metallama gemma" data-cats="high-gpu mid-gpu quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vndaih" target="_blank" rel="noopener">5090 alone or 5090 and 4070Ti Super ?</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/Fz1zz</span>
+      <span class="cr-date">2026-08-13</span>
+
+      <span class="cr-cat-badge">High-end GPU (24+ GB)</span><span class="cr-cat-badge">Mid-range GPU (8-16 GB)</span><span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Ever since I got the 5090 the 4070 Ti Super has been collecting dust on the shelf. Here’s the model + flags I’m currently running on the 5090: llama-server --model Qwen3.6-27B-UD-Q5_K_XL.gguf --mmproj mmproj-F16.gguf --n-gpu-layers all --ctx-size 163...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1vndaih" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="gemma 4 12b q3: +855% coding performance from tensorlevel quantization allocation ive been experimenting with taskaware gguf quants for months, taking inspiration from tasa and taqo but pushing the allocation lower to to the tensor level the basic idea is to generate a custom imatrix from a categoryspecific corpus, measure where quantization causes damage, then redistribute a fixed bit budget toward tensors where additional precision recovers the best performance in that ca… quantization openai " data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vnltec" target="_blank" rel="noopener">Gemma 4 12B Q3: +8.55% Coding Performance From Tensor-Level Quantization Allocation</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/devildip</span>
+      <span class="cr-date">2026-08-13</span>
+
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Ive been experimenting with task-aware GGUF quants for months, taking inspiration from TASA and TAQO but pushing the allocation lower to to the tensor level. The basic idea is to generate a custom imatrix from a category-specific corpus, measure wher...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1vnltec" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="ggmlcpuops: vectorize flashattention vcache f16 to f32 conversion by jinzihao · pull request #26947 · ggmlorgllamacpp overview ggmlcpufp16tofp32 leverages hardware f16c intrinsics (avx512, avx2, etc), faster than the softwareonly ggmlfp16tofp32row , bringing 1731% gain in prompt processing rate for a smaller model like qwen3:4b wish the pr had few additional models(recent ones like qwen3536 &amp; gemma4 models) with ts stats submitted by upmttyji [link] [comments] quantization inference metallam" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vn5s3o" target="_blank" rel="noopener">ggml-cpu/ops: vectorize flash-attention V-cache F16 to F32 conversion by jinzihao · Pull Request #26947 · ggml-org/llama</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/pmttyji</span>
+      <span class="cr-date">2026-08-13</span>
+
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Overview ggml_cpu_fp16_to_fp32 leverages hardware F16C intrinsics (AVX-512, AVX2, etc.), faster than the software-only ggml_fp16_to_fp32_row , bringing 17-31% gain in prompt processing rate for a smaller model like qwen3:4b. Wish the PR had few addit...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1vn5s3o" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="interesting uses for muse glimmer 30b? hey everyone, nonnative speaker, writing my post by hand, let me know if i make mistakes (can only learn from it!) muse glimmer 30b is so far quite nice, but i haven't found a clearcut case yet what i can use it for over gemma 4 31b qat (my goto model) or qwen36 27b i really appreciate that they have openai style toggable reasoning effort like gptoss 20b has i don't like the caveman speak… hardware quantization openai mistral gemma" data-cats="quantization">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vn20yw" target="_blank" rel="noopener">Interesting uses for Muse Glimmer 30B?</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/Kahvana</span>
+      <span class="cr-date">2026-08-13</span>
+
+      <span class="cr-cat-badge">Quantization &amp; Backends</span>
+    </div>
+  </div>
+  <p class="cr-summary">Hey everyone, Non-native speaker, writing my post by hand, let me know if I make mistakes (can only learn from it!) Muse Glimmer 30B is so far quite nice, but I haven't found a clear-cut case yet what I can use it for over Gemma 4 31B QAT (my go-to m...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1vn20yw" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
+</div>
+<div class="cr-card" data-search="local autonomous coding agent? hello! i have recently built my ai rig (3x rtx 5060 ti 16gb, with possibly a 4th on the way if i can fit it) i love it, it runs great, and i am getting between 70ts 110 ts (according to the pi agent web ui, have not confirmed it yet) while it is fast, i struggle to put it to use in the way i was hoping my dream has been to be able to put it to work writing code autonomously so that i can h… hardware agents qwen gemma" data-cats="mid-gpu">
+  <div class="cr-card-header">
+    <div class="cr-title-row">
+      <h4 class="cr-title"><a href="https://reddit.com/r/LocalLLaMA/comments/1vn5y7p" target="_blank" rel="noopener">Local autonomous coding agent?</a></h4>
+      <span class="cr-score ">+20</span>
+    </div>
+    <div class="cr-meta">
+      <span class="cr-author">u/Ejo2001</span>
+      <span class="cr-date">2026-08-13</span>
+
+      <span class="cr-cat-badge">Mid-range GPU (8-16 GB)</span>
+    </div>
+  </div>
+  <p class="cr-summary">Hello! I have recently built my AI rig (3x RTX 5060 Ti 16gb, with possibly a 4th on the way if I can fit it). I love it, it runs great, and I am getting between 70t/s - 110 t/s (according to the pi agent web UI, have not confirmed it yet). While it i...</p>
+  <a href="https://reddit.com/r/LocalLLaMA/comments/1vn5y7p" class="cr-source" target="_blank" rel="noopener">View full discussion on r/LocalLLaMA</a>
 </div>
 <div class="cr-card" data-search="anyone tried + 100b models locally with foreign languages? community discussion comparing gemma 4 31b, qwen 36 27b, and glm 47 30b on nonenglish (primarily european) languages original poster reports gemma 4 31b as the best at czech, noting it &quot;blows their mind&quot; at 18gb key community finding: gemma 4 31b (16bit) is reported as &quot;extremely good in hungarian&quot; while the 26b 8bit variant shows some &quot;slightly chinese&quot; output contamination expert commenter concludes gemma " data-cats="high-gpu quantization">
   <div class="cr-card-header">

--- a/site/data/field-notes.md
+++ b/site/data/field-notes.md
@@ -1,3 +1,45 @@
+## Field Notes - 2026-08-14
+
+A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.
+Curated from the latest Gemma-mentioning posts (5 new Gemma 4 posts from the August 14, 2026 ingest, 644 community index entries total) and their threads.
+Confidence is **moderate** for quantization tuning potential but **low** for generalized agentic performance on Gemma 4 31B. This five-post cycle highlights task-aware quantization gains and struggles with multi-turn autonomous coding. On the quantization front, one user reported that reallocating a fixed bit budget at the tensor level above the quantization cliff recovered 8.55 percent relative coding performance on a custom Gemma 4 12B Q3 imatrix, though at the expected cost of degradation in other categories. Meanwhile, Gemma 4 31B QAT remains a strong daily driver for natural language tasks, with one user preferring it over Muse Glimmer 30B. However, for autonomous agentic coding, a user with a triple-RTX 5060 Ti setup running Gemma 4 31B reported that the model fails to understand the agent framework, contrasting with other models that panic or loop. **No hardware tier recommendations change on measured grounds this cycle.**
+
+_August 14 sweep, 2026-08-14 00:00 UTC:_ a **five-post cycle focusing on task-aware quantization and multi-GPU agent setups**. The ingest surfaced **five Gemma-mentioning entries dated August 13**, taking the community index from **639 to 644**. The categoriser places four posts in **Quantization & Backends** (one of which also falls under **High-end GPU (24+ GB)** and **Mid-range GPU (8-16 GB)**), and one in **Mid-range GPU (8-16 GB)**. The cycle documents a proof-of-concept for tensor-level quantization allocation on Gemma 4 12B Q3 yielding an 8.55 percent coding score uplift on a hand-tuned imatrix, and hardware reports covering single RTX 5090, dual RTX 5060 Ti, and triple RTX 5060 Ti setups. The triple 5060 Ti rig self-reports 70 to 110 tok/s (the author notes this is unconfirmed and read off the pi agent web UI while running several models), yet that same report still describes friction running Gemma 4 31B under a multi-turn autonomous coding framework. **No Apple Silicon, laptop, integrated-graphics, single-GPU, CPU-only, Raspberry-Pi-class, or enterprise and cloud tier guidance changes.** All five entries are **single-author, placeholder-score (20) and zero-comment**, and **carry archived body text**.
+
+### Best current setup (this cycle's additions)
+
+- **No tier recommendation changes on measured grounds.** The hardware posts in this cycle are configuration questions and anecdotal agentic reports, so core hardware picks remain based on earlier sweeps.
+
+### What works
+
+- **Tensor-level precision reallocation above the quantization cliff can recover task-specific performance.** Shifting bits to the most damaged tensors under a fixed budget improved a Gemma 4 12B Q3 coding score by 8.55 percent (45.974 to 49.905) without a meaningful size increase (+0.119 percent) ([1vnltec](https://reddit.com/r/localllama/comments/1vnltec)).
+- **Gemma 4 31B QAT remains a preferred daily driver for natural language.** A user comparing it against Muse Glimmer 30B reported keeping Gemma 4 31B QAT as the go-to model for day-to-day tasks like websearch, QA, summarization, and translation ([1vn20yw](https://reddit.com/r/localllama/comments/1vn20yw)).
+- **Dual RTX 5060 Ti 16GB setups can fit 128k context windows for 30B-class models.** Using BF16 with dflash-kquant allows large contexts to fit comfortably across 32 GB of distributed VRAM ([1vn20yw](https://reddit.com/r/localllama/comments/1vn20yw)).
+- **Mini-PCs can serve 26B MoE models with large contexts.** A NucBox K8 Plus home server was reported running Gemma 4 26B A4B IT QAT at Q4_K_XL with a 131k context window ([1vndaih](https://reddit.com/r/localllama/comments/1vndaih)).
+
+### Known limits
+
+- **Gemma 4 31B struggles with autonomous agent coding frameworks.** A user running it on a triple RTX 5060 Ti setup reported that the model does not understand the agent framework during autonomous sketching, failing to build working code ([1vn5y7p](https://reddit.com/r/localllama/comments/1vn5y7p)).
+- **Category-specialized quantization causes degradation elsewhere.** Reallocating bits for coding performance damages capabilities in categories that were not selected for the imatrix tuning ([1vnltec](https://reddit.com/r/localllama/comments/1vnltec)).
+- **All five posts in this cycle are single-author and placeholder-score (20) with zero comments.** None of the reports carry community verification threads yet ([1vndaih](https://reddit.com/r/localllama/comments/1vndaih), [1vnltec](https://reddit.com/r/localllama/comments/1vnltec), [1vn5s3o](https://reddit.com/r/localllama/comments/1vn5s3o), [1vn20yw](https://reddit.com/r/localllama/comments/1vn20yw), [1vn5y7p](https://reddit.com/r/localllama/comments/1vn5y7p)).
+
+### Open questions
+
+- **How much performance drops in non-coding categories when tuning an imatrix specifically for code on Gemma 4 12B Q3?** The degradation is expected but unmeasured in the report ([1vnltec](https://reddit.com/r/localllama/comments/1vnltec)).
+- **Will the new ggml-cpu/ops F16 to F32 conversion vectorization improve Gemma 4 prompt processing?** The PR brings 17-31 percent gains for Qwen3 4B via F16C intrinsics, but Gemma 4 models remain unmeasured ([1vn5s3o](https://reddit.com/r/localllama/comments/1vn5s3o)).
+
+### Sources
+
+The five Gemma-mentioning posts driving this update (August 14 sweep). **All five are placeholder-score (20), zero-comment and carry archived body text**:
+
+- [5090 alone or 5090 and 4070Ti Super ?](https://reddit.com/r/localllama/comments/1vndaih) (Aug 13, 2026, u/Fz1zz. Hardware configuration query detailing an RTX 5090 setup for Qwen and a NucBox K8 Plus home server running Gemma 4 26B A4B IT QAT at Q4_K_XL with a 131k context window. Categorised High-end GPU (24+ GB), Mid-range GPU (8-16 GB), Quantization and Backends)
+- [Gemma 4 12B Q3: +8.55% Coding Performance From Tensor-Level Quantization Allocation](https://reddit.com/r/localllama/comments/1vnltec) (Aug 13, 2026, u/devildip. A proof-of-concept report on task-aware GGUF quantization. The author generated a custom imatrix for Gemma 4 12B Q3 and reallocated the bit budget at the tensor level to recover precision for coding tasks. Claims an 8.55 percent relative coding score improvement (45.974 to 49.905) with a 0.119 percent size increase (5.528 GB to 5.535 GB). Categorised Quantization and Backends)
+- [ggml-cpu/ops: vectorize flash-attention V-cache F16 to F32 conversion by jinzihao · Pull Request #26947 · ggml-org/llama.cpp](https://reddit.com/r/localllama/comments/1vn5s3o) (Aug 13, 2026, u/pmttyji. Notes a llama.cpp PR that leverages hardware F16C intrinsics for V-cache conversion, improving prompt processing by 17 to 31 percent for small Qwen models, and asks for Gemma 4 benchmarks. Categorised Quantization and Backends)
+- [Interesting uses for Muse Glimmer 30B?](https://reddit.com/r/localllama/comments/1vn20yw) (Aug 13, 2026, u/Kahvana. Comparative evaluation noting that Gemma 4 31B QAT remains the author's preferred model for day-to-day natural language tasks over Muse Glimmer 30B. Mentions running 128k context BF16 with dflash-kquant on dual RTX 5060 Ti 16GB GPUs. Categorised Quantization and Backends)
+- [Local autonomous coding agent?](https://reddit.com/r/localllama/comments/1vn5y7p) (Aug 13, 2026, u/Ejo2001. A user running a triple RTX 5060 Ti 16GB setup reports a self-measured, unconfirmed 70 to 110 tok/s across the models tried, and says Gemma 4 31B in particular fails to understand the autonomous agent framework to write code. Categorised Mid-range GPU (8-16 GB))
+
+_Last updated: 2026-08-14 (August 14 sweep). Confidence: moderate for quantization tuning potential but low for generalized agentic performance on Gemma 4 31B, on a five-post cycle documenting task-aware quantization gains, hardware setups, and friction with multi-turn autonomous coding. Key finding: reallocating a fixed bit budget toward the most damaged tensors on a custom imatrix recovered 8.55 percent relative coding performance on Gemma 4 12B Q3, with less than 0.2 percent size bloat, at the cost of expected degradation in other capabilities. Meanwhile, on a triple RTX 5060 Ti rig whose owner self-reports an unconfirmed 70 to 110 tok/s across several models, Gemma 4 31B was reported to fail at understanding autonomous agent frameworks. No Apple Silicon, laptop, integrated-graphics, single-GPU, CPU-only, Raspberry-Pi-class, or enterprise and cloud tier guidance changes. Next update fires when the daily Gemma 4 research cron flags notable new findings._
+
 ## Field Notes - 2026-08-13
 
 A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.

--- a/site/data/gemma4-hardware-configs.json
+++ b/site/data/gemma4-hardware-configs.json
@@ -4811,5 +4811,55 @@
       "Using LM Studio on Windows with 131k context length with kv cache quantised to q8_0 and q5_1, no MTP. It should all fit into vram but the results are very weirdly slow for some reason. Does anyone have any ideas for improvements? Windows could be the factor but idk &#32; submitted by &#32; /u/opoot_ [link] &#32; [comments]",
       "Using LM Studio on Windows with 131k context length with kv cache quantised to q8_0 and q5_1, no MTP. It should all fit into vram but the results are very weirdly slow for some reason. Does anyone have any ideas for improvements? Windows could be the factor but idk &#32; submitted by &#32; /u/opoot_ [link] &#32; [comments]"
     ]
+  },
+  {
+    "post": "1vndaih",
+    "file": "1vndaih.md",
+    "hardware_mentions": [
+      "# 5090 alone or 5090 and 4070Ti Super ?",
+      "- Score: 20",
+      "- URL: https://www.reddit.com/r/LocalLLaMA/comments/1vndaih/5090_alone_or_5090_and_4070ti_super/",
+      "Ever since I got the 5090 the 4070 Ti Super has been collecting dust on the shelf. Here\u2019s the model + flags I\u2019m currently running on the 5090: llama-server --model Qwen3.6-27B-UD-Q5_K_XL.gguf --mmproj mmproj-F16.gguf --n-gpu-layers all --ctx-size 163840 --parallel 1 --flash-attn on --cache-type-k q8_0 --cache-type-v q8_0 --spec-type draft-mtp --spec-draft-n-max 2 --min-p 0 --image-min-tokens 1024 --jinja --reasoning-preserve --host 0.0.0.0 --port 8888 --cors-origins localhost --alias qwen3.6-27b What would I actually gain by adding the 4070 Ti Super into the mix? I was thinking it might let me push context higher, but I\u2019m pretty sure multi-GPU would just end up slower than the 5090 by itself. I\u2019m also considering just selling the 4070. Open to any suggestions. On the side I have a home server (NucBox K8 Plus) running this: llama-server --model gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf --mmproj mmproj-gemma-4-26B-A4B-f16.gguf --no-mmproj-offload --ctx-size 131072 --kv-unified --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn on --batch-size 4096 --ubatch-size 2048 --cache-ram 3072 --n-gpu-layers 99 --parallel 1 --jinja --temp 1.0 --top-p 0.95 --top-k 64 --presence-penalty 0.0 Specs\u2026"
+    ]
+  },
+  {
+    "post": "1vnltec",
+    "file": "1vnltec.md",
+    "hardware_mentions": [
+      "# Gemma 4 12B Q3: +8.55% Coding Performance From Tensor-Level Quantization Allocation",
+      "- Score: 20",
+      "- URL: https://www.reddit.com/r/LocalLLaMA/comments/1vnltec/gemma_4_12b_q3_855_coding_performance_from/",
+      "Ive been experimenting with task-aware GGUF quants for months, taking inspiration from TASA and TAQO but pushing the allocation lower to to the tensor level. The basic idea is to generate a custom imatrix from a category-specific corpus, measure where quantization causes damage, then redistribute a fixed bit budget toward tensors where additional precision recovers the best performance in that category. Today I got my first real win. The pipeline is live. On Gemma 4 12b, the hand tuned imatrix q3_k_s scored 45.974. After tensor level allocation, the same q3_k_s based scored 49.905. Thats +3.931 points or an 8.55% relative improvement from the allocation on top of the imatrix. The models are effectively the same size: 5,528,230,848 bytes for the comparator versus 5,534,804,928 bytes for the allocated model, a difference of only +0.119%. I chose q3 deliberately. It had the largest amount of recoverable headroom while sitting above the quant cliff. This model is intentionally category specialized. Degredation in categories that werent selected is expected. There is still a lot of tweaking to do in order to maximize these results but the performance of this imatrix + allocation at q3\u2026"
+    ]
+  },
+  {
+    "post": "1vn5s3o",
+    "file": "1vn5s3o.md",
+    "hardware_mentions": [
+      "# ggml-cpu/ops: vectorize flash-attention V-cache F16 to F32 conversion by jinzihao \u00b7 Pull Request #26947 \u00b7 ggml-org/llama.cpp",
+      "- Score: 20",
+      "- URL: https://www.reddit.com/r/LocalLLaMA/comments/1vn5s3o/ggmlcpuops_vectorize_flashattention_vcache_f16_to/",
+      "Overview ggml_cpu_fp16_to_fp32 leverages hardware F16C intrinsics (AVX-512, AVX2, etc.), faster than the software-only ggml_fp16_to_fp32_row , bringing 17-31% gain in prompt processing rate for a smaller model like qwen3:4b. Wish the PR had few additional models(recent ones like Qwen3.5/3.6 & Gemma-4 models) with t/s stats. &#32; submitted by &#32; /u/pmttyji [link] &#32; [comments]"
+    ]
+  },
+  {
+    "post": "1vn20yw",
+    "file": "1vn20yw.md",
+    "hardware_mentions": [
+      "# Interesting uses for Muse Glimmer 30B?",
+      "- Score: 20",
+      "- URL: https://www.reddit.com/r/LocalLLaMA/comments/1vn20yw/interesting_uses_for_muse_glimmer_30b/",
+      "Hey everyone, Non-native speaker, writing my post by hand, let me know if I make mistakes (can only learn from it!) Muse Glimmer 30B is so far quite nice, but I haven't found a clear-cut case yet what I can use it for over Gemma 4 31B QAT (my go-to model) or Qwen3.6 27B. I really appreciate that they have openai style toggable reasoning effort like gpt-oss 20b has. I don't like the caveman speak style reasoning, makes it harder for me to pick up what it's doing or why it goes wrong. The vision encoder seems quite good on the model! Really large too. Toolcalling has been reliable, if not over eager. Fitting 128K BF16 context with dflash-kquant on dual RTX 5060 Ti 16GB is really nice! Don't mind the 128K (extendable to 256K) cap personally, can imagine it's not so nice when having many tool calls however. For day to day tasks (websearch, controlling smartlights, QA, etc) and natural language tasks (summarizing, translation, correction) I don't see it replace Gemma 4 31B QAT. Muse Glimmer's creative writing is as good as Mistral Small 3.2... which is 1 year old at least. For programming, it didn't seem to do better than Qwen3.6 27B at writing .NET 8.0 (with kilo code in vscode, jina\u2026"
+    ]
+  },
+  {
+    "post": "1vn5y7p",
+    "file": "1vn5y7p.md",
+    "hardware_mentions": [
+      "# Local autonomous coding agent?",
+      "- Score: 20",
+      "- URL: https://www.reddit.com/r/LocalLLaMA/comments/1vn5y7p/local_autonomous_coding_agent/",
+      "Hello! I have recently built my AI rig (3x RTX 5060 Ti 16gb, with possibly a 4th on the way if I can fit it). I love it, it runs great, and I am getting between 70t/s - 110 t/s (according to the pi agent web UI, have not confirmed it yet). While it is fast, I struggle to put it to use in the way I was hoping. My dream has been to be able to put it to work writing code autonomously so that I can have it sketch out my ideas before I commit to developing them, however, every attempt I make just seems to end in a mess. I have been trying Ornith:35b, Gemma4:31b, and Qwen3.6:35b, but none of them have been able to build anything that actually works. Ornith tends to get stuck in loops, Qwen panics and keeps rewritting the whole codebase every third turn it takes, and Gemma doesn't even understand the agent framework. Does anyone have any tips? Any AI models I have missed? Prompting strategies? Should I try something other than Cline, pi agent and copilot? Thanks for reading! &#32; submitted by &#32; /u/Ejo2001 [link] &#32; [comments]"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

August 14 Gemma 4 field-notes sweep. A five-post cycle (all five 2026-08-13 posts flagged by the daily r/LocalLLaMA ingest), led by a tensor-level quantization allocation report on Gemma 4 12B Q3, plus multi-GPU and mini-PC configuration reports.

Posts added (five distinct authors, all score 20 / zero comments / all carry archived body text):
- `1vnltec` (u/devildip) - proof-of-concept: tensor-level quant allocation recovers +8.55% relative coding score on Gemma 4 12B Q3 (45.974 to 49.905) at +0.119% file size. Category-specialized, not publicly reproducible.
- `1vndaih` (u/Fz1zz) - Gemma 4 26B A4B IT QAT Q4_K_XL on a NucBox K8 Plus mini-PC home server, 131k context (no throughput reported).
- `1vn20yw` (u/Kahvana) - Gemma 4 31B QAT kept as the go-to daily driver over Muse Glimmer 30B; dual RTX 5060 Ti 16GB, 128k BF16 with dflash-kquant.
- `1vn5y7p` (u/Ejo2001) - triple RTX 5060 Ti rig (self-reported, unconfirmed 70-110 tok/s); Gemma 4 31B fails to follow an autonomous agent framework.
- `1vn5s3o` (u/pmttyji) - llama.cpp F16C V-cache vectorization PR (17-31% prompt processing on Qwen3 4B); Gemma 4 benchmarks requested but unmeasured.

## Source knowledge files
- `knowledge/reddit/localllama/gemma4-hardware-configs.json`
- `knowledge/reddit/localllama/gemma4-latest.md`
- `knowledge/reddit/localllama/posts/{1vndaih,1vnltec,1vn5s3o,1vn20yw,1vn5y7p}.md`

## Editorial notes
- Throughput 70-110 tok/s is scoped as the rig's self-reported, unconfirmed figure across several models, not a Gemma-4-specific measurement.
- Categorizer tally verified against rendered card `data-cats`: quantization 4, mid-range GPU 2, high-end GPU 1 (1vndaih spans all three).
- Community index 639 to 644. Counts reconciled: 5 posts = 5 JSON ids = 5 Sources bullets.

## Checks run
- `pnpm check:changed` (exit 0), `pnpm test:changed` (exit 0, no changed test targets)
- `scripts/site/check-site-quality.sh` (ALL PASSED, incl. generate-site regression + judge-guard tests)
- `pnpm format:check` on data files (clean)
- Typographic-dash gate (patch-only vs origin/main): PASS, 210 added lines across 3 files
