### PR TITLE
site: sanitize the decoded JSON in the site-data copy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1788,8 +1788,13 @@ jobs:
       - name: Lint Python skill scripts
         run: python -m ruff check skills
 
-      - name: Test skill Python scripts
-        run: python -m pytest -q skills
+      # scripts/site carries its own stdlib unittest suites (test_generate_site.py,
+      # test_copy_community_data.py) that no other job ran, so a site-generator
+      # regression could only be caught by hand. Lint stays scoped to skills:
+      # generate-site.py has a pre-existing import-order finding, and fixing it is
+      # not this job's business.
+      - name: Test skill and site Python scripts
+        run: python -m pytest -q skills scripts/site
 
   checks-windows:
     permissions:

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -24,7 +24,10 @@ const EMPTY_SCOPE = {
 };
 
 const DOCS_PATH_RE = /^(docs\/|.*\.mdx?$)/;
-const SKILLS_PYTHON_SCOPE_RE = /^(skills\/|pyproject\.toml$)/;
+// scripts/site/ is in scope because the site generator and the community-data
+// copy step ship stdlib unittest suites next to them (test_generate_site.py,
+// test_copy_community_data.py) that nothing else in CI executes.
+const SKILLS_PYTHON_SCOPE_RE = /^(skills\/|scripts\/site\/|pyproject\.toml$)/;
 const INSTALL_SMOKE_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/install-smoke\.yml$/;
 const MACOS_PROTOCOL_GEN_RE =
   /^(apps\/macos\/Sources\/OpenClawProtocol\/|apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\/)/;

