### PR TITLE
fix: honor compaction reserve during tool loops

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1197,6 +1197,8 @@ export async function runEmbeddedAttempt(
               params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
             ),
           ),
+          reserveTokens: settingsManager.getCompactionReserveTokens(),
+          baseContextChars: systemPromptText.length,
         });
       } else {
         removeToolResultContextGuard = installContextEngineLoopHook({

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -96,10 +96,12 @@ async function applyGuardToContext(
   agent: { transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown },
   contextForNextCall: AgentMessage[],
   contextWindowTokens = 1_000,
+  options: { reserveTokens?: number; baseContextChars?: number } = {},
 ) {
   installToolResultContextGuard({
     agent,
     contextWindowTokens,
+    ...options,
   });
   return await agent.transformContext?.(contextForNextCall, new AbortController().signal);
 }
@@ -133,6 +135,38 @@ describe("installToolResultContextGuard", () => {
     const contextForNextCall = [makeUser("u".repeat(3_200))];
 
     const transformed = await applyGuardToContext(agent, contextForNextCall);
+
+    expect(transformed).toBe(contextForNextCall);
+  });
+
+  it("honors the configured compaction reserve during a live tool loop", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [makeUser("u".repeat(2_000))];
+
+    await expect(
+      applyGuardToContext(agent, contextForNextCall, 1_000, { reserveTokens: 500 }),
+    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+  });
+
+  it("counts fixed system prompt context against the live tool-loop budget", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [makeUser("u".repeat(1_000))];
+
+    await expect(
+      applyGuardToContext(agent, contextForNextCall, 1_000, {
+        reserveTokens: 250,
+        baseContextChars: 1_800,
+      }),
+    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+  });
+
+  it("caps an oversized reserve so small-context models retain a prompt budget", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [makeUser("u".repeat(1_000))];
+
+    const transformed = await applyGuardToContext(agent, contextForNextCall, 1_000, {
+      reserveTokens: 10_000,
+    });
 
     expect(transformed).toBe(contextForNextCall);
   });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
+import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "../pi-compaction-constants.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
@@ -141,9 +142,13 @@ function toolResultsNeedTruncation(params: {
 function exceedsPreemptiveOverflowThreshold(params: {
   messages: AgentMessage[];
   maxContextChars: number;
+  baseContextChars?: number;
 }): boolean {
   const estimateCache = createMessageCharEstimateCache();
-  return estimateContextChars(params.messages, estimateCache) > params.maxContextChars;
+  const baseContextChars = Math.max(0, Math.floor(params.baseContextChars ?? 0));
+  return (
+    baseContextChars + estimateContextChars(params.messages, estimateCache) > params.maxContextChars
+  );
 }
 
 function applyMessageMutationInPlace(
@@ -295,12 +300,25 @@ export function installContextEngineLoopHook(params: {
 export function installToolResultContextGuard(params: {
   agent: GuardableAgent;
   contextWindowTokens: number;
+  reserveTokens?: number;
+  baseContextChars?: number;
 }): () => void {
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
+  const requestedReserveTokens = Math.max(0, Math.floor(params.reserveTokens ?? 0));
+  const minPromptBudget = Math.min(
+    MIN_PROMPT_BUDGET_TOKENS,
+    Math.max(1, Math.floor(contextWindowTokens * MIN_PROMPT_BUDGET_RATIO)),
+  );
+  const effectiveReserveTokens = Math.min(
+    requestedReserveTokens,
+    Math.max(0, contextWindowTokens - minPromptBudget),
+  );
+  const promptBudgetTokens = Math.max(1, contextWindowTokens - effectiveReserveTokens);
   const maxContextChars = Math.max(
     1_024,
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
+    Math.floor(promptBudgetTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
   );
+  const baseContextChars = Math.max(0, Math.floor(params.baseContextChars ?? 0));
   const maxSingleToolResultChars = Math.max(
     1_024,
     Math.floor(
@@ -335,6 +353,7 @@ export function installToolResultContextGuard(params: {
       exceedsPreemptiveOverflowThreshold({
         messages: contextMessages,
         maxContextChars,
+        baseContextChars,
       })
     ) {
       throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);


### PR DESCRIPTION
Long local agent turns can add tool results after the initial preflight. The live context guard previously ignored both the configured compaction reserve and the fixed system prompt, allowing a request to reach the model hard limit before recovery.

This change budgets the live tool loop against the effective reserve, includes fixed system prompt text in the estimate, and preserves the existing minimum prompt budget for small context models.

Validation:
- targeted tool result context guard tests
- attempt workspace tests
- pnpm check:changed
- typographic dash gate