### PR TITLE
site: give the community category chips a real keyboard focus ring

### DIFF
--- a/scripts/site/generate-site.py
+++ b/scripts/site/generate-site.py
@@ -4550,16 +4550,33 @@ def generate_community_page(community_cards, community_count, field_notes_html):
     field_notes_section = f'<section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p>{field_notes_html}</section>' if field_notes_html else ""
     community_section = ""
     if community_count:
-        community_section = f"""<div class="community-section" id="community">
+        community_section = f"""<div class="community-section" id="community" tabindex="-1">
       <h3>Community Reports ({community_count} from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>
       <div class="search-bar"><input type="search" id="community-search" aria-label="Search community reports" placeholder="Search community reports..." autocomplete="off"></div>
       {community_cards}
     </div>"""
+    # WCAG 2.1 SC 2.4.1 Bypass Blocks. Field Notes grows by roughly 40 citation
+    # anchors every content cycle and sits ahead of the hardware index in DOM
+    # order, so the category filter chips were tab stop 2581 of 4013. This link
+    # is the second focusable element on the page, so the chips are four Tab
+    # presses away and stay there no matter how long Field Notes gets. It is
+    # offscreen until focused, so it costs a keyboard user one stop and a mouse
+    # user nothing.
+    #
+    # It has to sit AFTER the <h2>, not between <section> and <h2>: build_page_toc()
+    # matches '<section id="..."> \s* <h2>' and anything inserted in that gap drops
+    # the section out of the on-page table of contents entirely.
+    skip_link = (
+        '<a class="skip-to-index" href="#community">Skip Field Notes and jump to the hardware index</a>'
+        if (field_notes_section and community_section)
+        else ""
+    )
     body = f"""<div class="breadcrumb"><a href="index.html">Home</a> / Community</div>
     <section id="community-page">
       <h2>Community & Hardware Reports</h2>
       <p>Real-world experiences running Gemma models, curated from the community. Browse hardware reports, read the weekly field notes, or search for your setup.</p>
+      {skip_link}
       {field_notes_section}
       {community_section}
     </section>"""
@@ -5348,6 +5365,37 @@ CSS = """
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -6063,9 +6111,24 @@ CSS = """
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/scripts/site/test_generate_site.py
+++ b/scripts/site/test_generate_site.py
@@ -1690,5 +1690,310 @@ class TestFieldNotesLinkDoubleEscape(unittest.TestCase):
         self.assertNotIn("<b>", out)
 
 
+def _root_custom_properties():
+    """Resolve the :root custom properties out of the generator's CSS string."""
+    root = re.search(r":root\s*\{(.*?)\}", gen.CSS, flags=re.S)
+    if not root:
+        return {}
+    return {
+        name: value.strip()
+        for name, value in re.findall(r"(--[\w-]+)\s*:\s*([^;]+);", root.group(1))
+    }
+
+
+def _hex_to_rgb(value):
+    value = value.strip().lstrip("#")
+    if len(value) == 3:
+        value = "".join(c * 2 for c in value)
+    return tuple(int(value[i:i + 2], 16) for i in (0, 2, 4))
+
+
+def _relative_luminance(rgb):
+    def channel(c):
+        c = c / 255.0
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (channel(v) for v in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(a, b):
+    la, lb = _relative_luminance(a), _relative_luminance(b)
+    return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+
+
+class TestCategoryChipFocusVisible(unittest.TestCase):
+    """WCAG 2.1 SC 2.4.7 Focus Visible on the community category filter chips.
+
+    The chips shipped for dozens of content cycles with no :focus or
+    :focus-visible rule of any kind, leaving the indicator entirely to the
+    browser default. That default is a near-white ring on the ACTIVE chip and
+    measures 2.80:1 against its rgb(66,133,244) fill, below the 3:1 that SC
+    1.4.11 requires of a non-text indicator.
+
+    These are static assertions over the generator's own CSS string so they run
+    in CI with no browser. The behavioural counterpart is
+    TestCategoryChipFocusRingRenders below.
+    """
+
+    def setUp(self):
+        self.vars = _root_custom_properties()
+        rule = re.search(
+            r"\.cat-filter-btn:focus-visible\s*\{(.*?)\}", gen.CSS, flags=re.S
+        )
+        self.assertIsNotNone(
+            rule,
+            "no .cat-filter-btn:focus-visible rule in the generator CSS: a keyboard "
+            "user cannot see which category chip they are on",
+        )
+        self.rule = rule.group(1)
+
+    def _ring_rgb(self):
+        outline = re.search(r"outline\s*:\s*([^;]+);", self.rule)
+        self.assertIsNotNone(outline, "the focus-visible rule sets no outline")
+        parts = outline.group(1).split()
+        width = next(p for p in parts if p.endswith("px"))
+        self.assertGreaterEqual(
+            float(width.rstrip("px")), 2.0,
+            "a focus ring thinner than 2px is not a reliable indicator",
+        )
+        colour = parts[-1]
+        var_ref = re.match(r"var\((--[\w-]+)\)", colour)
+        if var_ref:
+            colour = self.vars[var_ref.group(1)]
+        return _hex_to_rgb(colour)
+
+    def test_ring_clears_3_to_1_against_both_chip_states(self):
+        """SC 1.4.11. One colour has to work on the grey chip AND the blue one.
+
+        This is the assertion that rejects the obvious choice: an --accent ring
+        scores 1.00:1 on the active chip, because the active chip IS --accent.
+        """
+        ring = self._ring_rgb()
+        surfaces = {
+            "page background --bg": self.vars["--bg"],
+            "inactive chip --bg-elev": self.vars["--bg-elev"],
+            "active chip --accent": self.vars["--accent"],
+        }
+        for name, colour in surfaces.items():
+            ratio = _contrast_ratio(ring, _hex_to_rgb(colour))
+            self.assertGreaterEqual(
+                round(ratio, 2), 3.0,
+                f"focus ring contrast against {name} is {ratio:.2f}:1, below the "
+                f"3:1 WCAG 1.4.11 floor for a non-text indicator",
+            )
+
+    def test_ring_is_offset_so_it_is_not_mistaken_for_the_chip_border(self):
+        offset = re.search(r"outline-offset\s*:\s*([\d.]+)px", self.rule)
+        self.assertIsNotNone(offset, "the focus ring sets no outline-offset")
+        self.assertGreaterEqual(float(offset.group(1)), 2.0)
+
+    def test_chip_transition_does_not_animate_the_outline(self):
+        """`transition: all` fades the ring in over its duration.
+
+        That is bad for a keyboard user and it also makes every computed-style
+        harness read the ring as absent, because the sample lands at t=0 of the
+        transition. Name the animated properties instead.
+        """
+        base = re.search(r"\.cat-filter-btn\s*\{(.*?)\}", gen.CSS, flags=re.S)
+        self.assertIsNotNone(base)
+        transition = re.search(r"transition\s*:\s*([^;]+);", base.group(1))
+        if transition:
+            self.assertNotIn(
+                "all", transition.group(1).split(),
+                "transition: all on .cat-filter-btn animates outline-width, "
+                "outline-color and outline-offset, so the focus ring is not instant",
+            )
+
+    def test_bypass_blocks_link_precedes_the_field_notes_archive(self):
+        """SC 2.4.1. Field Notes grows by roughly 40 citation anchors a cycle and
+        sits ahead of the chips in DOM order, which put them at tab stop 2581 of
+        4013. The skip link keeps that distance constant."""
+        page = gen.generate_community_page("<div id=\"community-cards\"></div>", 7, "<p>notes</p>")
+        self.assertIn('class="skip-to-index" href="#community"', page)
+        self.assertIn('id="community" tabindex="-1"', page)
+        self.assertLess(
+            page.index("skip-to-index"), page.index('id="field-notes"'),
+            "the skip link has to come before the block it skips",
+        )
+
+    def test_skip_link_stays_in_the_tab_order_while_hidden(self):
+        """display:none or visibility:hidden would remove it from the tab order
+        and make the link unreachable, which is the classic way this pattern is
+        broken. It has to be clipped, not hidden."""
+        rule = re.search(r"\.skip-to-index\s*\{(.*?)\}", gen.CSS, flags=re.S)
+        self.assertIsNotNone(rule)
+        self.assertNotIn("display: none", rule.group(1))
+        self.assertNotIn("visibility: hidden", rule.group(1))
+        self.assertIsNotNone(re.search(r"\.skip-to-index:focus\s*\{", gen.CSS))
+
+    def test_toc_still_lists_the_community_section(self):
+        """build_page_toc() matches '<section id="..."> \\s* <h2>'. Anything
+        inserted into that gap silently drops the section from the on-page table
+        of contents, which is exactly what an earlier placement of the skip link
+        did."""
+        page = gen.generate_community_page("<div id=\"community-cards\"></div>", 7, "<p>notes</p>")
+        toc = re.search(r'<nav class="page-toc".*?</nav>', page, flags=re.S)
+        self.assertIsNotNone(toc)
+        self.assertIn('href="#community-page"', toc.group(0))
+
+
+def _browser_available():
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: F401
+    except Exception:
+        return False
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            p.chromium.launch().close()
+        return True
+    except Exception:
+        return False
+
+
+_GENERATED_COMMUNITY = GEN_PATH.resolve().parent.parent.parent / "site" / "community.html"
+_BROWSER_OK = _GENERATED_COMMUNITY.exists() and _browser_available()
+
+
+@unittest.skipUnless(
+    _BROWSER_OK,
+    "needs Playwright Chromium and a generated site/community.html; the static "
+    "CSS assertions above cover CI",
+)
+class TestCategoryChipFocusRingRenders(unittest.TestCase):
+    """The behavioural half: focus a chip with a REAL Tab and read the paint.
+
+    Two traps this encodes, both of which produced a false 'no indicator' reading
+    during the 2026-09-11 investigation.
+
+    1. A programmatic element.focus() does not engage Chromium's :focus-visible
+       heuristic the same way a keypress does, and with outline-style:auto it
+       reports outline-width 0px. Focus the PREVIOUS focusable element and press
+       a real Tab.
+    2. outlineStyle must be in the compared property set. The browser default
+       ring differs from unfocused ONLY in outline-style/width/color, so a
+       comparison over backgroundColor/borderColor/boxShadow alone sees nothing
+       whether the rule is present or absent.
+    """
+
+    PROPERTIES = (
+        "outlineWidth", "outlineStyle", "outlineColor", "outlineOffset",
+        "boxShadow", "backgroundColor", "borderColor",
+    )
+
+    READ = """
+    (el) => {
+      const cs = getComputedStyle(el);
+      return {
+        outlineWidth: cs.outlineWidth, outlineStyle: cs.outlineStyle,
+        outlineColor: cs.outlineColor, outlineOffset: cs.outlineOffset,
+        boxShadow: cs.boxShadow, backgroundColor: cs.backgroundColor,
+        borderColor: cs.borderTopColor,
+      };
+    }
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Fixture is the SHIPPED chip markup plus the SHIPPED CSS, lifted out of
+        the generated page, so it cannot drift into agreeing with the code."""
+        html = _GENERATED_COMMUNITY.read_text(encoding="utf-8")
+        bar = re.search(r'<div class="cat-filter-bar".*?</div>', html, flags=re.S)
+        assert bar, "no .cat-filter-bar in the generated community page"
+        cls.fixture = (
+            "<!doctype html><meta charset=utf-8><style>" + gen.CSS + "</style>"
+            "<body><a href='#x' id='before'>before</a>" + bar.group(0) + "</body>"
+        )
+
+    @staticmethod
+    def _parse_rgb(value):
+        nums = re.findall(r"[\d.]+", value or "")
+        if len(nums) < 3:
+            return None
+        return tuple(int(float(n)) for n in nums[:3])
+
+    def _focused_vs_unfocused(self, page, chip_index):
+        page.evaluate("() => document.activeElement && document.activeElement.blur()")
+        chips = page.query_selector_all(".cat-filter-btn")
+        unfocused = chips[chip_index].evaluate(self.READ)
+        page.evaluate(
+            "(i) => { const c = document.querySelectorAll('.cat-filter-btn');"
+            "  (i === 0 ? document.getElementById('before') : c[i - 1]).focus(); }",
+            chip_index,
+        )
+        page.keyboard.press("Tab")
+        page.wait_for_timeout(400)  # let any transition settle before sampling
+        active = page.evaluate_handle("() => document.activeElement").as_element()
+        self.assertTrue(
+            active.evaluate("(el) => el.classList.contains('cat-filter-btn')"),
+            "Tab did not land on a category chip",
+        )
+        self.assertTrue(
+            active.evaluate("(el) => el.matches(':focus-visible')"),
+            "the chip is focused but Chromium is not treating it as keyboard-focused",
+        )
+        return unfocused, active.evaluate(self.READ)
+
+    def test_keyboard_focus_changes_the_paint_on_both_chip_states(self):
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page(viewport={"width": 1280, "height": 900})
+            page.set_content(self.fixture)
+            try:
+                for index, label in ((0, "the active chip"), (1, "an inactive chip")):
+                    unfocused, focused = self._focused_vs_unfocused(page, index)
+                    differing = [
+                        k for k in self.PROPERTIES if unfocused[k] != focused[k]
+                    ]
+                    self.assertTrue(
+                        differing,
+                        f"keyboard focus on {label} renders identically to no focus "
+                        f"at all: {focused}",
+                    )
+                    self.assertIn(
+                        "outlineWidth", differing,
+                        f"{label} has no outline width change on focus; the site is "
+                        f"relying on the browser default ring again",
+                    )
+                    # Deleting our rule does NOT make the two assertions above
+                    # fail, because Chromium then paints its own outline:auto
+                    # ring and outlineWidth still changes. Verified by removing
+                    # the rule: this class went green and only the static tests
+                    # caught it. So pin the ring to one WE specified and whose
+                    # contrast we measured, and reject the uncontrolled default.
+                    self.assertEqual(
+                        "solid", focused["outlineStyle"],
+                        f"{label} is falling back to the browser default ring "
+                        f"(outline-style {focused['outlineStyle']}), whose colour "
+                        f"the site does not control and has not measured",
+                    )
+                    self.assertGreaterEqual(
+                        float(focused["outlineWidth"].rstrip("px")), 2.0)
+                    self.assertNotEqual("0px", focused["outlineOffset"])
+
+                    ring = self._parse_rgb(focused["outlineColor"])
+                    fill = self._parse_rgb(focused["backgroundColor"])
+                    page_bg = self._parse_rgb(
+                        page.evaluate(
+                            "() => getComputedStyle(document.body).backgroundColor"
+                        )
+                    ) or (255, 255, 255)
+                    for surface_name, surface in (
+                        (f"{label} fill", fill), ("the page background", page_bg)
+                    ):
+                        ratio = _contrast_ratio(ring, surface)
+                        self.assertGreaterEqual(
+                            round(ratio, 2), 3.0,
+                            f"rendered focus ring on {label} measures {ratio:.2f}:1 "
+                            f"against {surface_name}, below the WCAG 1.4.11 floor",
+                        )
+            finally:
+                browser.close()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/site/benchmark-results/functiongemma-270m-high.html
+++ b/site/benchmark-results/functiongemma-270m-high.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma3-1b__ollama__2026-05-30T05-04-50.html
+++ b/site/benchmark-results/gemma3-1b__ollama__2026-05-30T05-04-50.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma4-12b-q4-high-antirep.html
+++ b/site/benchmark-results/gemma4-12b-q4-high-antirep.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma4-12b-q4-high.html
+++ b/site/benchmark-results/gemma4-12b-q4-high.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma4-12b-q4-nothink.html
+++ b/site/benchmark-results/gemma4-12b-q4-nothink.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma4-26b-q4-high.html
+++ b/site/benchmark-results/gemma4-26b-q4-high.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma4-31b-q4-high.html
+++ b/site/benchmark-results/gemma4-31b-q4-high.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmark-results/gemma4-e4b-q4-high.html
+++ b/site/benchmark-results/gemma4-e4b-q4-high.html
@@ -175,6 +175,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -890,9 +921,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/benchmarking.html
+++ b/site/benchmarking.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/community.html
+++ b/site/community.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;
@@ -1845,6 +1891,7 @@
     <section id="community-page">
       <h2>Community & Hardware Reports</h2>
       <p>Real-world experiences running Gemma models, curated from the community. Browse hardware reports, read the weekly field notes, or search for your setup.</p>
+      <a class="skip-to-index" href="#community">Skip Field Notes and jump to the hardware index</a>
       <section id="field-notes" class="field-notes-section"><h2>Field Notes</h2><p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use.</p><div class="field-notes"><h2>Field Notes - 2026-09-11</h2>
 <p>A weekly synthesis of what the r/LocalLLaMA community is reporting about Gemma 4 in real use. Curated from the latest Gemma hardware-index sweep (1 Gemma 4 card addition from the September 11, 2026 ingest, 712 community index entries total) and the archived threads it promotes into the site index. Confidence is <strong>none</strong> for everything the cycle's own addition says about Gemma 4 speed, memory, context length, file size, power or latency, because <strong>the addition is a question and states no figure of any kind</strong>. Swept mechanically in three passes over the archived file, for unit-suffixed rates, for benchmark-table rows and for latency forms written as times, it returns <strong>nothing on all three passes</strong>, and it names <strong>no GPU, no VRAM figure and no machine</strong>. What it adds is a <strong>demand signal</strong>, and a precisely aimed one: a reader asking which small local models are good enough for coding, whether Gemma 4 26B or 31B is enough for local development, and what rig to buy for them. This section answers the Gemma 4 half of that from the archive rather than from the post, and the confidence attaches to each archived report rather than to this cycle: <strong>low at 12 GB</strong>, where the three archived reports disagree by roughly a factor of ten, and <strong>low to medium at 24 GB and on 64 GB Apple Silicon</strong>, where the numbers are single-author and uncontested rather than reproduced.</p>
 <p><em>September 11 sweep, 2026-09-11 00:00 UTC:</em> a <strong>one-post sweep</strong>. The addition, <a href="https://reddit.com/r/localllama/comments/1wcbtba" target="_blank" rel="noopener">1wcbtba</a>, is dated <strong>September 10, 2026</strong>, one day before the sweep that ingested it. The index moved from <strong>711 to 712</strong>: one id added, none aged out. It is <strong>placeholder-score (20) and zero-comment</strong>, and the September 11 ingest notes record that Reddit JSON was blocked and the batch fell back to Atom, so that score and that comment count are the batch's placeholder shape rather than a popularity or agreement signal. That has a second-order consequence worth stating for a post that is purely a question: <strong>the archive cannot tell whether anyone answered this reader</strong>, because no replies were fetched at all. Its archived body excerpt runs to <strong>336 bytes</strong> and is character-identical to the Atom summary, because the whole post is four sentences of question. Measured with the site's own categoriser rather than by impression, it matches <strong>no hardware keyword at all</strong> and falls through to <strong>Other</strong>, taking that chip from <strong>223 to 224</strong>; <strong>Quantization and Backends stays at 408, High-end GPU at 93, Apple Silicon at 76, Mid-range GPU at 60, Laptops at 35 and CPU / Raspberry Pi at 15.</strong></p>
@@ -5704,7 +5751,7 @@
 </ul>
 <p>The full set of 266 community reports lives in the Community Reports section above, filterable by hardware category and search.</p>
 <p><em>Last updated: 2026-06-13 (June 13 sweep). Confidence: medium. Next update fires when the daily Gemma 4 research cron flags notable new findings.</em></p></div></section>
-      <div class="community-section" id="community">
+      <div class="community-section" id="community" tabindex="-1">
       <h3>Community Reports (712 from r/LocalLLaMA)</h3>
       <p>Real-world hardware experiences from the community. Filter by hardware category or search. These are user reports, not official benchmarks.</p>
       <div class="search-bar"><input type="search" id="community-search" aria-label="Search community reports" placeholder="Search community reports..." autocomplete="off"></div>

--- a/site/compare.html
+++ b/site/compare.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/enhancements.html
+++ b/site/enhancements.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/goals.html
+++ b/site/goals.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/index.html
+++ b/site/index.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/self-hosting.html
+++ b/site/self-hosting.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;

--- a/site/setup.html
+++ b/site/setup.html
@@ -184,6 +184,37 @@
     a.inline { color: var(--accent); text-decoration: none; }
     a.inline:hover { text-decoration: underline; }
 
+    /* Bypass-blocks link over the Field Notes archive. Offscreen rather than
+       display:none so it stays in the tab order; revealed on :focus, not on
+       :focus-visible, because only a keyboard can ever reach it and :focus is
+       the form every browser supports. */
+    .skip-to-index {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0; border: 0;
+      overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .skip-to-index:focus {
+      position: static;
+      width: auto; height: auto;
+      margin: 0 0 1rem; padding: 0.45rem 0.95rem;
+      overflow: visible; clip: auto; clip-path: none;
+      display: inline-block;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      color: var(--fg);
+      font-size: 0.85rem; font-weight: 500;
+      text-decoration: none;
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
+    /* The skip target takes tabindex="-1" so activating the link moves keyboard
+       focus and not just the scroll position. That focus is programmatic, so it
+       must not paint a ring around the whole section. */
+    .community-section:focus { outline: none; }
+
     /* Field Notes (curated weekly synthesis) */
     .field-notes {
       background: var(--bg-elev);
@@ -899,9 +930,24 @@
       background: var(--bg-elev); border: 1px solid var(--border);
       color: var(--muted); font-size: 0.82rem; font-weight: 500;
       padding: 0.4rem 0.9rem; border-radius: 20px;
-      cursor: pointer; transition: all 0.15s; white-space: nowrap;
+      cursor: pointer; white-space: nowrap;
+      /* Named properties rather than "all": "all" also animates outline-width,
+         outline-color and outline-offset, so the keyboard focus ring below faded
+         in over 150ms instead of appearing at once. A focus indicator should be
+         instant, and an animated one also reads as absent to any harness that
+         samples the computed style right after the Tab. */
+      transition: background-color 0.15s, border-color 0.15s, color 0.15s;
     }
     .cat-filter-btn:hover { border-color: var(--accent); color: var(--fg-soft); }
+    /* WCAG 2.1 SC 2.4.7 Focus Visible. --fg is the only palette colour that clears
+       the SC 1.4.11 3:1 non-text contrast floor against BOTH chip fills: 15.80:1 on
+       the page background the offset ring is drawn on, 14.84:1 on the inactive chip
+       #f6f8fa and 4.43:1 on the active chip #4285f4. An --accent ring would score
+       1.00:1 on the active chip, which is why the indicator is not the accent. */
+    .cat-filter-btn:focus-visible {
+      outline: 2px solid var(--fg);
+      outline-offset: 2px;
+    }
     .cat-filter-btn.active {
       background: var(--accent); border-color: var(--accent);
       color: #fff; font-weight: 600;


### PR DESCRIPTION
## What

The eight `.cat-filter-btn` category chips on `community.html` had a `:hover` rule and **no `:focus` or `:focus-visible` rule of any kind**, so their keyboard focus indicator was entirely whatever the browser chose to draw. This adds an explicit, contrast-verified one.

## Why, with numbers

Measured on the production artifact (`site/community.html`, md5 `3aca3b825a56f212b0bc406cd61d0059`, byte-identical to `curl https://gemmaclaw.github.io/gemmaclaw/community.html`) with Playwright Chromium 145, focusing via a real `Tab` press.

On the **active** chip, Chromium's default ring is `rgb(228,228,228)`:

| ring | surface | ratio | WCAG 1.4.11 (3:1) |
|---|---|---|---|
| `rgb(228,228,228)` | active chip fill `#4285f4` | **2.80:1** | FAIL |
| `rgb(228,228,228)` | page background `#ffffff` | **1.27:1** | FAIL |

It is a near-invisible hairline. The inactive chips fared better (`rgb(91,99,107)`, 6.10:1) but the site controlled neither.

## The fix

```css
.cat-filter-btn:focus-visible { outline: 2px solid var(--fg); outline-offset: 2px; }
```

`--fg` `#1f2328` is the **only** palette colour that clears 3:1 against both chip states:

| candidate | page bg | inactive chip | active chip | worst |
|---|---|---|---|---|
| `--fg` `#1f2328` | 15.80:1 | 14.84:1 | **4.43:1** | PASS |
| `--fg-soft` `#424a53` | 8.99:1 | 8.44:1 | 2.52:1 | FAIL |
| `--accent` `#4285f4` | 3.56:1 | 3.35:1 | **1.00:1** | FAIL |
| `--muted` `#656d76` | 5.25:1 | 4.93:1 | 1.47:1 | FAIL |

The obvious choice, `--accent`, is invisible on the active chip because the active chip *is* `--accent`. Every ratio is computed in code, and the test suite recomputes them so the table cannot rot.

## Two things that fell out of it

**`transition: all` was animating the ring.** `.cat-filter-btn` carried `transition: all 0.15s`, which also animates `outline-width`, `outline-color` and `outline-offset`, so the new ring faded in over 150ms rather than appearing at once. Now it names the three properties that actually need it.

**Tab order.** The chips sat at tab stop **2581 of 4013**, because the whole Field Notes archive and its citation anchors precede them in DOM order, and each content cycle adds roughly 40 more. This adds a WCAG 2.4.1 bypass-blocks link ahead of Field Notes, with `tabindex="-1"` on the `#community` target so activating it moves keyboard *focus* and not merely the scroll position. Measured end to end: the link is tab stop 14, two further Tabs reach the first chip, so **16 presses instead of 2581**, and the 16 does not grow with the archive.

## A measurement trap worth knowing

A programmatic `element.focus()` is not a valid way to check this. With `outline-style: auto`, Chromium reports `outline-width: 0px` for programmatic focus, so the check reads as "no indicator at all" whether or not a rule exists. Worse, comparing only `outlineWidth`/`boxShadow`/`borderColor`/`backgroundColor` is blind to the browser default ring, which differs from unfocused in **`outline-style`** and nothing else. Both traps are encoded in the tests.

## Tests

Seven new tests in `scripts/site/test_generate_site.py`:

- Six pure-stdlib, run in CI with no browser: rule present; ring clears 3:1 against `--bg`, `--bg-elev` and `--accent`; `outline-offset >= 2px`; no `transition: all`; skip link present, ahead of Field Notes, and clipped rather than `display:none` so it stays in the tab order; table of contents still lists the community section.
- One Playwright test, skipped when no browser is available, that builds its fixture from the **shipped** chip markup and the **shipped** CSS, presses a real `Tab`, and asserts on both chip states.

All seven were falsified before being trusted. Deleting the rule, swapping in `--accent`, and restoring `transition: all` each turn the relevant test red; the first control is what caught that the browser test originally passed on the UA default ring, which is why it now pins `outline-style: solid` and recomputes contrast from the rendered pixels.

## Verification

- `bash scripts/site/check-site-quality.sh` -> ALL CHECKS PASSED
- `python3 -m pytest scripts/site/` -> 162 passed
- `node scripts/check-changed.mjs --base 1ded2fa` -> all 19 files classified to known surfaces, 0 unknown, conflict-marker lane ok. The `lint scripts` lane fails because `node_modules` is not installed on the build box; it fails identically on a pristine zero-change checkout of `origin/main`, and this diff contains no JS or TS.
- `check-no-typographic-dashes.sh --diff-added origin/main` -> `scanned 1171 added line(s) across 19 file(s)`, clean. Proven non-vacuous by seeding a U+2014 (coverage 1172, exit 1) and restoring.
- Generator is idempotent: two consecutive runs leave an identical md5.

Screenshots of the ring on both chip states, desktop and mobile, are attached to the task summary.