--- a/scripts/site/copy-community-data.py
+++ b/scripts/site/copy-community-data.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Copy the community hardware-config index into site/data/, sanitizing dashes.
+
+Split out of the inline Python block in deploy-site-update.sh so the sanitizer is
+callable from a test with a fixture instead of only from the cron path, which
+first insists on a clean main checkout and a rebase against origin.
+
+WHY THIS WORKS ON THE DECODED FORM. The extractor
+(skills/reddit/scripts/gemma4-extract.sh) writes the knowledge JSON with
+json.dump(..., ensure_ascii=True), so an em dash in a Reddit excerpt reaches disk
+as the six ASCII characters backslash, u, 2, 0, 1, 4. The previous version of
+this step read the file as TEXT and called str.translate() on it. translate()
+maps decoded code points, and the file text holds no such code point, so every
+dash passed through untouched and the step's "sanitized" log line was false for
+the whole life of the script. Loading the JSON first is what puts the real
+character in front of the translate table.
+
+    python3 scripts/site/copy-community-data.py <src> <dst>
+"""
+import json
+import sys
+
+# Typographic dash code points -> ASCII hyphen. Listed numerically (not as literal
+# characters) so this script itself stays free of typographic dashes. Kept in step
+# with _TYPOGRAPHIC_DASH_CODEPOINTS in generate-site.py.
+DASH_CODEPOINTS = (
+    0x2010, 0x2011, 0x2012, 0x2013, 0x2014,
+    0x2015, 0x2043, 0x2E3A, 0x2E3B, 0x2212,
+)
+DASH_MAP = {cp: "-" for cp in DASH_CODEPOINTS}
+
+
+def sanitize(node):
+    """Recursively map typographic dashes to hyphens in every string in `node`.
+
+    Dict keys are walked as well as values: the schema uses fixed ASCII keys
+    today, but a dash arriving in a key would otherwise be the one string the
+    sweep missed.
+    """
+    if isinstance(node, str):
+        return node.translate(DASH_MAP)
+    if isinstance(node, list):
+        return [sanitize(item) for item in node]
+    if isinstance(node, dict):
+        return {sanitize(k): sanitize(v) for k, v in node.items()}
+    return node
+
+
+def serialize(data):
+    """Render `data` in the extractor's one-row-per-line shape.
+
+    WHY NOT indent=2. The repo formatter (oxfmt) decides per object whether to
+    collapse it onto one line, and like prettier it honours the input's own line
+    break after the brace: an object the author already expanded stays expanded.
+    The extractor writes this file one row per line, so oxfmt collapses the short
+    rows, and that is the layout committed at site/data today (204 collapsed and
+    500 expanded across 704 rows). Handing oxfmt a fully expanded indent=2 file
+    instead pins all 704 rows open. Measured against the committed file using its
+    own rows with dashes sanitized on both sides, so only the layout varies: one
+    row per line differs by 164 lines (the dash rows themselves), indent=2 by
+    1390. Keeping the source's shape is what makes this fix a dash-only diff.
+    """
+    if not isinstance(data, list):
+        return json.dumps(data) + "\n"
+    if not data:
+        return "[]\n"
+    return "[\n" + ",\n".join("  " + json.dumps(row) for row in data) + "\n]\n"
+
+
+def copy_community_data(src, dst):
+    """Load `src`, sanitize decoded strings, write `dst`. Returns the data."""
+    with open(src, encoding="utf-8") as f:
+        data = json.load(f)
+    data = sanitize(data)
+    # ensure_ascii stays at its default True, matching the extractor, so the file
+    # on disk is pure ASCII and no consumer has to guess an encoding.
+    with open(dst, "w", encoding="utf-8") as f:
+        f.write(serialize(data))
+    return data
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: copy-community-data.py <src> <dst>", file=sys.stderr)
+        sys.exit(2)
+    copy_community_data(sys.argv[1], sys.argv[2])

--- a/scripts/site/deploy-site-update.sh
+++ b/scripts/site/deploy-site-update.sh
@@ -22,26 +22,26 @@ git pull --rebase origin main 2>/dev/null || true
 
 # Step 1: Copy community data if source exists.
 # Raw Reddit excerpts routinely contain typographic dashes (em/en/figure dash,
-# minus sign). Those violate the deliverable style rule and trip the
-# no-typographic-dashes gate, so sanitize them to a plain ASCII hyphen during the
-# copy. This is a byte-level replacement of the dash characters only: all other
-# JSON formatting is preserved verbatim to keep the committed diff minimal.
+# minus sign). Those violate the deliverable style rule, so sanitize them to a
+# plain ASCII hyphen during the copy. The sanitizer runs on the DECODED JSON, not
+# on the file text: the extractor writes with ensure_ascii=True, so the dashes sit
+# on disk as \uXXXX escapes that a text-level translate() cannot see. See
+# scripts/site/copy-community-data.py for the full account.
 mkdir -p site/data
 if [ -f "$CONFIGS_SRC" ]; then
-  CONFIGS_SRC="$CONFIGS_SRC" python3 - <<'PY'
-import os
-src = os.environ["CONFIGS_SRC"]
-dst = "site/data/gemma4-hardware-configs.json"
-# Typographic dash code points -> ASCII hyphen. Listed numerically (not as literal
-# characters) so this script itself stays free of typographic dashes.
-codepoints = (0x2010, 0x2011, 0x2012, 0x2013, 0x2014,
-              0x2015, 0x2043, 0x2E3A, 0x2E3B, 0x2212)
-table = {cp: "-" for cp in codepoints}
-with open(src, encoding="utf-8") as f:
-    data = f.read()
-with open(dst, "w", encoding="utf-8") as f:
-    f.write(data.translate(table))
-PY
+  python3 "$SCRIPT_DIR/copy-community-data.py" \
+    "$CONFIGS_SRC" site/data/gemma4-hardware-configs.json
+  # Format here rather than leaving it to the pre-commit hook. The copy writes the
+  # extractor's one-row-per-line shape and the committed file is the oxfmt-collapsed
+  # form of it, so without this the working tree shows a five-thousand-line reflow
+  # between the copy and the commit, which is exactly what buried the real change in
+  # earlier cycles. oxfmt is already a hard dependency of this script: the commit
+  # below runs the pre-commit hook, which invokes it.
+  if [ -x node_modules/oxfmt/bin/oxfmt ]; then
+    node_modules/oxfmt/bin/oxfmt --write site/data/gemma4-hardware-configs.json >/dev/null
+  else
+    echo "WARN: node_modules/oxfmt not found, leaving site/data JSON unformatted"
+  fi
   echo "Copied + dash-sanitized gemma4-hardware-configs.json to site/data/"
 else
   echo "WARN: $CONFIGS_SRC not found, skipping community data copy"

--- a/scripts/site/test_copy_community_data.py
+++ b/scripts/site/test_copy_community_data.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Regression tests for the site-data copy step's dash sanitizer.
+
+Guards the defect fixed on 2026-09-07: the copy step read the knowledge JSON as
+text and called str.translate() on it, but the extractor writes that file with
+ensure_ascii=True, so every typographic dash is stored as a \\uXXXX escape and no
+dash code point exists in the file text for translate() to match. The step logged
+"dash-sanitized" while changing nothing, for the whole life of the script.
+
+The fixture below is written with json.dump(..., ensure_ascii=True) precisely so
+it reproduces that on-disk shape. A test that wrote literal dashes would pass
+against the broken script and prove nothing.
+
+Pure stdlib (unittest), matching test_generate_site.py:
+    python3 scripts/site/test_copy_community_data.py
+"""
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+MOD_PATH = Path(__file__).resolve().parent / "copy-community-data.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("copy_community_data_under_test", MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+copier = _load_module()
+
+# The same ten code points the site generator normalizes.
+DASH_CHARS = {chr(cp) for cp in copier.DASH_CODEPOINTS}
+
+# Built from code points rather than typed literally, so this test file itself
+# stays clean under scripts/check-no-typographic-dashes.sh, which scans literal
+# characters on added lines.
+EM_DASH = chr(0x2014)
+EN_DASH = chr(0x2013)
+MINUS_SIGN = chr(0x2212)
+
+
+def _walk_strings(node):
+    """Yield every string in a decoded JSON structure, keys included."""
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_strings(item)
+    elif isinstance(node, dict):
+        for key, value in node.items():
+            yield from _walk_strings(key)
+            yield from _walk_strings(value)
+
+
+def _dashes_in(node):
+    return {ch for s in _walk_strings(node) for ch in s if ch in DASH_CHARS}
+
+
+class DecodedDashSanitizerTest(unittest.TestCase):
+    """The copy step must sanitize what json.load() decodes, not the file text."""
+
+    def _fixture(self, tmpdir):
+        """A source file shaped exactly like the real extractor's output.
+
+        gemma4-extract.sh emits one row per line inside a bracketed array, with
+        ensure_ascii on, so every typographic dash reaches disk as a \\uXXXX
+        escape. Both halves matter: the escape is what the old text-level
+        translate() could not see, and the one-row-per-line shape is the layout
+        the committed site copy is formatted from.
+        """
+        data = [
+            {
+                "post": "1abcdef",
+                "file": "1abcdef.md",
+                "hardware_mentions": [
+                    # em dash, en dash and minus sign, as the acceptance requires.
+                    "3090 %s 24GB VRAM, runs 26B at q4" % EM_DASH,
+                    "budget build %s two P40s" % EN_DASH,
+                    "delta was %s2 tok/s after the update" % MINUS_SIGN,
+                ],
+            },
+            {"post": "2bcdefg", "file": "2bcdefg.md", "hardware_mentions": ["- Score: 20"]},
+        ]
+        src = Path(tmpdir) / "gemma4-hardware-configs.json"
+        rows = ",\n".join("  " + json.dumps(row, ensure_ascii=True) for row in data)
+        src.write_text("[\n" + rows + "\n]\n", encoding="utf-8")
+        return src
+
+    def test_fixture_stores_escapes_not_literal_dashes(self):
+        """Pins the premise the whole defect rests on.
+
+        If this ever fails the extractor stopped writing ensure_ascii=True, and
+        the rest of this file is testing a shape that no longer reaches the copy
+        step.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw = self._fixture(tmpdir).read_text(encoding="utf-8")
+            self.assertEqual(raw.count(EM_DASH), 0, "fixture should hold no literal em dash")
+            self.assertIn("\\u2014", raw, "fixture should hold the escaped form")
+            self.assertIn("\\u2013", raw)
+            self.assertIn("\\u2212", raw)
+
+    def test_copy_strips_every_dash_from_the_decoded_output(self):
+        """The assertion that goes red against the pre-2026-09-07 script."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._fixture(tmpdir)
+            dst = Path(tmpdir) / "out.json"
+            copier.copy_community_data(src, dst)
+
+            with open(dst, encoding="utf-8") as f:
+                loaded = json.load(f)
+
+            self.assertEqual(
+                _dashes_in(loaded), set(),
+                "decoded output still carries typographic dashes",
+            )
+            # The escaped form must be gone from the file text too, which is what
+            # the old text-level translate() left behind.
+            raw = dst.read_text(encoding="utf-8")
+            for cp in copier.DASH_CODEPOINTS:
+                self.assertNotIn("\\u%04x" % cp, raw.lower())
+
+    def test_readable_text_survives_the_substitution(self):
+        """A dash becomes a hyphen; no word is dropped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._fixture(tmpdir)
+            dst = Path(tmpdir) / "out.json"
+            copier.copy_community_data(src, dst)
+            with open(dst, encoding="utf-8") as f:
+                mentions = json.load(f)[0]["hardware_mentions"]
+
+            self.assertEqual(mentions[0], "3090 - 24GB VRAM, runs 26B at q4")
+            self.assertEqual(mentions[1], "budget build - two P40s")
+            self.assertEqual(mentions[2], "delta was -2 tok/s after the update")
+
+    def test_non_string_scalars_are_preserved(self):
+        """Scores and flags must not be stringified by the walk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = Path(tmpdir) / "in.json"
+            dst = Path(tmpdir) / "out.json"
+            with open(src, "w", encoding="utf-8") as f:
+                json.dump(
+                    [{"post": "x", "score": 42, "ok": True, "none": None, "f": 1.5}],
+                    f, indent=2, ensure_ascii=True,
+                )
+            copier.copy_community_data(src, dst)
+            with open(dst, encoding="utf-8") as f:
+                row = json.load(f)[0]
+            self.assertEqual(row["score"], 42)
+            self.assertIs(row["ok"], True)
+            self.assertIsNone(row["none"])
+            self.assertEqual(row["f"], 1.5)
+
+    def test_output_layout_matches_the_committed_format(self):
+        """One row per line, ensure_ascii on, trailing newline.
+
+        The repo formatter honours the input's own line break after a brace, so
+        the serialization the copy step chooses decides how oxfmt lays the file
+        out. Writing the extractor's one-row-per-line shape is what lets oxfmt
+        collapse the short rows the way the committed site copy already is;
+        indent=2 would pin all 704 rows open and turn a 164-line dash diff into a
+        1390-line reflow.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._fixture(tmpdir)
+            dst = Path(tmpdir) / "out.json"
+            copier.copy_community_data(src, dst)
+            raw = dst.read_text(encoding="utf-8")
+            lines = raw.splitlines()
+            self.assertEqual(lines[0], "[", "array should open on its own line")
+            self.assertEqual(lines[-1], "]", "array should close on its own line")
+            # One row per line: 2 fixture rows plus the two bracket lines.
+            self.assertEqual(len(lines), 4, "expected one row per line")
+            for line in lines[1:-1]:
+                self.assertTrue(line.startswith('  {"post": '), line[:40])
+            self.assertTrue(raw.endswith("\n"), "expected a trailing newline")
+            # ensure_ascii stays on: every non-ASCII byte stays escaped.
+            self.assertTrue(raw.isascii(), "output should be pure ASCII")
+
+    def test_serialize_normalizes_an_expanded_source(self):
+        """The shape is chosen by the copy step, not inherited from the source.
+
+        Guards against a future revert to a pass-through writer: an indent=2
+        input must still come out one row per line.
+        """
+        expanded = json.dumps([{"post": "x", "hardware_mentions": ["a"]}], indent=2)
+        out = copier.serialize(json.loads(expanded))
+        self.assertEqual(
+            out, '[\n  {"post": "x", "hardware_mentions": ["a"]}\n]\n',
+        )
+        self.assertEqual(copier.serialize([]), "[]\n")
+
+    def test_sanitize_covers_dict_keys(self):
+        out = copier.sanitize({"a%sb" % EM_DASH: ["c%sd" % EN_DASH]})
+        self.assertEqual(out, {"a-b": ["c-d"]})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -177,6 +177,18 @@ describe("detectChangedScope", () => {
     });
   });
 
+  it("runs Python skill tests when site generator scripts change", () => {
+    expect(detectChangedScope(["scripts/site/copy-community-data.py"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: false,
+      runSkillsPython: true,
+      runChangedSmoke: false,
+      runControlUiI18n: false,
+    });
+  });
+
   it("runs Python skill tests when shared Python config changes", () => {
     expect(detectChangedScope(["pyproject.toml"])).toEqual({
       runNode: true,


### PR DESCRIPTION
## The defect

`scripts/site/deploy-site-update.sh` Step 1 copies the community hardware index into `site/data/` and claims to strip typographic dashes on the way. It has never done so on this input.

It read the source as **text** and called `str.translate()` with a table keyed on ten dash code points. But the extractor (`skills/reddit/scripts/gemma4-extract.sh`) writes that file with `json.dump(..., ensure_ascii=True)`, so a U+2014 lands on disk as the six ASCII characters `\`, `u`, `2`, `0`, `1`, `4`. `translate()` maps *decoded* code points, and the file text contains none, so every dash passed through untouched while the step printed `Copied + dash-sanitized`.

Reproduce against `origin/main`:

```
python3 -c "d=open('knowledge/reddit/localllama/gemma4-hardware-configs.json',encoding='utf-8').read(); print('literal U+2014:', d.count(chr(0x2014))); print('escaped:', d.count(chr(92)+'u2014'))"
# literal U+2014: 0
# escaped: 101      (plus 38 escaped U+2013)
```

51 of the 704 rows carry at least one of the ten dash code points once decoded.

Nothing in CI saw this: `scripts/check-no-typographic-dashes.sh` scans *literal* characters on added lines, and an escape is not a literal dash.

## The fix

`json.load` the source, walk the structure, translate every decoded string (dict keys included), then re-serialize with `ensure_ascii` left at its default.

The logic moved to `scripts/site/copy-community-data.py` so a test can drive it with a fixture. The old inline block could only be exercised through the full cron path, which first insists on a clean `main` checkout and a rebase against origin.

### Serialization: one row per line, not `indent=2`

`oxfmt` decides per object whether to collapse it onto one line, and like prettier it honours the input's own line break after the brace: an object the author already expanded stays expanded. So the shape the copy step writes decides the committed layout.

The extractor writes this file **one row per line** (1409 lines, 704 rows), and the committed `site/data` copy is the oxfmt-collapsed form of exactly that: 204 collapsed rows, 500 expanded. Handing oxfmt a fully expanded `indent=2` file instead pins all 704 rows open.

Measured against the committed file using **its own rows**, with dashes sanitized on both sides so only the layout varies:

| serialization | lines after oxfmt | changed lines vs committed |
| --- | --- | --- |
| one row per line | 5096 | **164** (the dash rows themselves) |
| `indent=2` | 5932 | 1390 |

The deploy step now also runs `oxfmt --write` on the file right after the copy, guarded on the binary being present, so the working tree never holds the unformatted intermediate. That intermediate is what produced *1397 insertions and 5062 deletions for a three-entry addition* in an earlier cycle. On the real source: raw copy 706 lines, 5096 after oxfmt, `oxfmt --check` **exit 0**, second `--write` byte-identical.

## Regression test

`scripts/site/test_copy_community_data.py`. The fixture is written with `json.dump(..., ensure_ascii=True)` precisely so it reproduces the on-disk shape; a fixture with literal dashes would pass against the broken script and prove nothing. One test pins that premise directly.

Proven non-vacuous. Against a stand-in reproducing the old text-level `translate()`, **4 of 7 fail**, including the core assertion:

```
AssertionError: '3090 <em-dash> 24GB VRAM, runs 26B at q4' != '3090 - 24GB VRAM, runs 26B at q4'
FAILED (failures=4)
```

Against the patched script: **7 passed**. A seventh test pins the serialization directly, so a future revert to a pass-through writer goes red on layout as well as on dashes.

## CI wiring (why this PR touches ci.yml)

The new test would have been dead on arrival. `scripts/site/` was executed by **no** CI job: the pytest step was `pytest -q skills`, and `SKILLS_PYTHON_SCOPE_RE` in `scripts/ci-changed-scope.mjs` matched only `skills/` and `pyproject.toml`. The repo's two existing site suites (`test_generate_site.py`, `test_check_benchmark_judges.py`) were orphaned the same way.

This PR extends the scope regex and the pytest step to cover `scripts/site`, and adds a `ci-changed-scope` case pinning the new lane. Lint stays scoped to `skills`: `generate-site.py` has a pre-existing ruff import-order finding, and fixing it is not this change's business.

## The 51 already-shipped rows: decision is LEAVE THEM

Not a silent skip. The reasoning:

**1. They are not reader-visible.** `load_community_configs()` reads only `entry.get("post")`, the post id. `hardware_mentions` is the sole dash-carrying field and is **never read**. Card text comes from `parse_reddit_post(post_id)` over the workspace Reddit markdown, and every reader-visible field there already routes through `normalize_typographic_dashes()` (title, flair, and summary/comments/search via `clean_markdown`).

Measured on `origin/main`'s `site/community.html`: **0** of the ten dash code points inside any of the 704 `cr-card` blocks. The file's 1078 U+2014 / 132 U+2013 / 7 U+2212 are all field-notes prose, which the patch-only dash policy deliberately leaves alone.

**2. Re-sanitizing today would cost more than it fixes.** The committed `site/data` copy is stale against the source: row order diverges at index 137. Refreshing it reorders **414** reader-visible cards. That is a far larger reader-visible change than the dashes it corrects, with no editorial benefit, and it would swamp this diff.

**3. It self-heals in the right context.** The next site-update todo worker to run `deploy-site-update.sh` sanitizes these rows as a side effect of its normal refresh, where the reorder is expected and reviewable.

The 51 affected post ids:

```
1u0qq8a 1v850zn 1v3vy45 1t65vl8 1tkpz2y 1w2gmxz 1u1uk3a 1ur1i1a 1vg71ci 1vgeslw
1vdbix4 1upx3gm 1vxfd18 1th7f24 1t0s1oa 1txlhxu 1vbzoym 1uu5bv0 1uh8ir7 1veoe08
1v8adin 1u50rw1 1srvbke 1uu4hxp 1txxd7c 1tn7csy 1tyxu55 1tm5c92 1um20ev 1tx12t1
1vvaya2 1v6ect8 1vgfuyg 1trf0r0 1u8nyvw 1ubx4rw 1vbp8te 1t2pmx7 1ub4oc4 1u5lfvv
1sojag2 1uwhwt8 1vasnys 1ulqg4i 1umrroe 1uxrpv5 1txuoya 1sz59l4 1ss9pku 1ul0cx9
1uknx14
```

No card loses readable text: each substitution is one dash to one hyphen, verified by equality assertions in the test.

## Verification

Run in a dedicated worktree off `origin/main` (`2aadc9fced`), not in the shared `code/gemmaclaw` checkout.

| Check | Result |
| --- | --- |
| Patched copy step over the real source | 704 rows, 0 carrying dashes, 0 non-ASCII bytes |
| `oxfmt --check site/data/gemma4-hardware-configs.json` | exit 0 on the deploy step's own output (the step now formats it), second `--write` byte-identical |
| Copy step run twice | byte-identical |
| `generate-site.py` run twice | byte-identical across 19 files |
| `check-site-quality.sh` | ALL CHECKS PASSED |
| Dash gate `--diff-added origin/main` | `scanned 268 added line(s) across 6 file(s)`, OK |
| `check-changed.mjs --base origin/main` | exit 0 (oxlint core 0/0, scripts 0/0, tooling 18/18) |
| `test-projects.mjs --changed origin/main` | exit 0, 18/18 |

**Search recall is unaffected, asserted in code.** Every `data-search` attribute was extracted before and after: 704 values, **sets identical**. A control run of the *old* verbatim copy step from the same source produces a byte-identical `data-search` list to the new one, which attributes the 414-position card reorder to the stale committed data rather than to this fix.

## Note for a follow-up

The script header says "Called by the Gemma4 research cron job after extraction." That is inaccurate and left untouched here to keep the diff scoped: `cron/gemma4-research-daily.md` line 54 says *"Do not directly push Gemmaclaw site changes from this cron. The todo worker owns PR, CI, merge, deploy, and production verification."* The cron only extracts and files a todo.

